### PR TITLE
Implement Phase 6: CI/CD pipeline for Docker build-and-deploy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,17 @@ permissions:
   contents: read
 
 jobs:
+  set-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+    - name: compute-tag
+      id: tag
+      run: echo "image_tag=sha-${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: set-tag
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
     strategy:
@@ -46,7 +56,7 @@ jobs:
     - name: build-and-push
       run: |
         IMAGE="${{ steps.ecr.outputs.registry }}/cabal-${{ matrix.tier }}"
-        TAG="sha-${GITHUB_SHA::8}"
+        TAG="${{ needs.set-tag.outputs.image_tag }}"
         docker build \
           -f docker/${{ matrix.tier }}/Dockerfile \
           -t ${IMAGE}:${TAG} \
@@ -54,3 +64,10 @@ jobs:
           docker/
         docker push ${IMAGE}:${TAG}
         docker push ${IMAGE}:latest
+
+  deploy:
+    needs: [set-tag, build]
+    uses: ./.github/workflows/terraform.yml
+    with:
+      image_tag: ${{ needs.set-tag.outputs.image_tag }}
+    secrets: inherit

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -3,7 +3,19 @@ name: Build and Deploy Terraform Infrastructure
 
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to deploy (e.g. sha-abc12345)'
+        required: false
+        default: 'latest'
+        type: string
   workflow_call:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to deploy (e.g. sha-abc12345)'
+        required: false
+        type: string
+        default: 'latest'
   repository_dispatch:
     types: [trigger_build]
   schedule:
@@ -162,6 +174,7 @@ jobs:
         echo "repo = \"${{ vars.TF_VAR_REPO }}\"" >> terraform.tfvars
         echo "backup = ${{ vars.TF_VAR_BACKUP }}" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
+        echo "image_tag = \"${{ inputs.image_tag || 'latest' }}\"" >> terraform.tfvars
     - name: init-terraform
       run: terraform init
     - name: plan-terraform
@@ -214,6 +227,7 @@ jobs:
         echo "repo = \"${{ vars.TF_VAR_REPO }}\"" >> terraform.tfvars
         echo "backup = ${{ vars.TF_VAR_BACKUP }}" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
+        echo "image_tag = \"${{ inputs.image_tag || 'latest' }}\"" >> terraform.tfvars
     - name: init-terraform
       run: terraform init
     - name: apply-terraform


### PR DESCRIPTION
Wire docker.yml to trigger terraform.yml after image builds, passing the image tag (sha-XXXXXXXX) so ECS task definitions reference a specific image rather than 'latest'. The cookbook.yml workflow is intentionally preserved for the parallel-run transition period.

- docker.yml: add set-tag job to compute the image tag once, refactor build job to consume it, add deploy job that calls terraform.yml via workflow_call with the tag and inherited secrets
- terraform.yml: accept image_tag input on both workflow_dispatch and workflow_call triggers, include it in tfvars generation for plan and apply jobs (defaults to 'latest' when not provided)

https://claude.ai/code/session_0151DJqGocm4V4eLqHYK88hm