### PR TITLE
Derive correct IMAP/SMTP hosts from control_domain, add connect timeout

### DIFF
--- a/apple/CabalmailKit/Sources/CabalmailKit/CabalmailClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/CabalmailClient.swift
@@ -58,11 +58,11 @@ public actor CabalmailClient {
             transport: httpTransport
         )
         let imap = LiveImapClient(
-            factory: NetworkImapConnectionFactory(host: configuration.controlDomain),
+            factory: NetworkImapConnectionFactory(host: configuration.imapHost),
             authService: auth
         )
         let smtp = LiveSmtpClient(
-            factory: NetworkSmtpConnectionFactory(host: configuration.controlDomain),
+            factory: NetworkSmtpConnectionFactory(host: configuration.smtpHost),
             authService: auth
         )
         let addresses = AddressCache()

--- a/apple/CabalmailKit/Sources/CabalmailKit/Config/Configuration.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Config/Configuration.swift
@@ -30,6 +30,25 @@ public struct Configuration: Sendable, Codable, Equatable {
         case invokeUrl
         case cognito = "cognitoConfig"
     }
+
+    /// IMAP hostname derived from the control domain.
+    ///
+    /// Mirrors the rule `react/admin/src/App.jsx` uses: a `dev.*` control
+    /// domain swaps the `dev.` prefix for `imap.`, everything else gets
+    /// `imap.` prepended. The resulting hostname is what the
+    /// `terraform/infra/modules/elb` DNS records point at.
+    public var imapHost: String {
+        if controlDomain.hasPrefix("dev.") {
+            return "imap." + controlDomain.dropFirst("dev.".count)
+        }
+        return "imap.\(controlDomain)"
+    }
+
+    /// Submission hostname — always `smtp-out.<control_domain>` per the
+    /// same convention.
+    public var smtpHost: String {
+        "smtp-out.\(controlDomain)"
+    }
 }
 
 /// One of the mail domains the Cabalmail deployment is authoritative for.

--- a/apple/CabalmailKit/Sources/CabalmailKit/IMAP/NetworkByteStream.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/IMAP/NetworkByteStream.swift
@@ -32,8 +32,13 @@ public final class NetworkByteStream: ByteStream, @unchecked Sendable {
         self.host = host
     }
 
+    /// Opens the connection. Throws `CabalmailError.timeout` after 20 seconds
+    /// if the TLS handshake never completes — without this, a wrong-host /
+    /// wrong-port configuration silently hangs indefinitely because
+    /// `NWConnection` never times the setup out on its own.
     public func start() async throws {
         let guardFlag = ResumeGuard()
+        let connection = self.connection
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             connection.stateUpdateHandler = { state in
                 switch state {
@@ -52,6 +57,12 @@ public final class NetworkByteStream: ByteStream, @unchecked Sendable {
                 }
             }
             connection.start(queue: queue)
+            queue.asyncAfter(deadline: .now() + 20) {
+                if guardFlag.tryFire() {
+                    connection.cancel()
+                    continuation.resume(throwing: CabalmailError.timeout)
+                }
+            }
         }
         connection.stateUpdateHandler = nil
     }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/CabalmailKitTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/CabalmailKitTests.swift
@@ -50,6 +50,27 @@ final class CabalmailKitTests: XCTestCase {
         XCTAssertEqual(config.cognito.clientId, "xyz")
     }
 
+    func testImapAndSmtpHostDerivation() {
+        let prod = Configuration(
+            controlDomain: "cabal-mail.net",
+            domains: [],
+            invokeUrl: URL(string: "https://api.example.com/prod")!,
+            cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
+        )
+        XCTAssertEqual(prod.imapHost, "imap.cabal-mail.net")
+        XCTAssertEqual(prod.smtpHost, "smtp-out.cabal-mail.net")
+
+        // `dev.` prefix swaps to `imap.`, matching the React app.
+        let dev = Configuration(
+            controlDomain: "dev.cabal-mail.net",
+            domains: [],
+            invokeUrl: URL(string: "https://api.example.com/prod")!,
+            cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
+        )
+        XCTAssertEqual(dev.imapHost, "imap.cabal-mail.net")
+        XCTAssertEqual(dev.smtpHost, "smtp-out.dev.cabal-mail.net")
+    }
+
     func testClientRoundTripsConfiguration() async throws {
         let config = Configuration(
             controlDomain: "example.com",


### PR DESCRIPTION
The Apple client was trying to open IMAP on the control domain itself (e.g. `cabal-mail.net:993`), which DNS-resolves fine but never accepts a TCP connection. The NWConnection silently sat in `.preparing` for as long as the user waited — the UI stayed on "Loading folders…" for 15+ minutes.

Cabalmail's real IMAP / SMTP endpoints follow a convention:
- `imap.<control_domain>` (or `dev.<x>` → `imap.<x>`, matching the React app's rule in `react/admin/src/App.jsx`)
- `smtp-out.<control_domain>`

Fix:

- `Configuration.imapHost` / `Configuration.smtpHost` derive the right hostnames from `control_domain`, with the `dev.` → `imap.` swap.
- `CabalmailClient.make(...)` uses these when constructing the `NetworkImapConnectionFactory` and `NetworkSmtpConnectionFactory`.
- `NetworkByteStream.start()` enforces a 20-second connect timeout. Future misconfigurations surface as `CabalmailError.timeout` instead of an infinite spinner.

New test asserts both host derivations (prod + `dev.*`); 40/40 green.