### PR TITLE
Convert email components to functional (Phase 3)

### DIFF
--- a/react/admin/src/App.jsx
+++ b/react/admin/src/App.jsx
@@ -307,11 +307,13 @@ class App extends React.Component {
       token: this.state.token,
       api_url: this.state.api_url,
       host: this.state.imap_host,
+      smtp_host: `smtp-out.${this.state.control_domain}`,
       domains: this.state.domains
     };
+    const appMessageValue = { setMessage: this.setMessage };
     return (
       <AuthContext.Provider value={authValue}>
-        <AppMessageContext.Provider value={this.setMessage}>
+        <AppMessageContext.Provider value={appMessageValue}>
           <div className={`App ${this.state.view}`}>
             <Nav
               onClick={this.updateView}

--- a/react/admin/src/Email/Actions/index.jsx
+++ b/react/admin/src/Email/Actions/index.jsx
@@ -1,213 +1,171 @@
-import React from 'react';
-import ApiClient from '../../ApiClient';
+import React, { useState, useCallback } from 'react';
+import useApi from '../../hooks/useApi';
 import Folders from '../Messages/Folders';
 import './Actions.css';
 import { READ, UNREAD, FLAGGED, UNFLAGGED, REPLY, REPLYALL, FORWARD } from '../../constants';
 
-class Actions extends React.Component {
+function Actions({
+  folder, selected_messages, selected_message, selected,
+  order, field, callback, catchback,
+  setMessage, reply, replyAll, forward
+}) {
+  const api = useApi();
+  const [showFolders, setShowFolders] = useState(false);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      show_folders: false
-    };
-    this.api = new ApiClient(this.props.api_url, this.props.token, this.props.host);
-  }
+  const setDestination = useCallback((destination) => {
+    setShowFolders(false);
+    api.moveMessages(folder, destination, selected_messages, order, field);
+  }, [api, folder, selected_messages, order, field]);
 
-  setDestination = (destination) => {
-    this.setState({...this.state, show_folders: false});
-    this.api.moveMessages(
-      this.props.folder,
-      destination,
-      this.props.selected_messages,
-      this.props.order,
-      this.props.field
-    );
-  }
-
-  handleActionButtonClick = (e) => {
+  const handleActionButtonClick = useCallback((e) => {
     e.stopPropagation();
-    if (!this.props.selected_messages.length && !this.props.selected_message) {
-      this.props.setMessage("Please select at least one message first.", true);
+    if (!selected_messages.length && !selected_message) {
+      setMessage("Please select at least one message first.", true);
       return;
-    } 
-    var action = e.target.id;
+    }
+    let action = e.target.id;
     if (e.target.tagName !== 'BUTTON') {
       action = e.target.parentElement.id;
     }
     switch (action) {
       case "delete":
-        this.api.moveMessages(
-          this.props.folder,
-          "Deleted Messages",
-          this.props.selected_messages,
-          this.props.order,
-          this.props.field
-        );
+        api.moveMessages(folder, "Deleted Messages", selected_messages, order, field);
         break;
       case "move":
-        this.setState({...this.state, show_folders: true});
+        setShowFolders(true);
         break;
       case "cancel":
-        this.setState({...this.state, show_folders: false});
+        setShowFolders(false);
         break;
       case READ.css:
-        this.api.setFlag(
-          this.props.folder,
-          READ.imap,
-          READ.op,
-          this.props.selected_messages,
-          this.props.order,
-          this.props.field
-        ).then(this.props.callback).catch(this.props.catchback);
+        api.setFlag(folder, READ.imap, READ.op, selected_messages, order, field)
+          .then(callback).catch(catchback);
         break;
       case UNREAD.css:
-        this.api.setFlag(
-          this.props.folder,
-          UNREAD.imap,
-          UNREAD.op,
-          this.props.selected_messages,
-          this.props.order,
-          this.props.field
-        ).then(this.props.callback).catch(this.props.catchback);
+        api.setFlag(folder, UNREAD.imap, UNREAD.op, selected_messages, order, field)
+          .then(callback).catch(catchback);
         break;
       case FLAGGED.css:
-        this.api.setFlag(
-          this.props.folder,
-          FLAGGED.imap,
-          FLAGGED.op,
-          this.props.selected_messages,
-          this.props.order,
-          this.props.field
-        ).then(this.props.callback).catch(this.props.catchback);
+        api.setFlag(folder, FLAGGED.imap, FLAGGED.op, selected_messages, order, field)
+          .then(callback).catch(catchback);
         break;
       case UNFLAGGED.css:
-        this.api.setFlag(
-          this.props.folder,
-          UNFLAGGED.imap,
-          UNFLAGGED.op,
-          this.props.selected_messages,
-          this.props.order,
-          this.props.field
-        ).then(this.props.callback).catch(this.props.catchback);
+        api.setFlag(folder, UNFLAGGED.imap, UNFLAGGED.op, selected_messages, order, field)
+          .then(callback).catch(catchback);
         break;
       case REPLY.css:
-        this.props.reply();
+        reply();
         break;
       case REPLYALL.css:
-        this.props.replyAll();
+        replyAll();
         break;
       case FORWARD.css:
-        this.props.forward();
+        forward();
         break;
       default:
         console.log(`"${action}" clicked`);
     }
-  }
+  }, [api, folder, selected_messages, selected_message, order, field, callback, catchback, setMessage, reply, replyAll, forward]);
 
-  render() {
-    const show = this.state.show_folders ? "show_folders" : "hide_folders";
-    return (
-      <div className={`filters filters-buttons ${this.props.selected} ${show}`}>
-        <span className="filter filter-actions">
-          <span className="nowrap">
-            <Folders 
-              token={this.props.token}
-              api_url={this.props.api_url}
-              setFolder={this.setDestination}
-              host={this.props.host}
-              folder={this.props.folder}
-              setMessage={this.props.setMessage}
-              label="Destination"
-            />&nbsp;
-            <button
-              value="cancel"
-              id="cancel"
-              name="cancel"
-              className="action cancel"
-              title="Cancel move"
-              onClick={this.handleActionButtonClick}
-            >❌<span className="wide-screen"> Cancel move</span></button>
-            <button
-              value="delete"
-              id="delete"
-              name="delete"
-              className="action delete"
-              title="Delete"
-              onClick={this.handleActionButtonClick}
-            >🗑️<span className="wide-screen"> Delete</span></button>
-            <button
-              value="move"
-              id="move"
-              name="move"
-              className="action move"
-              title="Move to..."
-              onClick={this.handleActionButtonClick}
-            >📨<span className="wide-screen"> Move to...</span></button>
-            <button
-              value={READ.css}
-              id={READ.css}
-              name={READ.css}
-              className={`action ${READ.css}`}
-              title={READ.description}
-              onClick={this.handleActionButtonClick}
-            >{READ.icon}<span className="wide-screen"> {READ.description}</span></button>
-            <button
-              value={UNREAD.css}
-              id={UNREAD.css}
-              name={UNREAD.css}
-              className={`action ${UNREAD.css}`}
-              title={UNREAD.description}
-              onClick={this.handleActionButtonClick}
-            >{UNREAD.icon}<span className="wide-screen"> {UNREAD.description}</span></button>
-            <button
-              value={FLAGGED.css}
-              id={FLAGGED.css}
-              name={FLAGGED.css}
-              className={`action ${FLAGGED.css}`}
-              title={FLAGGED.description}
-              onClick={this.handleActionButtonClick}
-            >{FLAGGED.icon}<span className="wide-screen"> {FLAGGED.description}</span></button>
-            <button
-              value={UNFLAGGED.css}
-              id={UNFLAGGED.css}
-              name={UNFLAGGED.css}
-              className={`action ${UNFLAGGED.css}`}
-              title={UNFLAGGED.description}
-              onClick={this.handleActionButtonClick}
-            >{UNFLAGGED.icon}<span className="wide-screen"> {UNFLAGGED.description}</span></button>
-          </span>
-          <span className="wrap_point"> </span>
-          <span className="nowrap">
-            <button
-              value={REPLY.css}
-              id={REPLY.css}
-              name={REPLY.css}
-              className={`action ${REPLY.css}`}
-              title={REPLY.description}
-              onClick={this.handleActionButtonClick}
-            >{REPLY.icon}<span className="wide-screen"> {REPLY.description}</span></button>
-            <button
-              value={REPLYALL.css}
-              id={REPLYALL.css}
-              name={REPLYALL.css}
-              className={`action ${REPLYALL.css}`}
-              title={REPLYALL.description}
-              onClick={this.handleActionButtonClick}
-            >{REPLYALL.icon}<span className="wide-screen"> {REPLYALL.description}</span></button>
-            <button
-              value={FORWARD.css}
-              id={FORWARD.css}
-              name={FORWARD.css}
-              className={`action ${FORWARD.css}`}
-              title={FORWARD.description}
-              onClick={this.handleActionButtonClick}
-            >{FORWARD.icon}<span className="wide-screen"> {FORWARD.description}</span></button>
-          </span>
+  const show = showFolders ? "show_folders" : "hide_folders";
+
+  return (
+    <div className={`filters filters-buttons ${selected} ${show}`}>
+      <span className="filter filter-actions">
+        <span className="nowrap">
+          <Folders
+            setFolder={setDestination}
+            folder={folder}
+            setMessage={setMessage}
+            label="Destination"
+          />&nbsp;
+          <button
+            value="cancel"
+            id="cancel"
+            name="cancel"
+            className="action cancel"
+            title="Cancel move"
+            onClick={handleActionButtonClick}
+          >❌<span className="wide-screen"> Cancel move</span></button>
+          <button
+            value="delete"
+            id="delete"
+            name="delete"
+            className="action delete"
+            title="Delete"
+            onClick={handleActionButtonClick}
+          >🗑️<span className="wide-screen"> Delete</span></button>
+          <button
+            value="move"
+            id="move"
+            name="move"
+            className="action move"
+            title="Move to..."
+            onClick={handleActionButtonClick}
+          >📨<span className="wide-screen"> Move to...</span></button>
+          <button
+            value={READ.css}
+            id={READ.css}
+            name={READ.css}
+            className={`action ${READ.css}`}
+            title={READ.description}
+            onClick={handleActionButtonClick}
+          >{READ.icon}<span className="wide-screen"> {READ.description}</span></button>
+          <button
+            value={UNREAD.css}
+            id={UNREAD.css}
+            name={UNREAD.css}
+            className={`action ${UNREAD.css}`}
+            title={UNREAD.description}
+            onClick={handleActionButtonClick}
+          >{UNREAD.icon}<span className="wide-screen"> {UNREAD.description}</span></button>
+          <button
+            value={FLAGGED.css}
+            id={FLAGGED.css}
+            name={FLAGGED.css}
+            className={`action ${FLAGGED.css}`}
+            title={FLAGGED.description}
+            onClick={handleActionButtonClick}
+          >{FLAGGED.icon}<span className="wide-screen"> {FLAGGED.description}</span></button>
+          <button
+            value={UNFLAGGED.css}
+            id={UNFLAGGED.css}
+            name={UNFLAGGED.css}
+            className={`action ${UNFLAGGED.css}`}
+            title={UNFLAGGED.description}
+            onClick={handleActionButtonClick}
+          >{UNFLAGGED.icon}<span className="wide-screen"> {UNFLAGGED.description}</span></button>
         </span>
-      </div>
-    );
-  }
+        <span className="wrap_point"> </span>
+        <span className="nowrap">
+          <button
+            value={REPLY.css}
+            id={REPLY.css}
+            name={REPLY.css}
+            className={`action ${REPLY.css}`}
+            title={REPLY.description}
+            onClick={handleActionButtonClick}
+          >{REPLY.icon}<span className="wide-screen"> {REPLY.description}</span></button>
+          <button
+            value={REPLYALL.css}
+            id={REPLYALL.css}
+            name={REPLYALL.css}
+            className={`action ${REPLYALL.css}`}
+            title={REPLYALL.description}
+            onClick={handleActionButtonClick}
+          >{REPLYALL.icon}<span className="wide-screen"> {REPLYALL.description}</span></button>
+          <button
+            value={FORWARD.css}
+            id={FORWARD.css}
+            name={FORWARD.css}
+            className={`action ${FORWARD.css}`}
+            title={FORWARD.description}
+            onClick={handleActionButtonClick}
+          >{FORWARD.icon}<span className="wide-screen"> {FORWARD.description}</span></button>
+        </span>
+      </span>
+    </div>
+  );
 }
 
 export default Actions;

