### PR TITLE
Pin certbot Lambda image_uri to the deployed-image-tag SSM parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Let's Encrypt production CA in every environment.** `lambda/certbot-renewal/handler.py` no longer branches on `USE_STAGING`, and the `certbot_renewal` Terraform module drops its `prod` input variable. Staging certs (previously used for non-prod environments) aren't trusted by iOS/macOS root stores, so an Apple client hitting `smtp-out.<control_domain>` on port 465 (TCP passthrough, Dovecot presents the Let's Encrypt cert directly) couldn't complete the implicit-TLS handshake. The certbot Lambda re-issues against production on its next run; force a manual invocation after deploy if you want the swap immediately rather than on the scheduled renewal.
+- **Certbot Lambda `image_uri` rotates per deploy.** The module had `image_uri = "${repo_url}:latest"` hardcoded, which Terraform treats as a string that never changes — the Lambda kept running whichever image had been pushed the first time it was created, even when CI pushed a new `:latest` tag. The module now takes an `image_tag` input wired from `/cabal/deployed_image_tag` (the same SSM parameter the ECS task definitions consume), so the Lambda's image reference rotates on every deploy.
 
 ## [0.5.0] - Unreleased
 

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -152,6 +152,7 @@ module "certbot_renewal" {
   zone_id          = data.terraform_remote_state.zone.outputs.control_domain_zone_id
   email            = var.email
   region           = var.aws_region
+  image_tag        = data.aws_ssm_parameter.deployed_image_tag.value
   ecs_cluster_name = module.ecs.cluster_name
   ecs_service_names = [
     module.ecs.imap_service_name,

--- a/terraform/infra/modules/certbot_renewal/lambda.tf
+++ b/terraform/infra/modules/certbot_renewal/lambda.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "certbot" {
   function_name = "cabal-certbot-renewal"
   role          = aws_iam_role.certbot_lambda.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.certbot.repository_url}:latest"
+  image_uri     = "${aws_ecr_repository.certbot.repository_url}:${var.image_tag}"
   timeout       = 300
   memory_size   = 512
   architectures = ["arm64"]

--- a/terraform/infra/modules/certbot_renewal/variables.tf
+++ b/terraform/infra/modules/certbot_renewal/variables.tf
@@ -13,6 +13,11 @@ variable "email" {
   description = "Contact email for Let's Encrypt certificate registration."
 }
 
+variable "image_tag" {
+  type        = string
+  description = "Docker image tag for the certbot Lambda. Rotating this on each deploy is what actually updates the Lambda's container — a bare ':latest' reference looks unchanged to Terraform and leaves the Lambda running the previously-pushed image."
+}
+
 variable "region" {
   type        = string
   description = "AWS region."


### PR DESCRIPTION
The module had `image_uri = "${repo_url}:latest"` hardcoded. Terraform sees that string as unchanged on every plan, so even when CI pushed a new :latest tag to ECR the Lambda kept running the image that happened to be loaded the first time the function was created. Incidental Lambda config updates (env-var changes, role edits) would re-resolve the tag to the current digest as a side effect, which is why :latest worked in practice some of the time and then stopped working the rest of the time — exactly the shape of bug we just hit trying to flip off LE staging.

The module now takes `image_tag` wired from
`/cabal/deployed_image_tag`, matching how the ECS task definitions consume the SSM parameter. Every deploy changes the tag, Terraform sees a real diff on the Lambda's image_uri, and the new image is pulled.