### PR TITLE
Add S3 backend to bootstrap workflow for dns remote state

### DIFF
--- a/.github/scripts/make-terraform.sh
+++ b/.github/scripts/make-terraform.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
-cat << EO_TF > ./terraform/infra/backend.tf
+
+if [ -z "$TF_MODULE" ]; then
+  echo "TF_MODULE is not set" >&2
+  exit 1
+fi
+
+if [ "$TF_MODULE" = "dns" ]; then
+  TF_KEY="${TF_ENVIRONMENT}-bootstrap"
+else
+  TF_KEY="$TF_ENVIRONMENT"
+fi
+
+cat << EO_TF > ./terraform/${TF_MODULE}/backend.tf
 terraform {
   backend "s3" {
     bucket = "cabal-tf-backend"
-    key    = "$TF_ENVIRONMENT"
+    key    = "$TF_KEY"
     region = "$TF_VAR_AWS_REGION"
   }
 }

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -6,8 +6,27 @@ on:
   workflow_call:
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: generate-backend
+      run: env TF_MODULE=dns TF_ENVIRONMENT="${{ vars.TF_VAR_ENVIRONMENT }}" ./.github/scripts/make-terraform.sh
+    - name: debug-1
+      run: cat ./terraform/dns/backend.tf
+    - name: debug-2
+      run: echo "${{ vars.TF_VAR_ENVIRONMENT }}"
+    - name: store-artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: backend.tf
+        path: ./terraform/dns/backend.tf
   plan:
     runs-on: ubuntu-latest
+    needs:
+    - build
     outputs:
       exit_code: ${{ steps.plan-terraform.outputs.exit_code }}
     defaults:
@@ -22,6 +41,12 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: retrieve-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: backend.tf
+    - name: move
+      run: mv ../../backend.tf backend.tf
     - name: install-terraform
       uses: hashicorp/setup-terraform@v2
       with:
@@ -56,25 +81,21 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v3
+    - name: retrieve-artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: backend.tf
+    - name: move
+      run: mv ../../backend.tf backend.tf
     - name: install-terraform
       uses: hashicorp/setup-terraform@v2
       with:
         cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
     - name: tfvars-terraform
       run: |
-        echo "smtpout_scale = ${{ vars.TF_VAR_SMTPOUT_SCALE }}" > terraform.tfvars
-        echo "availability_zones = ${{ vars.TF_VAR_AVAILABILITY_ZONES}}" >> terraform.tfvars
         echo "aws_region = \"${{ vars.TF_VAR_AWS_REGION}}\"" >> terraform.tfvars
-        echo "cidr_block = \"${{ vars.TF_VAR_CIDR_BLOCK}}\"" >> terraform.tfvars
-        echo "control_domain = \"${{ vars.TF_VAR_CONTROL_DOMAIN}}\"" >> terraform.tfvars
-        echo "email = \"${{ vars.TF_VAR_EMAIL }}\"" >> terraform.tfvars
-        echo "environment = \"${{ vars.TF_VAR_ENVIRONMENT }}\"" >> terraform.tfvars
-        echo "imap_scale = ${{ vars.TF_VAR_IMAP_SCALE }}" >> terraform.tfvars
-        echo "mail_domains = ${{ vars.TF_VAR_MAIL_DOMAINS }}" >> terraform.tfvars
-        echo "smtpin_scale = ${{ vars.TF_VAR_SMTPIN_SCALE }}" >> terraform.tfvars
-        echo "chef_license = \"${{ vars.TF_VAR_CHEF_LICENSE}}\"" >> terraform.tfvars
         echo "repo = \"${{ vars.TF_VAR_REPO }}\"" >> terraform.tfvars
-        echo "backup = ${{ vars.TF_VAR_BACKUP }}" >> terraform.tfvars
+        echo "control_domain = \"${{ vars.TF_VAR_CONTROL_DOMAIN}}\"" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
     - name: init-terraform
       run: terraform init


### PR DESCRIPTION
The terraform/infra module reads terraform_remote_state from the dns module using an S3 backend with key "${environment}-bootstrap", but the bootstrap workflow never configured an S3 backend for terraform/dns.

- Update make-terraform.sh to be module-aware: use TF_MODULE to determine the output path, and use a "-bootstrap" key suffix for the dns module
- Add a build job to bootstrap.yml that generates backend.tf via make-terraform.sh (matching the pattern in terraform.yml)
- Thread the backend.tf artifact through plan and apply jobs
- Fix the apply job's tfvars to only include dns-relevant variables

https://claude.ai/code/session_01Y455ccLDbdigUgCQsq6meV