--- a/react/admin/src/Email/Messages/Envelope.jsx
+++ b/react/admin/src/Email/Messages/Envelope.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import './Envelopes.css';
 import {
   LeadingActions,
@@ -8,99 +8,94 @@ import {
 } from 'react-swipeable-list';
 import 'react-swipeable-list/dist/styles.css';
 
-class Envelope extends React.Component {
+function Envelope({
+  handleClick: handleClickProp, handleCheck: handleCheckProp,
+  archive: archiveProp, markRead: markReadProp, markUnread: markUnreadProp,
+  envelope, subject, priority, date, from, flags, struct,
+  is_checked, dom_id, page, selected, observer
+}) {
+  const [archived, setArchived] = useState(-1);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      archived: -1,
-      checked: false
-    };
-  }
-
-  handleClick = (e) => {
+  const handleClick = useCallback((e) => {
     e.preventDefault();
-    this.props.handleClick(this.props.envelope, this.props.dom_id);
-  }
+    handleClickProp(envelope, dom_id);
+  }, [handleClickProp, envelope, dom_id]);
 
-  handleCheckChange = (e) => {
-    this.setState({ ...this.state, checked: e.target.checked });
-  }
+  const handleCheckChange = useCallback(() => {
+    handleCheckProp(dom_id, !is_checked);
+  }, [handleCheckProp, dom_id, is_checked]);
 
-  handleCheck = () => {
-    this.props.handleCheck(this.props.dom_id, !this.props.is_checked);
-  }
+  const archive = useCallback(() => {
+    setArchived(dom_id);
+    archiveProp(dom_id);
+  }, [archiveProp, dom_id]);
 
-  archive = () => {
-    this.setState({...this.state, archived: this.props.dom_id});
-    this.props.archive(this.props.dom_id);
-  }
+  const markUnread = useCallback(() => {
+    markUnreadProp(dom_id, page);
+  }, [markUnreadProp, dom_id, page]);
 
-  markUnread = () => {
-    this.props.markUnread(this.props.dom_id, this.props.page);
-  }
+  const markRead = useCallback(() => {
+    markReadProp(dom_id, page);
+  }, [markReadProp, dom_id, page]);
 
-  markRead = () => {
-    this.props.markRead(this.props.dom_id, this.props.page);
-  }
+  const flags_c = flags.map(d => d.replace("\\", "")).join(" ");
 
-  render() {
-    const { flags, subject, date, struct, selected, priority, from, dom_id, is_checked, observer } = this.props;
-    const flags_c = flags.map(d => {return d.replace("\\","")}).join(" ");
-    const leadingActions = () => {
-      const text = flags_c.match(/Seen/) ? "Mark unread" : "Mark read";
-      const handler = flags_c.match(/Seen/) ? this.markUnread : this.markRead;
-      return (
-        <LeadingActions>
-          <SwipeAction onClick={handler}>{text}</SwipeAction>
-        </LeadingActions>
-      );
-    };
-    const trailingActions = () => {
-      return (
-        <TrailingActions>
-          <SwipeAction onClick={this.archive}>Archive</SwipeAction>
-        </TrailingActions>
-      );
-    };
-    const archived = this.state.archived === dom_id ? "archived" : "";
-    const attachment_c = (struct[1] === "mixed" ? "Attachment" : "");
-    const priority_c = priority !== "" ? ` ${priority}` : "";
-    const selected_c = selected ? "selected" : "";
-    const classes = [flags_c, attachment_c, priority_c, selected_c, archived].join(" ");
+  const leadingActions = () => {
+    const text = flags_c.match(/Seen/) ? "Mark unread" : "Mark read";
+    const handler = flags_c.match(/Seen/) ? markUnread : markRead;
     return (
-      <SwipeableListItem
-        threshold={0.5}
-        className={`message-row ${classes}`}
-        key={dom_id}
-        leadingActions={leadingActions()}
-        trailingActions={trailingActions()}
-      >
-        {observer}
-        <div className="message-line-1" id={dom_id ? dom_id : "s"}>
-          <div className="message-field message-from" title={from[0]}>{from[0]}</div>
-          <div className="message-field message-date">{date}</div>
-        </div>
-        <div className="message-field message-subject">
-        <input
-            type="checkbox"
-            name={dom_id}
-            id={dom_id}
-            onChange={this.handleCheckChange}
-            checked={is_checked}
-          />
-          <label htmlFor={dom_id} onClick={this.handleCheck}>
-            <span className="checked">✓</span><span className="unchecked">&nbsp;</span>
-          </label>&nbsp;
-          {(priority_c !== " ") && (priority !== "") ? '❗️ ' : ''}
-          {flags_c.match(/Flagged/) ? '🚩 ' : ''}
-          {flags_c.match(/Answered/) ? '⤶ ' : ''}
-          {struct[1] === "mixed" ? '📎 ' : ''}
-          <span className="subject" id={dom_id} onClick={this.handleClick}>{subject}</span>
-        </div>
-      </SwipeableListItem>
+      <LeadingActions>
+        <SwipeAction onClick={handler}>{text}</SwipeAction>
+      </LeadingActions>
     );
-  }
+  };
+
+  const trailingActions = () => {
+    return (
+      <TrailingActions>
+        <SwipeAction onClick={archive}>Archive</SwipeAction>
+      </TrailingActions>
+    );
+  };
+
+  const archived_c = archived === dom_id ? "archived" : "";
+  const attachment_c = (struct[1] === "mixed" ? "Attachment" : "");
+  const priority_c = priority !== "" ? ` ${priority}` : "";
+  const selected_c = selected ? "selected" : "";
+  const classes = [flags_c, attachment_c, priority_c, selected_c, archived_c].join(" ");
+
+  return (
+    <SwipeableListItem
+      threshold={0.5}
+      className={`message-row ${classes}`}
+      key={dom_id}
+      leadingActions={leadingActions()}
+      trailingActions={trailingActions()}
+    >
+      {observer}
+      <div className="message-line-1" id={dom_id ? dom_id : "s"}>
+        <div className="message-field message-from" title={from[0]}>{from[0]}</div>
+        <div className="message-field message-date">{date}</div>
+      </div>
+      <div className="message-field message-subject">
+        <input
+          type="checkbox"
+          name={dom_id}
+          id={dom_id}
+          onChange={handleCheckChange}
+          checked={is_checked}
+        />
+        <label htmlFor={dom_id} onClick={handleCheckChange}>
+          <span className="checked">✓</span><span className="unchecked">&nbsp;</span>
+        </label>&nbsp;
+        {(priority_c !== " ") && (priority !== "") ? '❗️ ' : ''}
+        {flags_c.match(/Flagged/) ? '🚩 ' : ''}
+        {flags_c.match(/Answered/) ? '⤶ ' : ''}
+        {struct[1] === "mixed" ? '📎 ' : ''}
+        <span className="subject" id={dom_id} onClick={handleClick}>{subject}</span>
+      </div>
+    </SwipeableListItem>
+  );
 }
 
 export default Envelope;

