### PR TITLE
Raise UID_MAX/GID_MAX in Docker images to fix useradd warning

### DIFF
--- a/docker/imap/Dockerfile
+++ b/docker/imap/Dockerfile
@@ -13,7 +13,9 @@ RUN dnf install -y \
       awscli-2 jq \
       pip \
     && pip install supervisor \
-    && dnf clean all
+    && dnf clean all \
+    && sed -i 's/^UID_MAX.*/UID_MAX                 2147483647/' /etc/login.defs \
+    && sed -i 's/^GID_MAX.*/GID_MAX                 2147483647/' /etc/login.defs
 
 # Static dovecot configuration
 COPY imap/configs/dovecot/10-auth.conf       /etc/dovecot/conf.d/10-auth.conf

--- a/docker/smtp-in/Dockerfile
+++ b/docker/smtp-in/Dockerfile
@@ -11,7 +11,9 @@ RUN dnf install -y \
       awscli-2 jq \
       pip \
     && pip install supervisor \
-    && dnf clean all
+    && dnf clean all \
+    && sed -i 's/^UID_MAX.*/UID_MAX                 2147483647/' /etc/login.defs \
+    && sed -i 's/^GID_MAX.*/GID_MAX                 2147483647/' /etc/login.defs
 
 # Sendmail .mc template (placeholder for cert domain)
 COPY templates/in-sendmail.mc               /etc/mail/sendmail.mc.template

--- a/docker/smtp-out/Dockerfile
+++ b/docker/smtp-out/Dockerfile
@@ -14,7 +14,9 @@ RUN dnf install -y \
       awscli-2 jq \
       pip \
     && pip install supervisor \
-    && dnf clean all
+    && dnf clean all \
+    && sed -i 's/^UID_MAX.*/UID_MAX                 2147483647/' /etc/login.defs \
+    && sed -i 's/^GID_MAX.*/GID_MAX                 2147483647/' /etc/login.defs
 
 # Dovecot submission configuration
 COPY smtp-out/configs/dovecot/00-protocols.conf   /etc/dovecot/conf.d/00-protocols.conf


### PR DESCRIPTION
UIDs like 65536 fall outside the default 1000-60000 range, causing useradd warnings during sync-users.sh. Set both limits to 2^31-1.