### PR TITLE
Use TEMPFAIL instead of REJECT for IMAP access map domain catch-alls

### DIFF
--- a/docker/shared/generate-config.sh
+++ b/docker/shared/generate-config.sh
@@ -155,8 +155,8 @@ def gen_imap_access():
             sd = d["subdomains"][subd]
             for addr in sorted(sd["addresses"]):
                 lines.append(f"To:{addr}@{subd}.{tld}\tOK")
-            lines.append(f"To:{subd}.{tld}\tREJECT")
-        lines.append(f"To:{tld}\tREJECT")
+            lines.append(f"To:{subd}.{tld}\tTEMPFAIL")
+        lines.append(f"To:{tld}\tTEMPFAIL")
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
During the brief window between address creation and reconfigure completion, IMAP's sendmail would route unrecognized addresses via MX (back to smtp-in), creating a mail loop. By using TEMPFAIL (4xx) instead of REJECT (5xx) for the domain-level catch-all entries, smtp-in will queue and retry the message, which succeeds once reconfigure finishes updating the maps.

REJECT is unnecessary here because smtp-in already gates inbound mail — IMAP should only receive mail for known domains.

https://claude.ai/code/session_01KNVyC9gs4kDfyG7qkkNfcq