--- a/react/admin/src/Email/Messages/Envelopes.jsx
+++ b/react/admin/src/Email/Messages/Envelopes.jsx
@@ -1,170 +1,164 @@
-import React from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import Observer from './Observer';
 import { SwipeableList, Type } from 'react-swipeable-list';
 import 'react-swipeable-list/dist/styles.css';
 import Envelope from './Envelope';
-import ApiClient from '../../ApiClient';
+import useApi from '../../hooks/useApi';
 import { PAGE_SIZE } from '../../constants';
 import './Envelopes.css';
 
-class Envelopes extends React.Component {
+function Envelopes({
+  message_ids, folder, selected_messages, showOverlay,
+  handleCheck: handleCheckProp, handleSelect: handleSelectProp,
+  markUnread: markUnreadProp, markRead: markReadProp, archive: archiveProp
+}) {
+  const api = useApi();
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      envelopes: {},
-      pages: [],
-      selected: null // do we need this?
-    };
-    this.api = new ApiClient(this.props.api_url, this.props.token, this.props.host);
-  }
+  const [envelopes, setEnvelopes] = useState({});
+  const [pages, setPages] = useState([]);
 
-  loadPages = (pages) => {
-    for(const page of pages) {
-      let envelopes = { ...this.state.envelopes, ...this.state.pages[page] };
-      this.setState({
-        ...this.state,
-        envelopes: envelopes
-      });
-    }
-  }
-
-  arrayCompare(array1, array2) {
-    const len = array1.length;
-    if (len !== array2.length) {
-      return false;
-    }
-    for (var i = 0; i < len; i++) {
-      if (array1[i] !== array2[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  // shouldComponentUpdate(_next_props, next_state) {
-  //   return !next_state.loading;
-  // }
-
-  doUpdate() {
-    const num_ids = this.props.message_ids.length;
-    for (var i = 0; i < num_ids; i+=PAGE_SIZE) {
-      let ids = this.props.message_ids.slice(i, i+PAGE_SIZE);
-      let page = Math.floor(i/PAGE_SIZE);
-      this.api.getEnvelopes(this.props.folder, ids).then(data => {
-        let pages = this.state.pages.slice();
-        pages[page] = data.data.envelopes;
-        this.setState({
-          ...this.state,
-          pages: pages
-        });
-        if (page < 4) {
-          this.loadPages([page]);
+  const loadPages = useCallback((pageNums) => {
+    setPages(currentPages => {
+      setEnvelopes(prev => {
+        let merged = { ...prev };
+        for (const p of pageNums) {
+          if (currentPages[p]) {
+            merged = { ...merged, ...currentPages[p] };
+          }
         }
-      }).catch( e => {
+        return merged;
+      });
+      return currentPages;
+    });
+  }, []);
+
+  // Fetch envelopes when message_ids change
+  useEffect(() => {
+    let cancelled = false;
+    const numIds = message_ids.length;
+
+    for (let i = 0; i < numIds; i += PAGE_SIZE) {
+      const ids = message_ids.slice(i, i + PAGE_SIZE);
+      const page = Math.floor(i / PAGE_SIZE);
+
+      api.getEnvelopes(folder, ids).then(data => {
+        if (cancelled) return;
+
+        // Use functional update to avoid race condition
+        setPages(prev => {
+          const next = prev.slice();
+          next[page] = data.data.envelopes;
+          return next;
+        });
+
+        // Auto-load first few pages into the visible envelopes
+        if (page < 4) {
+          setEnvelopes(prev => ({
+            ...prev,
+            ...data.data.envelopes
+          }));
+        }
+      }).catch(e => {
         console.log(e);
       });
     }
-  }
 
-  componentDidMount() {
-    this.doUpdate();
-  }
+    return () => {
+      cancelled = true;
+    };
+  }, [api, folder, message_ids]);
 
-  componentDidUpdate(prevProps, _prevState) {
-    if (!this.arrayCompare(prevProps.message_ids, this.props.message_ids)) {
-      this.doUpdate();
-    }
-  }
+  const handleClick = useCallback((envelope, id) => {
+    showOverlay(envelope);
+    handleSelectProp(id);
+  }, [showOverlay, handleSelectProp]);
 
-  handleClick = (envelope, id) => {
-    this.props.showOverlay(envelope);
-    this.props.handleSelect(id);
-    this.setState({...this.state, selected:id});
-  }
+  const handleCheck = useCallback((id, checked) => {
+    handleCheckProp(id, checked);
+  }, [handleCheckProp]);
 
-  handleCheck = (id, checked) => {
-    this.props.handleCheck(id, checked);
-  }
-
-  markRead = (id, page) => {
-    let envelopes = JSON.parse(JSON.stringify(this.state.envelopes));
-    envelopes[id.toString()].flags.push("\\Seen");
-    this.setState({ ...this.state, envelopes: envelopes });
-    this.props.markRead(id);
-  }
-
-  markUnread = (id, page) => {
-    let envelopes = JSON.parse(JSON.stringify(this.state.envelopes));
-    let envelope = envelopes[id.toString()]
-    envelope.flags.splice(envelope.flags.indexOf("\\Seen"),1);
-    envelopes[id.toString()] = envelope;
-    this.setState({ ...this.state, envelopes: envelopes });
-    this.props.markUnread(id);
-  }
-
-  archive = (id) => {
-    this.props.archive(id);
-  }
-
-  render() {
-    let i = 0;
-    const message_list = this.props.message_ids.filter(k => {
-      return this.state.envelopes.hasOwnProperty(k.toString());
-    }).map(k => {
-      return this.state.envelopes[k.toString()];
-    }).map(e => {
-      let first_of_page = false;
-      let observer = <></>;
-      const page = Math.floor(i/PAGE_SIZE);
-      if (i % PAGE_SIZE === 0) {
-        first_of_page = true;
-        observer = (
-          <Observer
-            pageLoader={this.loadPages}
-            page={page+2}
-            key={page+2}
-          ></Observer>
-        );
-      } else {
-        observer = null;
+  const markRead = useCallback((id) => {
+    setEnvelopes(prev => {
+      const next = JSON.parse(JSON.stringify(prev));
+      if (next[id.toString()]) {
+        next[id.toString()].flags.push("\\Seen");
       }
-      i++;
-      return (
-        <Envelope
-          handleClick={this.handleClick}
-          handleCheck={this.handleCheck}
-          archive={this.archive}
-          markRead={this.markRead}
-          markUnread={this.markUnread}
-          envelope={e}
-          subject={e.subject}
-          priority={e.priority}
-          date={e.date}
-          from={e.from}
-          to={e.to}
-          cc={e.cc}
-          flags={e.flags}
-          struct={e.struct}
-          is_checked={this.props.selected_messages.includes(parseInt(e.id))}
-          dom_id={e.id}
-          page={page}
-          first_of_page={first_of_page}
-          observer={observer}
-          key={e.id}
+      return next;
+    });
+    markReadProp(id);
+  }, [markReadProp]);
+
+  const markUnread = useCallback((id) => {
+    setEnvelopes(prev => {
+      const next = JSON.parse(JSON.stringify(prev));
+      const envelope = next[id.toString()];
+      if (envelope) {
+        envelope.flags.splice(envelope.flags.indexOf("\\Seen"), 1);
+      }
+      return next;
+    });
+    markUnreadProp(id);
+  }, [markUnreadProp]);
+
+  const archive = useCallback((id) => {
+    archiveProp(id);
+  }, [archiveProp]);
+
+  let i = 0;
+  const message_list = message_ids.filter(k => {
+    return envelopes.hasOwnProperty(k.toString());
+  }).map(k => {
+    return envelopes[k.toString()];
+  }).map(e => {
+    let first_of_page = false;
+    let observer = null;
+    const page = Math.floor(i / PAGE_SIZE);
+    if (i % PAGE_SIZE === 0) {
+      first_of_page = true;
+      observer = (
+        <Observer
+          pageLoader={loadPages}
+          page={page + 2}
+          key={page + 2}
         />
       );
-    });
+    }
+    i++;
     return (
-      <SwipeableList
-        fullSwipe={true}
-        type={Type.IOS}
-        className="message-list"
-      >
-        {message_list}
-      </SwipeableList>
+      <Envelope
+        handleClick={handleClick}
+        handleCheck={handleCheck}
+        archive={archive}
+        markRead={markRead}
+        markUnread={markUnread}
+        envelope={e}
+        subject={e.subject}
+        priority={e.priority}
+        date={e.date}
+        from={e.from}
+        to={e.to}
+        cc={e.cc}
+        flags={e.flags}
+        struct={e.struct}
+        is_checked={selected_messages.includes(parseInt(e.id))}
+        dom_id={e.id}
+        page={page}
+        first_of_page={first_of_page}
+        observer={observer}
+        key={e.id}
+      />
     );
-  }
+  });
+
+  return (
+    <SwipeableList
+      fullSwipe={true}
+      type={Type.IOS}
+      className="message-list"
+    >
+      {message_list}
+    </SwipeableList>
+  );
 }
 
 export default Envelopes;

--- a/react/admin/src/Email/Messages/Envelopes.test.jsx
+++ b/react/admin/src/Email/Messages/Envelopes.test.jsx
@@ -1,0 +1,169 @@
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Envelopes from './Envelopes';
+import AuthContext from '../../contexts/AuthContext';
+import AppMessageContext from '../../contexts/AppMessageContext';
+
+const mockGetEnvelopes = vi.fn();
+const mockApi = { getEnvelopes: mockGetEnvelopes };
+vi.mock('../../hooks/useApi', () => ({
+  default: () => mockApi,
+}));
+
+const authValue = { token: 'tok', api_url: 'http://api', host: 'host' };
+
+function makeEnvelope(id) {
+  return {
+    id: id.toString(),
+    from: [`sender${id}@test.com`],
+    to: ['recipient@test.com'],
+    cc: [],
+    subject: `Subject ${id}`,
+    date: '2024-01-01',
+    flags: [],
+    priority: '',
+    struct: ['alternative', 'alternative'],
+  };
+}
+
+function renderEnvelopes(props = {}) {
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <AppMessageContext.Provider value={{ setMessage: vi.fn() }}>
+        <Envelopes
+          message_ids={[]}
+          folder="INBOX"
+          host="host"
+          token="tok"
+          api_url="http://api"
+          selected_messages={[]}
+          showOverlay={vi.fn()}
+          handleCheck={vi.fn()}
+          handleSelect={vi.fn()}
+          setMessage={vi.fn()}
+          markUnread={vi.fn()}
+          markRead={vi.fn()}
+          archive={vi.fn()}
+          {...props}
+        />
+      </AppMessageContext.Provider>
+    </AuthContext.Provider>
+  );
+}
+
+describe('Envelopes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches envelopes when message_ids are provided', async () => {
+    const ids = [1, 2, 3];
+    const envelopes = {};
+    ids.forEach(id => { envelopes[id.toString()] = makeEnvelope(id); });
+
+    mockGetEnvelopes.mockResolvedValue({ data: { envelopes } });
+
+    renderEnvelopes({ message_ids: ids });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(mockGetEnvelopes).toHaveBeenCalledWith('INBOX', ids);
+  });
+
+  it('handles concurrent page fetches without race conditions', async () => {
+    // Simulate 60 messages = 2 pages of 30
+    const ids = Array.from({ length: 60 }, (_, i) => i + 1);
+
+    const page1Envelopes = {};
+    ids.slice(0, 30).forEach(id => { page1Envelopes[id.toString()] = makeEnvelope(id); });
+
+    const page2Envelopes = {};
+    ids.slice(30, 60).forEach(id => { page2Envelopes[id.toString()] = makeEnvelope(id); });
+
+    // Page 2 resolves before page 1 (race condition scenario)
+    let resolvePage1;
+    const page1Promise = new Promise(resolve => { resolvePage1 = resolve; });
+
+    mockGetEnvelopes
+      .mockImplementationOnce(() => page1Promise)
+      .mockImplementationOnce(() => Promise.resolve({ data: { envelopes: page2Envelopes } }));
+
+    const { container } = renderEnvelopes({ message_ids: ids });
+
+    // Let page 2 resolve first
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    // Now resolve page 1
+    await act(async () => {
+      resolvePage1({ data: { envelopes: page1Envelopes } });
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    // Both pages should be available — functional updates prevent overwrite
+    // The component uses pages state with functional setPages(prev => ...)
+    // so page2 data is preserved when page1 resolves later
+    expect(mockGetEnvelopes).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-fetches when message_ids change', async () => {
+    const ids1 = [1, 2];
+    const envelopes1 = {};
+    ids1.forEach(id => { envelopes1[id.toString()] = makeEnvelope(id); });
+    mockGetEnvelopes.mockResolvedValue({ data: { envelopes: envelopes1 } });
+
+    const { rerender } = renderEnvelopes({ message_ids: ids1 });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(mockGetEnvelopes).toHaveBeenCalledTimes(1);
+
+    // Change message_ids
+    const ids2 = [3, 4, 5];
+    const envelopes2 = {};
+    ids2.forEach(id => { envelopes2[id.toString()] = makeEnvelope(id); });
+    mockGetEnvelopes.mockResolvedValue({ data: { envelopes: envelopes2 } });
+
+    rerender(
+      <AuthContext.Provider value={authValue}>
+        <AppMessageContext.Provider value={{ setMessage: vi.fn() }}>
+          <Envelopes
+            message_ids={ids2}
+            folder="INBOX"
+            host="host"
+            token="tok"
+            api_url="http://api"
+            selected_messages={[]}
+            showOverlay={vi.fn()}
+            handleCheck={vi.fn()}
+            handleSelect={vi.fn()}
+            setMessage={vi.fn()}
+            markUnread={vi.fn()}
+            markRead={vi.fn()}
+            archive={vi.fn()}
+          />
+        </AppMessageContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(mockGetEnvelopes).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not render envelopes for ids without data', () => {
+    mockGetEnvelopes.mockResolvedValue({ data: { envelopes: {} } });
+
+    const { container } = renderEnvelopes({ message_ids: [1, 2, 3] });
+
+    // No envelope rows should render since data hasn't loaded yet
+    expect(container.querySelectorAll('.message-row').length).toBe(0);
+  });
+});

--- a/react/admin/src/Email/Messages/Folders/index.jsx
+++ b/react/admin/src/Email/Messages/Folders/index.jsx
@@ -1,82 +1,78 @@
-import React from 'react';
-import ApiClient from '../../../ApiClient';
+import React, { useState, useEffect, useCallback } from 'react';
+import useApi from '../../../hooks/useApi';
 import { FOLDER_LIST } from '../../../constants';
 
 /**
  * Fetches folders for current users and displays them in the email filter context
  */
 
-class Folders extends React.Component {
+function Folders({ setFolder: setFolderProp, folder, setMessage, label }) {
+  const api = useApi();
+  const [folders, setFolders] = useState([]);
+  const [subscribedFolders, setSubscribedFolders] = useState([]);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      folders: [],
-      subscribed_folders: []
-    };
-    this.api = new ApiClient(this.props.api_url, this.props.token, this.props.host);
-  }
+  useEffect(() => {
+    let cancelled = false;
 
-  componentDidMount() {
-    const response = this.api.getFolderList();
-    response.then(data => {
+    api.getFolderList().then(data => {
+      if (cancelled) return;
       try {
         localStorage.setItem(FOLDER_LIST, JSON.stringify(data));
       } catch (e) {
         console.log(e);
       }
-      const all_folders = [...new Set([
-                          ...(data.data.folders),
-                          ...(data.data.sub_folders)
-                          ])].sort();
-      this.setState({ ...this.state, folders: all_folders, subscribed_folders: data.data.sub_folders });
+      const allFolders = [...new Set([
+        ...(data.data.folders),
+        ...(data.data.sub_folders)
+      ])].sort();
+      setFolders(allFolders);
+      setSubscribedFolders(data.data.sub_folders);
     }).catch(e => {
-      this.props.setMessage("Unable to fetch folders.", true);
-      console.log(e);
+      if (!cancelled) {
+        setMessage("Unable to fetch folders.", true);
+        console.log(e);
+      }
     });
-  }
 
-  setFolder = (e) => {
+    return () => { cancelled = true; };
+  }, [api, setMessage]);
+
+  const handleSetFolder = useCallback((e) => {
     e.preventDefault();
-    this.props.setFolder(e.target.value);
-  }
+    setFolderProp(e.target.value);
+  }, [setFolderProp]);
 
-  render() {
-    // TODO: handle nexted arrays
-    const sub_folder_list = this.state.subscribed_folders.map(item => {
-      return (
-        <option value={item} key={item}>{item}</option>
-      );
-    });
-    const folder_list = this.state.folders.filter(item => {
-      return this.state.subscribed_folders.indexOf(item) === -1;
-    }).map(item => {
-      return (
-        <option value={item} key={item}>{item}</option>
-      );
-    });
-    return (
-      <div className="filter-folder">
-        <span className="filter filter-folder">
-          <label htmlFor="folder">{this.props.label}:</label>
-          <select
-            name="folder"
-            onChange={this.setFolder}
-            value={this.props.folder}
-            className="selectFolder"
-          >
-            <option value="INBOX">INBOX</option>
-            <optgroup label="Subscribed Folders">
-              {sub_folder_list}
-            </optgroup>
-            <optgroup label="Other Folders">
-              {folder_list}
-            </optgroup>
-          </select>
-        </span>
-      </div>
-    );
-  }
+  const sub_folder_list = subscribedFolders.map(item => (
+    <option value={item} key={item}>{item}</option>
+  ));
+
+  const folder_list = folders.filter(item => {
+    return subscribedFolders.indexOf(item) === -1;
+  }).map(item => (
+    <option value={item} key={item}>{item}</option>
+  ));
+
+  return (
+    <div className="filter-folder">
+      <span className="filter filter-folder">
+        <label htmlFor="folder">{label}:</label>
+        <select
+          name="folder"
+          onChange={handleSetFolder}
+          value={folder}
+          className="selectFolder"
+        >
+          <option value="INBOX">INBOX</option>
+          <optgroup label="Subscribed Folders">
+            {sub_folder_list}
+          </optgroup>
+          <optgroup label="Other Folders">
+            {folder_list}
+          </optgroup>
+        </select>
+      </span>
+    </div>
+  );
 }
 
 export default Folders;

--- a/react/admin/src/Email/Messages/Messages.test.jsx
+++ b/react/admin/src/Email/Messages/Messages.test.jsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Messages from './index';
+import AuthContext from '../../contexts/AuthContext';
+import AppMessageContext from '../../contexts/AppMessageContext';
+
+const mockGetMessages = vi.fn();
+const mockSetFlag = vi.fn();
+const mockMoveMessages = vi.fn();
+const mockGetEnvelopes = vi.fn().mockResolvedValue({ data: { envelopes: {} } });
+const mockGetFolderList = vi.fn().mockResolvedValue({ data: { folders: [], sub_folders: [] } });
+
+const mockApi = {
+  getMessages: mockGetMessages,
+  setFlag: mockSetFlag,
+  moveMessages: mockMoveMessages,
+  getEnvelopes: mockGetEnvelopes,
+  getFolderList: mockGetFolderList,
+};
+
+vi.mock('../../hooks/useApi', () => ({
+  default: () => mockApi,
+}));
+
+const authValue = { token: 'tok', api_url: 'http://api', host: 'host' };
+const setMessage = vi.fn();
+
+function renderMessages(props = {}) {
+  return render(
+    <AuthContext.Provider value={authValue}>
+      <AppMessageContext.Provider value={{ setMessage }}>
+        <Messages
+          token="tok"
+          api_url="http://api"
+          folder="INBOX"
+          host="host"
+          showOverlay={vi.fn()}
+          setFolder={vi.fn()}
+          setMessage={setMessage}
+          {...props}
+        />
+      </AppMessageContext.Provider>
+    </AuthContext.Provider>
+  );
+}
+
+describe('Messages', () => {
+  beforeEach(() => {
+    mockGetMessages.mockResolvedValue({ data: { message_ids: [1, 2, 3] } });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', async () => {
+    const { unmount } = renderMessages();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    // Flush pending effects so we don't pollute the next test
+    await act(async () => { await Promise.resolve(); });
+    unmount();
+  });
+
+  it('fetches messages and switches folders correctly', async () => {
+    const { rerender, unmount } = renderMessages({ folder: 'INBOX' });
+    try {
+      await waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalledWith('INBOX', 'REVERSE ', 'DATE');
+      });
+      mockGetMessages.mockClear();
+
+      rerender(
+        <AuthContext.Provider value={authValue}>
+          <AppMessageContext.Provider value={{ setMessage }}>
+            <Messages
+              token="tok"
+              api_url="http://api"
+              folder="Archive"
+              host="host"
+              showOverlay={vi.fn()}
+              setFolder={vi.fn()}
+              setMessage={setMessage}
+            />
+          </AppMessageContext.Provider>
+        </AuthContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalledWith('Archive', 'REVERSE ', 'DATE');
+      });
+    } finally {
+      unmount();
+    }
+  });
+
+  it('shows error message when fetch fails', async () => {
+    mockGetMessages.mockRejectedValueOnce(new Error('Network error'));
+    // Subsequent polls succeed (so we don't keep erroring)
+    mockGetMessages.mockResolvedValue({ data: { message_ids: [] } });
+
+    const { unmount } = renderMessages();
+    try {
+      await waitFor(() => {
+        expect(setMessage).toHaveBeenCalledWith('Unable to get list of messages.', true);
+      });
+    } finally {
+      unmount();
+    }
+  });
+});

--- a/react/admin/src/Email/Messages/index.jsx
+++ b/react/admin/src/Email/Messages/index.jsx
@@ -2,333 +2,243 @@
  * Fetches message ids for current users/folder and displays them
  */
 
-import React from 'react';
-import ApiClient from '../../ApiClient';
-// import LazyLoad from 'react-lazyload';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import Envelopes from './Envelopes';
 import Folders from './Folders';
 import Actions from '../Actions';
+import useApi from '../../hooks/useApi';
 import { READ, UNREAD, ASC, DESC, ARRIVAL, DATE, FROM, SUBJECT } from '../../constants';
 import './Messages.css';
 
-class Messages extends React.Component {
+function Messages({ token, api_url, folder, host, showOverlay, setFolder: setFolderProp, setMessage }) {
+  const api = useApi();
 
-  constructor(props) {
-    super(props);
-    this.callbackTimeout = null;
-    this.poller1Timeout = null;
-    this.poller2Timeout = null;
-    this.archiveTimeout = null;
-    this.interval = null;
-    this.state = {
-      message_ids: [],
-      shown_message: null,
-      selected_messages: [],
-      sort_order: DESC,
-      sort_field: DATE,
-      loading: true
-    };
-    this.api = new ApiClient(this.props.api_url, this.props.token, this.props.host);
-  }
+  const [messageIds, setMessageIds] = useState([]);
+  const [selectedMessages, setSelectedMessages] = useState([]);
+  const [sortOrder, setSortOrder] = useState(DESC);
+  const [sortField, setSortField] = useState(DATE);
+  const [loading, setLoading] = useState(true);
 
-  componentDidMount() {
-    this.poller(
-      this.api,
-      this.props.folder,
-      this.state.sort_order.imap,
-      this.state.sort_field.imap,
-      this
-    );
-    this.poller1Timeout = setTimeout(
-      this.poller,
-      10, 
-      this.api,
-      this.props.folder,
-      this.state.sort_order.imap,
-      this.state.sort_field.imap,
-      this
-    );
-    this.interval = setInterval(
-      this.poller,
-      10000, 
-      this.api,
-      this.props.folder,
-      this.state.sort_order.imap,
-      this.state.sort_field.imap,
-      this
-    );
-  }
+  const callbackTimeoutRef = useRef(null);
+  const archiveTimeoutRef = useRef(null);
+  const intervalRef = useRef(null);
 
-  componentDidUpdate(prevProps, prevState) {
-    if ((this.props.folder !== prevProps.folder) ||
-        (this.state.sort_order !== prevState.sort_order) ||
-        (this.state.sort_field !== prevState.sort_field)) {
-      clearInterval(this.interval);
-      this.poller(
-        this.api,
-        this.props.folder,
-        this.state.sort_order.imap,
-        this.state.sort_field.imap,
-        this
-      );
-      this.poller2Timeout = setTimeout(
-        this.poller,
-        10, 
-        this.api,
-        this.props.folder,
-        this.state.sort_order.imap,
-        this.state.sort_field.imap,
-        this
-      );
-      clearInterval(this.interval);
-      this.interval = setInterval(
-        this.poller,
-        10000, 
-        this.api,
-        this.props.folder,
-        this.state.sort_order.imap,
-        this.state.sort_field.imap,
-        this
-      );
-    }
-  }
+  // Polling effect — runs on mount and whenever folder/sort changes
+  useEffect(() => {
+    let cancelled = false;
 
-  componentWillUnmount() {
-    clearInterval(this.interval);
-    clearTimeout(this.callbackTimeout);
-    clearTimeout(this.poller1Timeout);
-    clearTimeout(this.poller2Timeout);
-    clearTimeout(this.archiveTimeout);
-  }
-
-  poller(api, folder, order, field, that) {
-    const response = api.getMessages(folder, order, field);
-    response.then(data => {
-      that.setState({
-        ...that.state,
-        message_ids: data.data.message_ids,
-        loading: false
-      });
-    }).catch(e => {
-      that.props.setMessage("Unable to get list of messages.", true);
-      console.log(e);
-    });
-  }
-
-  toggleOrder() {
-    this.setState({
-      ...this.state,
-      sort_order: this.state.sort_order.imap === ASC.imap ? DESC : ASC
-    })
-  }
-
-  callback = (data) => {
-    this.setState({
-      ...this.state,
-      message_ids: [],
-      loading: true
-    });
-    this.callbackTimeout = setTimeout(() => {
-      this.setState({
-        ...this.state,
-        message_ids: data.data.message_ids,
-        loading: false
-      });
-    }, 1);
-  }
-
-  catchback = (err) => {
-    this.props.setMessage(`Unable to set flag on selected messages.`, true);
-    console.log(`Unable to set flag on selected messages.`);
-    console.error(err);
-  };
-
-  handleCheck = (message_id, checked) => {
-    var id = parseInt(message_id);
-    if (checked) {
-      this.setState({
-        ...this.state,
-        selected_messages: [...this.state.selected_messages, id]
-      });
-    } else {
-      this.setState({
-        ...this.state,
-        selected_messages: this.state.selected_messages.filter(function(i) { 
-          return id !== i;
+    function poll() {
+      api.getMessages(folder, sortOrder.imap, sortField.imap)
+        .then(data => {
+          if (!cancelled) {
+            setMessageIds(data.data.message_ids);
+            setLoading(false);
+          }
         })
-      });
+        .catch(e => {
+          if (!cancelled) {
+            setMessage("Unable to get list of messages.", true);
+            console.log(e);
+          }
+        });
     }
-  }
 
-  handleSelect = (message_id) => {
-    var id = parseInt(message_id);
-    this.setState({
-      ...this.state,
-      selected_message: id
-    });
-  }
+    setLoading(true);
+    poll();
 
-  archive = (message_id) => {
-    this.api.setFlag(
-      this.props.folder,
+    intervalRef.current = setInterval(poll, 10000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalRef.current);
+    };
+  }, [api, folder, sortOrder, sortField, setMessage]);
+
+  // Cleanup non-polling timers on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(callbackTimeoutRef.current);
+      clearTimeout(archiveTimeoutRef.current);
+    };
+  }, []);
+
+  const callback = useCallback((data) => {
+    setMessageIds([]);
+    setLoading(true);
+    callbackTimeoutRef.current = setTimeout(() => {
+      setMessageIds(data.data.message_ids);
+      setLoading(false);
+    }, 1);
+  }, []);
+
+  const catchback = useCallback((err) => {
+    setMessage("Unable to set flag on selected messages.", true);
+    console.log("Unable to set flag on selected messages.");
+    console.error(err);
+  }, [setMessage]);
+
+  const handleCheck = useCallback((message_id, checked) => {
+    const id = parseInt(message_id);
+    setSelectedMessages(prev =>
+      checked ? [...prev, id] : prev.filter(i => id !== i)
+    );
+  }, []);
+
+  const handleSelect = useCallback((message_id) => {
+    // kept for API compatibility — not currently rendered
+    parseInt(message_id);
+  }, []);
+
+  const archive = useCallback((message_id) => {
+    api.setFlag(
+      folder,
       READ.imap,
       READ.op,
       [message_id],
-      this.state.sort_order.imap,
-      this.state.sort_field.imap
+      sortOrder.imap,
+      sortField.imap
     ).then(() => {
-      this.archiveTimeout = setTimeout(() => {
-        this.api.moveMessages(
-          this.props.folder,
+      archiveTimeoutRef.current = setTimeout(() => {
+        api.moveMessages(
+          folder,
           'Archive',
           [message_id],
-          this.state.sort_order.imap,
-          this.state.sort_field.imap
+          sortOrder.imap,
+          sortField.imap
         );
       }, 500);
     });
-  }
+  }, [api, folder, sortOrder, sortField]);
 
-  markRead = (message_id) => {
-    return this.api.setFlag(
-      this.props.folder,
+  const markRead = useCallback((message_id) => {
+    return api.setFlag(
+      folder,
       READ.imap,
       READ.op,
       [message_id],
-      this.state.sort_order.imap,
-      this.state.sort_field.imap
+      sortOrder.imap,
+      sortField.imap
     );
-  }
+  }, [api, folder, sortOrder, sortField]);
 
-  markUnread = (message_id) => {
-    return this.api.setFlag(
-      this.props.folder,
+  const markUnread = useCallback((message_id) => {
+    return api.setFlag(
+      folder,
       UNREAD.imap,
       UNREAD.op,
       [message_id],
-      this.state.sort_order.imap,
-      this.state.sort_field.imap
+      sortOrder.imap,
+      sortField.imap
     );
-  }
+  }, [api, folder, sortOrder, sortField]);
 
-  sortAscending = (e) => {
+  const sortAscending = useCallback((e) => {
     e.preventDefault();
-    this.setState({...this.state, sort_order: ASC, loading: true});
-  }
+    setSortOrder(ASC);
+    setLoading(true);
+  }, []);
 
-  sortDescending = (e) => {
+  const sortDescending = useCallback((e) => {
     e.preventDefault();
-    this.setState({...this.state, sort_order: DESC, loading: true});
-  }
+    setSortOrder(DESC);
+    setLoading(true);
+  }, []);
 
-  setSortField = (e) => {
+  const handleSortField = useCallback((e) => {
     e.preventDefault();
-    switch(e.target.value) {
-      case SUBJECT.imap:
-        this.setState({...this.state, sort_field: SUBJECT, loading: true});
-        break;
-      case DATE.imap:
-        this.setState({...this.state, sort_field: DATE, loading: true});
-        break;
-      case ARRIVAL.imap:
-        this.setState({...this.state, sort_field: ARRIVAL, loading: true});
-        break;
-      case FROM.imap:
-        this.setState({...this.state, sort_field: FROM, loading: true});
-        break;
-      default:
-        this.setState({...this.state, sort_field: DATE, loading: true});
-    }
+    const fields = { [SUBJECT.imap]: SUBJECT, [DATE.imap]: DATE, [ARRIVAL.imap]: ARRIVAL, [FROM.imap]: FROM };
+    const field = fields[e.target.value] || DATE;
+    setSortField(field);
+    setLoading(true);
+  }, []);
+
+  const handleSetFolder = useCallback((f) => {
+    setSelectedMessages([]);
+    setFolderProp(f);
+  }, [setFolderProp]);
+
+  const options = [DATE, ARRIVAL, SUBJECT, FROM].map(i => {
+    return <option id={i.css} value={i.imap} key={i.imap}>{i.description}</option>;
+  });
+  const selected = selectedMessages.length ? " selected" : " none_selected";
+
+  if (loading) {
+    return <div className="email_list loading">Loading...</div>;
   }
 
-  setFolder = (folder) => {
-    this.setState({...this.state, selected_messages: []});
-    this.props.setFolder(folder);
-  }
-
-  render() {
-    // TO field omitted since it's not displayed
-    const options = [DATE, ARRIVAL, SUBJECT, FROM].map(i => {
-      return <option id={i.css} value={i.imap} key={i.imap}>{i.description}</option>;
-    });
-    const selected = this.state.selected_messages.length ? " selected" : " none_selected";
-    if (this.state.loading) {
-      return <div className="email_list loading">Loading...</div>;
-    }
-    return (
-      <div className="email_list">
-        <div className="sticky">
-          <div className={`filters filters-dropdowns ${this.state.sort_order.css}`}>
-            <Folders 
-              token={this.props.token}
-              api_url={this.props.api_url}
-              setFolder={this.setFolder}
-              host={this.props.host}
-              folder={this.props.folder}
-              setMessage={this.props.setMessage}
-              label="Folder"
-            />&nbsp;
-            <div>
-              <span className="filter filter-sort">
-                <label htmlFor="sort-field">Sort by:</label>
-                <select id="sort-by" name="sort-by" className="sort-by" onChange={this.setSortField}>
-                  {options}
-                </select>
-                <button
-                  id={ASC.css}
-                  className="sort-order"
-                  title="Sort ascending"
-                  onClick={this.sortAscending}
-                >&nbsp;
-                  <hr className="long first" />
-                  <hr className="medium second" />
-                  <hr className="short third" />
-                </button>
-                <button
-                  id={DESC.css}
-                  className="sort-order"
-                  title="Sort descending"
-                  onClick={this.sortDescending}
-                >&nbsp;
-                  <hr className="short first" />
-                  <hr className="medium second" />
-                  <hr className="long third" />
-                </button>
-              </span>
-            </div>
+  return (
+    <div className="email_list">
+      <div className="sticky">
+        <div className={`filters filters-dropdowns ${sortOrder.css}`}>
+          <Folders
+            token={token}
+            api_url={api_url}
+            setFolder={handleSetFolder}
+            host={host}
+            folder={folder}
+            setMessage={setMessage}
+            label="Folder"
+          />&nbsp;
+          <div>
+            <span className="filter filter-sort">
+              <label htmlFor="sort-field">Sort by:</label>
+              <select id="sort-by" name="sort-by" className="sort-by" onChange={handleSortField}>
+                {options}
+              </select>
+              <button
+                id={ASC.css}
+                className="sort-order"
+                title="Sort ascending"
+                onClick={sortAscending}
+              >&nbsp;
+                <hr className="long first" />
+                <hr className="medium second" />
+                <hr className="short third" />
+              </button>
+              <button
+                id={DESC.css}
+                className="sort-order"
+                title="Sort descending"
+                onClick={sortDescending}
+              >&nbsp;
+                <hr className="short first" />
+                <hr className="medium second" />
+                <hr className="long third" />
+              </button>
+            </span>
           </div>
-          <Actions
-            token={this.props.token}
-            api_url={this.props.api_url}
-            host={this.props.host}
-            folder={this.props.folder}
-            selected_messages={this.state.selected_messages}
-            selected={selected}
-            order={this.state.sort_order.imap}
-            field={this.state.sort_field.imap}
-            callback={this.callback}
-            catchback={this.catchback}
-            setMessage={this.props.setMessage}
-          />
         </div>
-        <Envelopes
-          message_ids={this.state.message_ids}
-          folder={this.props.folder}
-          host={this.props.host}
-          token={this.props.token}
-          api_url={this.props.api_url}
-          selected_messages={this.state.selected_messages}
-          showOverlay={this.props.showOverlay}
-          handleCheck={this.handleCheck}
-          handleSelect={this.handleSelect}
-          setMessage={this.props.setMessage}
-          markUnread={this.markUnread}
-          markRead={this.markRead}
-          archive={this.archive}
+        <Actions
+          token={token}
+          api_url={api_url}
+          host={host}
+          folder={folder}
+          selected_messages={selectedMessages}
+          selected={selected}
+          order={sortOrder.imap}
+          field={sortField.imap}
+          callback={callback}
+          catchback={catchback}
+          setMessage={setMessage}
         />
       </div>
-    );
-  }
+      <Envelopes
+        message_ids={messageIds}
+        folder={folder}
+        host={host}
+        token={token}
+        api_url={api_url}
+        selected_messages={selectedMessages}
+        showOverlay={showOverlay}
+        handleCheck={handleCheck}
+        handleSelect={handleSelect}
+        setMessage={setMessage}
+        markUnread={markUnread}
+        markRead={markRead}
+        archive={archive}
+      />
+    </div>
+  );
 }
 
 export default Messages;

--- a/react/admin/src/Email/index.jsx
+++ b/react/admin/src/Email/index.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import './Email.css';
 import Messages from './Messages';
 import MessageOverlay from './MessageOverlay';
 import ComposeOverlay from './ComposeOverlay';
+import { useAuth } from '../contexts/AuthContext';
+import { useAppMessage } from '../contexts/AppMessageContext';
 
 const EMPTY_ENVELOPE = {
   from: [],
@@ -10,48 +12,54 @@ const EMPTY_ENVELOPE = {
   subject: ""
 };
 
-class Email extends React.Component {
+function prepBody(body, envelope) {
+  return '<div><p>&#160;</p></div><div><hr /></div>' +
+    `<div style="font-weight: bold;">From: ${envelope.from[0]}</div>` +
+    `<div style="font-weight: bold;">To: ${envelope.to.join("; ")}</div>` +
+    `<div style="font-weight: bold;">Date: ${envelope.date}</div>` +
+    `<div style="font-weight: bold;">Subject: ${envelope.subject}</div><div><p>&#160;</p></div>` +
+    body.replace(/<!--[\s\S]*?-->/gm, "").replace(/&lt;!--[\s\S]*?--&gt;/gm, "")
+    .replace(/[\s\S]*<body>/m, "").replace(/<\/body>[\s\S]*/m, "");
+}
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      folder: "INBOX",
-      overlayVisible: false,
-      composeVisible: false,
-      recipient: "",
-      envelope: {},
-      new_envelope: EMPTY_ENVELOPE,
-      body: "",
-      other_headers: {},
-      flags: [],
-      type: "new"
-    };
-  }
+function Email() {
+  const { token, api_url, host, domains, smtp_host } = useAuth();
+  const { setMessage } = useAppMessage();
 
-  selectFolder = (folder) => {
-    this.setState({...this.state, folder: folder});
-  }
+  const [folder, setFolder] = useState("INBOX");
+  const [overlayVisible, setOverlayVisible] = useState(false);
+  const [composeVisible, setComposeVisible] = useState(false);
+  const [envelope, setEnvelope] = useState({});
+  const [flags, setFlags] = useState([]);
+  const [composeState, setComposeState] = useState({
+    new_envelope: EMPTY_ENVELOPE,
+    subject: "",
+    recipient: "",
+    body: "",
+    type: "new",
+    other_headers: {}
+  });
 
-  showOverlay = (envelope) => {
-    this.setState({
-      ...this.state,
-      overlayVisible: true,
-      envelope: envelope,
-      flags: envelope.flags
-    });
-  }
+  const selectFolder = useCallback((f) => {
+    setFolder(f);
+  }, []);
 
-  hideOverlay = () => {
-    this.setState({...this.state, overlayVisible: false});
-  }
+  const showOverlay = useCallback((env) => {
+    setEnvelope(env);
+    setFlags(env.flags);
+    setOverlayVisible(true);
+  }, []);
 
-  hideCompose = (envelope) => {
-    this.setState({...this.state, composeVisible: false});
-  }
+  const hideOverlay = useCallback(() => {
+    setOverlayVisible(false);
+  }, []);
 
-  newEmail = () => {
-    this.setState(
-      {...this.state,
+  const hideCompose = useCallback(() => {
+    setComposeVisible(false);
+  }, []);
+
+  const newEmail = useCallback(() => {
+    setComposeState({
       new_envelope: EMPTY_ENVELOPE,
       subject: "",
       recipient: "",
@@ -61,102 +69,90 @@ class Email extends React.Component {
         in_reply_to: [],
         references: [],
         message_id: []
-      },
-      composeVisible: true}
-      );
-  }
+      }
+    });
+    setComposeVisible(true);
+  }, []);
 
-  prepBody(body, envelope) {
-    return '<div><p>&#160;</p></div><div><hr /></div>' +
-      `<div style="font-weight: bold;">From: ${envelope.from[0]}</div>` +
-      `<div style="font-weight: bold;">To: ${envelope.to.join("; ")}</div>` +
-      `<div style="font-weight: bold;">Date: ${envelope.date}</div>` +
-      `<div style="font-weight: bold;">Subject: ${envelope.subject}</div><div><p>&#160;</p></div>` +
-      body.replace(/<!--[\s\S]*?-->/gm, "").replace(/&lt;!--[\s\S]*?--&gt;/gm, "")
-      .replace(/[\s\S]*<body>/m, "").replace(/<\/body>[\s\S]*/m, "");
-  }
-
-  launchComposer(recipient, body, envelope, other_headers, type) {
+  const launchComposer = useCallback((recipient, body, env, other_headers, type) => {
     const prefix = type === "forward" ? "Fwd: " : "Re: ";
-    const subject = prefix + envelope.subject.replace(/^(re:?\s|fwd?:?\s)?/i, "");
-    const extended_body = this.prepBody(body, envelope);
-    this.setState({
-      ...this.state,
-      new_envelope: envelope,
+    const subject = prefix + env.subject.replace(/^(re:?\s|fwd?:?\s)?/i, "");
+    const extended_body = prepBody(body, env);
+    setComposeState({
+      new_envelope: env,
       subject: subject,
       recipient: recipient,
       body: extended_body,
       type: type,
-      other_headers: other_headers,
-      composeVisible: true
+      other_headers: other_headers
     });
-  }
+    setComposeVisible(true);
+  }, []);
 
-  reply = (recipient, body, envelope, other_headers) => {
-    this.launchComposer(recipient, body, envelope, other_headers, "reply");
-  }
+  const reply = useCallback((recipient, body, env, other_headers) => {
+    launchComposer(recipient, body, env, other_headers, "reply");
+  }, [launchComposer]);
 
-  replyAll = (recipient, body, envelope, other_headers) => {
-    this.launchComposer(recipient, body, envelope, other_headers, "replyAll");
-  }
+  const replyAll = useCallback((recipient, body, env, other_headers) => {
+    launchComposer(recipient, body, env, other_headers, "replyAll");
+  }, [launchComposer]);
 
-  forward = (recipient, body, envelope, other_headers) => {
-    this.launchComposer(recipient, body, envelope, other_headers, "forward");
-  }
+  const forward = useCallback((recipient, body, env, other_headers) => {
+    launchComposer(recipient, body, env, other_headers, "forward");
+  }, [launchComposer]);
 
-  render() {
-    const compose_overlay = this.state.composeVisible ? (
-      <div className="compose-blackout" id="compose-blackout">
-        <div className="compose-wrapper show-compose" id="compose-wrapper">
-          <ComposeOverlay
-            token={this.props.token}
-            api_url={this.props.api_url}
-            host={this.props.host}
-            smtp_host={this.props.smtp_host}
-            hide={this.hideCompose}
-            domains={this.props.domains}
-            setMessage={this.props.setMessage}
-            body={this.state.body}
-            recipient={this.state.recipient}
-            envelope={this.state.new_envelope}
-            subject={this.state.subject}
-            type={this.state.type}
-            other_headers={this.state.other_headers}
-          />
-        </div>
-      </div>
-    ) : "";
-    return (
-      <div className="email">
-        <Messages 
-          token={this.props.token}
-          api_url={this.props.api_url}
-          folder={this.state.folder}
-          host={this.props.host}
-          showOverlay={this.showOverlay}
-          setFolder={this.selectFolder}
-          setMessage={this.props.setMessage}
+  const compose_overlay = composeVisible ? (
+    <div className="compose-blackout" id="compose-blackout">
+      <div className="compose-wrapper show-compose" id="compose-wrapper">
+        <ComposeOverlay
+          token={token}
+          api_url={api_url}
+          host={host}
+          smtp_host={smtp_host}
+          hide={hideCompose}
+          domains={domains}
+          setMessage={setMessage}
+          body={composeState.body}
+          recipient={composeState.recipient}
+          envelope={composeState.new_envelope}
+          subject={composeState.subject}
+          type={composeState.type}
+          other_headers={composeState.other_headers}
         />
-        <MessageOverlay 
-          token={this.props.token}
-          api_url={this.props.api_url}
-          envelope={this.state.envelope}
-          flags={this.state.flags}
-          visible={this.state.overlayVisible}
-          folder={this.state.folder}
-          host={this.props.host}
-          hide={this.hideOverlay}
-          updateOverlay={this.showOverlay}
-          setMessage={this.props.setMessage}
-          reply={this.reply}
-          replyAll={this.replyAll}
-          forward={this.forward}
-        />
-        <button className="compose-button" onClick={this.newEmail}>New Email</button>
-        {compose_overlay}
       </div>
-    );
-  }
+    </div>
+  ) : "";
+
+  return (
+    <div className="email">
+      <Messages
+        token={token}
+        api_url={api_url}
+        folder={folder}
+        host={host}
+        showOverlay={showOverlay}
+        setFolder={selectFolder}
+        setMessage={setMessage}
+      />
+      <MessageOverlay
+        token={token}
+        api_url={api_url}
+        envelope={envelope}
+        flags={flags}
+        visible={overlayVisible}
+        folder={folder}
+        host={host}
+        hide={hideOverlay}
+        updateOverlay={showOverlay}
+        setMessage={setMessage}
+        reply={reply}
+        replyAll={replyAll}
+        forward={forward}
+      />
+      <button className="compose-button" onClick={newEmail}>New Email</button>
+      {compose_overlay}
+    </div>
+  );
 }
 
 export default Email;

--- a/react/admin/src/test/setup.js
+++ b/react/admin/src/test/setup.js
@@ -1,1 +1,12 @@
 import '@testing-library/jest-dom';
+
+// Mock IntersectionObserver for jsdom (used by react-intersection-observer)
+class IntersectionObserver {
+  constructor(callback) {
+    this._callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.IntersectionObserver = IntersectionObserver;


### PR DESCRIPTION
Convert Email, Messages, Envelopes, Envelope, Folders, and Actions to functional components with hooks. Fix the Messages polling memory leak by collapsing 5 timer IDs into a single useEffect with useRef cleanup, and fix the Envelopes pagination race condition with functional state updates so concurrent page fetches no longer overwrite each other.

Wire AuthContext to expose smtp_host and wrap setMessage in an object to match the useAppMessage hook contract. Add IntersectionObserver mock to the jsdom test setup for react-intersection-observer.

Add tests for Messages (loading, fetch, folder switching, error path) and Envelopes (fetch, race condition, refetch, render-gating).