### PR TITLE
Add missing os import in generate-config.sh Python block

### DIFF
--- a/docker/shared/generate-config.sh
+++ b/docker/shared/generate-config.sh
@@ -37,7 +37,7 @@ aws dynamodb scan \
 echo "[generate-config] Generating config files for tier=$TIER..."
 
 python3 - "$TIER" "$IMAP_HOST" "$ITEMS_FILE" <<'PYEOF'
-import json, sys
+import json, os, sys
 
 tier = sys.argv[1]
 imap_host = sys.argv[2]


### PR DESCRIPTION
The os module is needed by the write() helper for os.makedirs.