### PR TITLE
Fix sendmail staying down after reconfigure kills it

### DIFF
--- a/docker/shared/reconfigure.sh
+++ b/docker/shared/reconfigure.sh
@@ -60,8 +60,10 @@ regenerate() {
 
   # Restart sendmail to pick up all changes including Fw-referenced
   # flat files (local-host-names, relay-domains) that SIGHUP may not
-  # re-read on all sendmail versions.  Supervisord will restart it.
-  pkill sendmail || true
+  # re-read on all sendmail versions.  Use supervisorctl so the
+  # wrapper script and daemon are stopped/started together cleanly,
+  # avoiding a window where port 25 is down.
+  supervisorctl restart sendmail
 
   # For SMTP-OUT, also reload OpenDKIM tables
   if [ "$TIER" = "smtp-out" ]; then

--- a/docker/shared/sendmail-wrapper.sh
+++ b/docker/shared/sendmail-wrapper.sh
@@ -7,12 +7,16 @@
 # supervisord can detect the failure and restart.
 set -euo pipefail
 
-/usr/sbin/sendmail -bd -q15m
-
 PIDFILE=/var/run/sendmail.pid
 
-# Wait for sendmail to create its PID file (up to 5 seconds)
-for i in $(seq 1 50); do
+# Remove stale PID file from a previous run so we don't read it
+# before sendmail has a chance to write a fresh one.
+rm -f "$PIDFILE"
+
+/usr/sbin/sendmail -bd -q15m
+
+# Wait for sendmail to create its PID file (up to 10 seconds)
+for i in $(seq 1 100); do
   [ -f "$PIDFILE" ] && break
   sleep 0.1
 done
@@ -23,6 +27,14 @@ if [ ! -f "$PIDFILE" ]; then
 fi
 
 PID=$(cat "$PIDFILE")
+
+# Verify the PID is actually alive (guards against a stale file
+# that was written and then the process immediately died).
+if ! kill -0 "$PID" 2>/dev/null; then
+  echo "[sendmail-wrapper] sendmail (pid $PID) exited immediately" >&2
+  rm -f "$PIDFILE"
+  exit 1
+fi
 echo "[sendmail-wrapper] sendmail started (pid $PID)"
 
 # Stay alive while the sendmail daemon is running


### PR DESCRIPTION
The reconfigure script used `pkill sendmail` to restart sendmail after regenerating maps. This left a stale PID file that caused the wrapper to read a dead PID, immediately exit, and rapid-loop until supervisord put it in FATAL state — making sendmail permanently unavailable.

Two fixes:
- reconfigure.sh: use `supervisorctl restart sendmail` for a clean stop/start cycle instead of raw pkill
- sendmail-wrapper.sh: remove stale PID file before starting, increase PID file wait timeout, and verify the PID is alive before monitoring