### PR TITLE
Fix NAT instance iptables rules lost on reboot causing cross-AZ outage

### DIFF
--- a/terraform/infra/modules/ecs/task-definitions.tf
+++ b/terraform/infra/modules/ecs/task-definitions.tf
@@ -63,6 +63,7 @@ resource "aws_ecs_task_definition" "imap" {
         "awslogs-group"         = aws_cloudwatch_log_group.tier["imap"].name
         "awslogs-region"        = var.region
         "awslogs-stream-prefix" = "imap"
+        "mode"                  = "non-blocking"
       }
     }
   }])
@@ -126,6 +127,7 @@ resource "aws_ecs_task_definition" "smtp_in" {
         "awslogs-group"         = aws_cloudwatch_log_group.tier["smtp-in"].name
         "awslogs-region"        = var.region
         "awslogs-stream-prefix" = "smtp-in"
+        "mode"                  = "non-blocking"
       }
     }
   }])
@@ -183,6 +185,7 @@ resource "aws_ecs_task_definition" "smtp_out" {
         "awslogs-group"         = aws_cloudwatch_log_group.tier["smtp-out"].name
         "awslogs-region"        = var.region
         "awslogs-stream-prefix" = "smtp-out"
+        "mode"                  = "non-blocking"
       }
     }
   }])

--- a/terraform/infra/modules/vpc/nat.tf
+++ b/terraform/infra/modules/vpc/nat.tf
@@ -122,14 +122,38 @@ resource "aws_instance" "nat" {
 
   user_data = base64encode(<<-EOF
     #!/bin/bash
-    echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/nat.conf
+    # Enable IP forwarding (persists across reboots via sysctl.d)
+    echo "net.ipv4.ip_forward = 1" > /etc/sysctl.d/nat.conf
     sysctl -p /etc/sysctl.d/nat.conf
-    yum install -y iptables-services
+
+    # Set up iptables NAT rules
     iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
     iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
     iptables -A FORWARD -j ACCEPT
-    service iptables save
-    systemctl enable iptables
+
+    # Persist rules to disk (iptables-save is in the base AMI, no package needed)
+    mkdir -p /etc/sysconfig
+    iptables-save > /etc/sysconfig/iptables
+
+    # Create a systemd service to restore rules on boot (replaces iptables-services
+    # which requires yum and can't be installed during first boot — the instance has
+    # no public IP until the EIP is associated after creation)
+    cat > /etc/systemd/system/restore-iptables.service <<'UNIT'
+    [Unit]
+    Description=Restore iptables NAT rules
+    After=network.target
+
+    [Service]
+    Type=oneshot
+    ExecStart=/sbin/iptables-restore /etc/sysconfig/iptables
+    RemainAfterExit=yes
+
+    [Install]
+    WantedBy=multi-user.target
+    UNIT
+
+    systemctl daemon-reload
+    systemctl enable restore-iptables.service
   EOF
   )
 


### PR DESCRIPTION
NAT instance user_data relied on yum installing iptables-services, but the instance has no public IP during boot (EIP is associated after creation), so yum fails silently. iptables rules were set up in memory but never persisted — any reboot (including AWS maintenance) loses them, breaking internet access for the entire AZ's private subnet.

Replace with a self-contained approach: iptables-save (base AMI) persists rules to disk, and a systemd oneshot service restores them on boot.

Also switch awslogs driver to non-blocking mode on all ECS tasks so that future connectivity issues produce visible error logs instead of silently blocking the entrypoint.