### PR TITLE
Fix Configuration.domains schema to match live config.json

### DIFF
--- a/apple/CabalmailKit/Sources/CabalmailKit/Config/Configuration.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Config/Configuration.swift
@@ -8,13 +8,13 @@ import Foundation
 /// app's `config.js` — they are sibling representations of the same values.
 public struct Configuration: Sendable, Codable, Equatable {
     public let controlDomain: String
-    public let domains: [String]
+    public let domains: [MailDomain]
     public let invokeUrl: URL
     public let cognito: CognitoConfiguration
 
     public init(
         controlDomain: String,
-        domains: [String],
+        domains: [MailDomain],
         invokeUrl: URL,
         cognito: CognitoConfiguration
     ) {
@@ -29,6 +29,38 @@ public struct Configuration: Sendable, Codable, Equatable {
         case domains
         case invokeUrl
         case cognito = "cognitoConfig"
+    }
+}
+
+/// One of the mail domains the Cabalmail deployment is authoritative for.
+/// Phase 4 only reads `domain`; Phase 5's From-address picker uses it to
+/// build subdomain choices. The remaining fields mirror the Route 53 hosted-
+/// zone record Terraform writes into `config.json`.
+public struct MailDomain: Sendable, Codable, Equatable, Hashable, Identifiable {
+    public let domain: String
+    public let arn: String?
+    public let zoneId: String?
+    public let nameServers: [String]
+
+    public var id: String { domain }
+
+    public init(
+        domain: String,
+        arn: String? = nil,
+        zoneId: String? = nil,
+        nameServers: [String] = []
+    ) {
+        self.domain = domain
+        self.arn = arn
+        self.zoneId = zoneId
+        self.nameServers = nameServers
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case domain
+        case arn
+        case zoneId = "zone_id"
+        case nameServers = "name_servers"
     }
 }
 

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientTests.swift
@@ -5,7 +5,7 @@ final class ApiClientTests: XCTestCase {
     private func makeConfiguration() -> Configuration {
         Configuration(
             controlDomain: "cabalmail.example",
-            domains: ["cabalmail.example"],
+            domains: [MailDomain(domain: "cabalmail.example")],
             invokeUrl: URL(string: "https://api.cabalmail.example/prod")!,
             cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
         )

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/AuthServiceTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/AuthServiceTests.swift
@@ -5,7 +5,7 @@ final class AuthServiceTests: XCTestCase {
     private func makeConfiguration() -> Configuration {
         Configuration(
             controlDomain: "cabalmail.example",
-            domains: ["cabalmail.example"],
+            domains: [MailDomain(domain: "cabalmail.example")],
             invokeUrl: URL(string: "https://api.cabalmail.example/prod")!,
             cognito: .init(region: "us-east-1", userPoolId: "us-east-1_ABC", clientId: "clientX")
         )

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/CabalmailKitTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/CabalmailKitTests.swift
@@ -7,12 +7,27 @@ final class CabalmailKitTests: XCTestCase {
     }
 
     func testConfigurationDecodesConfigJsonShape() throws {
-        // Matches the shape emitted by terraform/infra/modules/app/templates/config.js
-        // (which is valid JSON) and the config.json sibling.
+        // Matches the real shape emitted by
+        // terraform/infra/modules/app/templates/config.js (which is valid
+        // JSON) and the config.json sibling. `domains` is an array of
+        // Route 53 hosted-zone records, not a plain string list.
         let json = Data("""
         {
           "control_domain": "example.com",
-          "domains": ["example.com", "example.net"],
+          "domains": [
+            {
+              "arn": "arn:aws:route53:::hostedzone/Z1",
+              "domain": "example.com",
+              "name_servers": ["ns-1.awsdns-0.net"],
+              "zone_id": "Z1"
+            },
+            {
+              "arn": "arn:aws:route53:::hostedzone/Z2",
+              "domain": "example.net",
+              "name_servers": ["ns-2.awsdns-0.net"],
+              "zone_id": "Z2"
+            }
+          ],
           "invokeUrl": "https://api.example.com/prod",
           "cognitoConfig": {
             "region": "us-east-1",
@@ -27,7 +42,8 @@ final class CabalmailKitTests: XCTestCase {
         let config = try JSONDecoder().decode(Configuration.self, from: json)
 
         XCTAssertEqual(config.controlDomain, "example.com")
-        XCTAssertEqual(config.domains, ["example.com", "example.net"])
+        XCTAssertEqual(config.domains.map(\.domain), ["example.com", "example.net"])
+        XCTAssertEqual(config.domains.first?.zoneId, "Z1")
         XCTAssertEqual(config.invokeUrl.absoluteString, "https://api.example.com/prod")
         XCTAssertEqual(config.cognito.region, "us-east-1")
         XCTAssertEqual(config.cognito.userPoolId, "us-east-1_ABC")
@@ -37,7 +53,7 @@ final class CabalmailKitTests: XCTestCase {
     func testClientRoundTripsConfiguration() async throws {
         let config = Configuration(
             controlDomain: "example.com",
-            domains: ["example.com"],
+            domains: [MailDomain(domain: "example.com")],
             invokeUrl: URL(string: "https://api.example.com/prod")!,
             cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
         )


### PR DESCRIPTION
The deployed /config.json serves `domains` as an array of Route 53 hosted-zone records — `{arn, domain, name_servers, zone_id}` — not the plain `[String]` I had assumed. Sign-in against a real deployment failed decoding with "The data couldn't be read because it isn't in the correct format."

- `Configuration.domains` becomes `[MailDomain]` with the full Route 53 hosted-zone shape (mirrors what Terraform emits from `terraform/infra/modules/app/templates/config.js`).
- New `MailDomain` value type exposes `domain`, `arn`, `zoneId`, and `nameServers`; `Identifiable` by `domain` so Phase 5's From picker can bind to a `ForEach` without extra plumbing.
- `CabalmailKitTests.testConfigurationDecodesConfigJsonShape` updated to a realistic two-domain fixture. The Auth + Api + round-trip tests construct `MailDomain(domain:)` wrappers. 39/39 green.