### PR TITLE
Wire Info.plist version fields through build settings

### DIFF
--- a/apple/project.yml
+++ b/apple/project.yml
@@ -57,6 +57,12 @@ targets:
         # App uses only standard HTTPS/TLS; exempt from export compliance
         # questions on every TestFlight upload.
         ITSAppUsesNonExemptEncryption: false
+        # Route the plist's version fields through build settings so CI's
+        # `CURRENT_PROJECT_VERSION=<timestamp>` actually reaches the shipped
+        # Info.plist. Without this, XcodeGen hardcodes "1" / "1.0" and
+        # every archive uploads as CFBundleVersion=1.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen:
           UIColorName: AccentColor
         UISupportedInterfaceOrientations:
@@ -103,6 +109,11 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: public.app-category.productivity
         NSHumanReadableCopyright: ""
+        # See the Cabalmail target's equivalent comment — XcodeGen defaults
+        # these to "1" / "1.0" unless explicitly plumbed through to the
+        # build settings.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.cabalmail.CabalmailMac


### PR DESCRIPTION
CI's timestamp-based `CURRENT_PROJECT_VERSION` wasn't reaching the shipped Info.plist — both iOS and macOS archives uploaded with `CFBundleVersion=1` regardless of what the archive step computed. App Store Connect rejected iOS because build 1 is ≤ the previously-uploaded build 6; macOS succeeded by coincidence because nothing had been uploaded there yet.

Root cause: XcodeGen generates Info.plist from `project.yml` at CI time, and the `info.properties` block didn't include
`CFBundleVersion` / `CFBundleShortVersionString`. XcodeGen then fills both with its hardcoded defaults (`1` and `1.0`) instead of referencing the build settings — `xcodebuild CURRENT_PROJECT_VERSION=...` is ignored because no `$(CURRENT_PROJECT_VERSION)` appears in the plist to substitute into.

Fix: explicitly set both version keys in `project.yml` so the regenerated plist reads `$(MARKETING_VERSION)` and `$(CURRENT_PROJECT_VERSION)`. xcodebuild's plist-processing step then substitutes whatever CI passed.

Verified with `MARKETING_VERSION=0.6.0 CURRENT_PROJECT_VERSION=1761234567`: the built `Cabalmail.app/Info.plist` reads
`CFBundleVersion = 1761234567` / `CFBundleShortVersionString = 0.6.0`.

Info.plist itself is already gitignored by `apple/.gitignore` — local edits never committed anyway, since the file is purely an XcodeGen output. All version plumbing now lives in `project.yml`.