### PR TITLE
Route reconfigure.sh output to container stdout for CloudWatch visibi…

### DIFF
--- a/docker/imap/supervisord.conf
+++ b/docker/imap/supervisord.conf
@@ -36,6 +36,9 @@ priority=30
 
 [program:reconfigure]
 command=/usr/local/bin/reconfigure.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 autorestart=true
 priority=40
 stopwaitsecs=30

--- a/docker/smtp-in/supervisord.conf
+++ b/docker/smtp-in/supervisord.conf
@@ -28,6 +28,9 @@ priority=20
 
 [program:reconfigure]
 command=/usr/local/bin/reconfigure.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 autorestart=true
 priority=30
 stopwaitsecs=30

--- a/docker/smtp-out/supervisord.conf
+++ b/docker/smtp-out/supervisord.conf
@@ -41,6 +41,9 @@ priority=30
 
 [program:reconfigure]
 command=/usr/local/bin/reconfigure.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 autorestart=true
 priority=40
 stopwaitsecs=30


### PR DESCRIPTION
…lity

The reconfigure program in all three supervisord configs (imap, smtp-in, smtp-out) was missing stdout_logfile, stdout_logfile_maxbytes, and redirect_stderr directives. Without these, its output went to /var/log/supervisord.log instead of container stdout, so it never reached the ECS CloudWatch logs driver.

https://claude.ai/code/session_013LgbdF1yw3AnKNBUmp2oqm