### PR TITLE
0.8.0 Phase 5: reader advanced surfaces (view source + match theme + overflow)

### DIFF
--- a/react/admin/src/ApiClient.js
+++ b/react/admin/src/ApiClient.js
@@ -341,6 +341,14 @@ export default class ApiClient {
     return response;
   };
   
+  getRawMessage(signedUrl) {
+    return axios.get(signedUrl, {
+      responseType: 'text',
+      transformResponse: [(v) => v],
+      timeout: ONE_SECOND * 30,
+    });
+  }
+
   getAttachment(a, folder, id, seen) {
     const response = axios.get('/fetch_attachment',
       {

--- a/react/admin/src/Email/MessageOverlay/MessageOverlay.css
+++ b/react/admin/src/Email/MessageOverlay/MessageOverlay.css
@@ -155,7 +155,8 @@
   cursor: not-allowed;
 }
 
-.reader-menu-check {
+.reader-menu-check,
+.reader-menu-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -164,6 +165,248 @@
   margin-right: 8px;
   color: var(--accent);
   flex: 0 0 16px;
+}
+
+.reader-menu-icon {
+  color: var(--ink-quiet);
+}
+
+.reader-menu-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reader-menu-hint {
+  margin-left: 8px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-quiet);
+  flex: 0 0 auto;
+}
+
+.reader-menu-sep {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border-faint);
+}
+
+.reader-menu-item.danger {
+  color: var(--ink-danger);
+}
+
+.reader-menu-item.danger .reader-menu-icon {
+  color: var(--ink-danger);
+}
+
+.reader-menu-item.danger:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--ink-danger) 10%, var(--surface));
+}
+
+.reader-menu-item[aria-checked="true"] .reader-menu-label {
+  font-weight: 600;
+}
+
+/* --- View source modal ------------------------------------------------- */
+
+.source-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  background: oklch(0 0 0 / 0.45);
+  animation: source-scrim-in 140ms ease-out;
+}
+
+@keyframes source-scrim-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.source-window {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 880px;
+  max-height: 80vh;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-modal);
+  overflow: hidden;
+  animation: source-window-in 140ms ease-out;
+}
+
+@keyframes source-window-in {
+  from { opacity: 0; transform: scale(0.98); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.source-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px 12px 18px;
+  background: var(--pane-bg);
+  border-bottom: 1px solid var(--border-faint);
+}
+
+.source-header-title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.source-header-label {
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--ink);
+  flex: 0 0 auto;
+}
+
+.source-header-subject {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-quiet);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  max-width: 48ch;
+  word-break: break-word;
+}
+
+.source-header-tools {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.source-seg {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  height: 26px;
+  background: var(--surface-hover);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.source-seg-btn {
+  height: 20px;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-quiet);
+  font: inherit;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.02em;
+}
+
+.source-seg-btn:hover:not(.active) {
+  color: var(--ink);
+}
+
+.source-seg-btn.active {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.source-tool {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--ink-soft);
+  font: inherit;
+  font-family: var(--font-ui);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.source-tool:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--ink);
+}
+
+.source-tool:disabled {
+  cursor: not-allowed;
+  color: var(--ink-quiet);
+}
+
+.source-close {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  background: transparent;
+  color: var(--ink-quiet);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.source-close:hover {
+  background: var(--surface-hover);
+  color: var(--ink);
+}
+
+.source-body {
+  flex: 1 1 auto;
+  overflow: auto;
+  margin: 0;
+  padding: 18px 22px;
+  background: var(--reader-bg);
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+  tab-size: 2;
+}
+
+.source-hdr-row {
+  display: block;
+}
+
+.source-body .hdr-name {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.source-body .hdr-sep {
+  margin: 10px 0;
+  border-top: 1px dashed var(--border-faint);
+}
+
+.source-status {
+  padding: 12px 0;
+  color: var(--ink-quiet);
+  font-family: var(--font-ui);
+  font-size: 12px;
+}
+
+@media (max-width: 899px) {
+  .source-scrim { padding: 16px; }
+  .source-window { max-height: 90vh; }
+  .source-header { flex-wrap: wrap; }
+  .source-header-subject { display: none; }
 }
 
 /* --- Header ------------------------------------------------------------ */

--- a/react/admin/src/Email/MessageOverlay/MessageOverlay.test.jsx
+++ b/react/admin/src/Email/MessageOverlay/MessageOverlay.test.jsx
@@ -4,10 +4,20 @@ import MessageOverlay from './index';
 import AuthContext from '../../contexts/AuthContext';
 import AppMessageContext from '../../contexts/AppMessageContext';
 
+const RAW_EML = [
+  'From: Alice Sender <sender@example.com>',
+  'Subject: Test Subject',
+  'Date: Thu, 17 Apr 2025 13:10:00 +0000',
+  '',
+  'Raw body line 1',
+  'Raw body line 2',
+].join('\r\n');
+
 const mockGetMessage = vi.fn().mockResolvedValue({
   data: {
     message_body_plain: 'plain text body',
     message_body_html: '<p>html body</p>',
+    message_raw: 'https://cache.example/signed',
     recipient: 'me@test.com',
     message_id: ['<msg1@test>'],
     in_reply_to: [],
@@ -20,12 +30,14 @@ const mockGetAttachments = vi.fn().mockResolvedValue({
 const mockGetEnvelopes = vi.fn().mockResolvedValue({
   data: { envelopes: { 1: { id: 1 } } },
 });
+const mockGetRawMessage = vi.fn().mockResolvedValue({ data: RAW_EML });
 
 const mockApi = {
   getMessage: mockGetMessage,
   getAttachments: mockGetAttachments,
   getEnvelopes: mockGetEnvelopes,
   getAttachment: vi.fn().mockResolvedValue({ data: { url: 'http://dl.url' } }),
+  getRawMessage: mockGetRawMessage,
   fetchImage: vi.fn().mockResolvedValue({ data: { url: 'http://img.url' } }),
   setFlag: vi.fn().mockResolvedValue({}),
   moveMessages: vi.fn().mockResolvedValue({}),
@@ -183,6 +195,100 @@ describe('MessageOverlay (Reader)', () => {
       await waitFor(() => {
         expect(setMessage).toHaveBeenCalledWith('Unable to get message.', true);
       });
+    } finally {
+      unmount();
+    }
+  });
+
+  it('opens the View source modal and fetches raw text once', async () => {
+    const { unmount } = renderOverlay();
+    try {
+      await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('More actions'));
+      fireEvent.click(screen.getByText('View source'));
+      await waitFor(() => {
+        expect(mockGetRawMessage).toHaveBeenCalledWith('https://cache.example/signed');
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: 'Message source' })).toBeInTheDocument();
+      });
+    } finally {
+      unmount();
+    }
+  });
+
+  it('"Show original headers" opens the same modal pre-set to Headers', async () => {
+    const { unmount } = renderOverlay();
+    try {
+      await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('More actions'));
+      fireEvent.click(screen.getByText('Show original headers'));
+      await waitFor(() => {
+        expect(screen.getByRole('dialog', { name: 'Message source' })).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole('tab', { name: 'Headers' }).getAttribute('aria-selected'),
+      ).toBe('true');
+    } finally {
+      unmount();
+    }
+  });
+
+  it('Match theme item is only shown in Rich mode and toggles state', async () => {
+    const { unmount } = renderOverlay();
+    try {
+      await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('More actions'));
+      const match = screen.getByText('Match app theme');
+      const item = match.closest('button');
+      expect(item.getAttribute('aria-checked')).toBe('false');
+      fireEvent.click(match);
+      // Menu stays open on check-toggle; the re-rendered button reflects state.
+      const reMatch = screen.getByText('Match app theme').closest('button');
+      expect(reMatch.getAttribute('aria-checked')).toBe('true');
+    } finally {
+      unmount();
+    }
+  });
+
+  it('Match theme is hidden in Plain mode', async () => {
+    const { unmount } = renderOverlay({ readerFormat: 'plain' });
+    try {
+      await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('More actions'));
+      expect(screen.queryByText('Match app theme')).not.toBeInTheDocument();
+    } finally {
+      unmount();
+    }
+  });
+
+  it('overflow menu exposes Archive, Mark as spam, Block sender, Print', async () => {
+    const { unmount } = renderOverlay();
+    try {
+      await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('More actions'));
+      expect(screen.getByText('Archive')).toBeInTheDocument();
+      expect(screen.getByText('Mark as spam')).toBeInTheDocument();
+      expect(screen.getByText('Block sender')).toBeInTheDocument();
+      expect(screen.getByText('Print…')).toBeInTheDocument();
+    } finally {
+      unmount();
+    }
+  });
+
+  it('Archive overflow item moves the message and hides the reader', async () => {
+    const hide = vi.fn();
+    const { unmount } = renderOverlay({ hide });
+    try {
+      await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('More actions'));
+      fireEvent.click(screen.getByText('Archive'));
+      await waitFor(() => {
+        expect(mockApi.moveMessages).toHaveBeenCalledWith(
+          'INBOX', 'Archive', [1], '', expect.anything(),
+        );
+      });
+      await waitFor(() => expect(hide).toHaveBeenCalled());
     } finally {
       unmount();
     }

--- a/react/admin/src/Email/MessageOverlay/OverflowMenu.jsx
+++ b/react/admin/src/Email/MessageOverlay/OverflowMenu.jsx
@@ -1,18 +1,33 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { MoreHorizontal, Check } from 'lucide-react';
+import {
+  MoreHorizontal, Check,
+  Palette, Code, Info, Forward, Printer,
+  Archive, Ban, ShieldOff,
+} from 'lucide-react';
 
 /* =========================================================================
-   Reader overflow menu — §4d. Phase 4 lands only the FORMAT group
-   (Rich / Plain text alternative); the rest of the items (View source,
-   Show original headers, Forward as attachment, Print, Archive, Mark as
-   spam, Block sender) are deferred to Phase 5 per the phased plan.
+   Reader overflow menu — §4d.
 
-   The FORMAT group is only shown for messages that are multipart/
-   alternative — i.e. when both plain and HTML bodies are present. If
-   only one format exists the group would be degenerate.
+   Phase 4 shipped the FORMAT group (Rich / Plain). Phase 5 adds the rest
+   of the menu per the design spec:
+
+     - Match app theme  — checkable, only when Rich mode is active.
+     - View source
+     - Show original headers  → opens the same modal pre-set to Headers
+     - Forward as attachment
+     - Print…
+     - Archive
+     - Mark as spam
+     - Block sender  (destructive, --ink-danger)
+
+   Keyboard behavior follows the pattern already established elsewhere in
+   the app: arrow keys move focus between items, Enter / Space activates
+   the focused item, Escape closes the menu.
    ========================================================================= */
 
-function MenuItem({ checked, onClick, children }) {
+const ITEM_SELECTOR = '[role="menuitem"], [role="menuitemcheckbox"]';
+
+function MenuCheckItem({ checked, onClick, children }) {
   return (
     <button
       type="button"
@@ -24,29 +39,87 @@ function MenuItem({ checked, onClick, children }) {
       <span className="reader-menu-check" aria-hidden="true">
         {checked ? <Check size={14} /> : null}
       </span>
-      {children}
+      <span className="reader-menu-label">{children}</span>
     </button>
   );
 }
 
+function MenuActionItem({
+  icon: Icon, onClick, disabled, danger, hint, children,
+}) {
+  return (
+    <button
+      type="button"
+      className={`reader-menu-item ${danger ? 'danger' : ''}`}
+      role="menuitem"
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <span className="reader-menu-icon" aria-hidden="true">
+        {Icon ? <Icon size={14} /> : null}
+      </span>
+      <span className="reader-menu-label">{children}</span>
+      {hint && <span className="reader-menu-hint" aria-hidden="true">{hint}</span>}
+    </button>
+  );
+}
+
+function Separator() {
+  return <div className="reader-menu-sep" role="separator" aria-hidden="true" />;
+}
+
 function OverflowMenu({
   format, setFormat, hasRich, hasPlain,
+  matchTheme, setMatchTheme,
+  onViewSource, onShowHeaders, onForwardAsAttachment, onPrint,
+  onArchive, onMarkSpam, onBlockSender,
 }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef(null);
+  const menuRef = useRef(null);
+  const triggerRef = useRef(null);
 
   const showFormatGroup = hasRich && hasPlain;
+  const inRichMode = format === 'rich' && hasRich;
 
-  const close = useCallback(() => setOpen(false), []);
+  const close = useCallback(() => {
+    setOpen(false);
+    /* return focus to the trigger so keyboard flow is uninterrupted */
+    if (triggerRef.current) triggerRef.current.focus();
+  }, []);
 
   useEffect(() => {
     if (!open) return undefined;
     const onDocClick = (e) => {
       if (!rootRef.current) return;
-      if (!rootRef.current.contains(e.target)) close();
+      if (!rootRef.current.contains(e.target)) setOpen(false);
     };
     const onKey = (e) => {
-      if (e.key === 'Escape') close();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (!menuRef.current) return;
+      const items = Array.from(menuRef.current.querySelectorAll(ITEM_SELECTOR))
+        .filter((el) => !el.disabled);
+      if (items.length === 0) return;
+      const idx = items.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = idx < 0 ? 0 : (idx + 1) % items.length;
+        items[next].focus();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = idx <= 0 ? items.length - 1 : idx - 1;
+        items[prev].focus();
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        items[0].focus();
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        items[items.length - 1].focus();
+      }
     };
     document.addEventListener('mousedown', onDocClick);
     document.addEventListener('keydown', onKey);
@@ -56,14 +129,32 @@ function OverflowMenu({
     };
   }, [open, close]);
 
+  // On open, move focus to the first interactive item so arrow keys work.
+  useEffect(() => {
+    if (!open || !menuRef.current) return;
+    const first = menuRef.current.querySelector(ITEM_SELECTOR);
+    if (first && !first.disabled) first.focus();
+  }, [open]);
+
+  const run = (fn) => () => {
+    close();
+    if (fn) fn();
+  };
+
   const choose = (nextFormat) => {
     setFormat(nextFormat);
-    close();
+    /* keep the menu open so users can see the checkmark flip, matching
+       the prototype behavior */
+  };
+
+  const toggleMatch = () => {
+    if (setMatchTheme) setMatchTheme(!matchTheme);
   };
 
   return (
     <div className="reader-overflow" ref={rootRef}>
       <button
+        ref={triggerRef}
         type="button"
         className="reader-btn icon-only"
         aria-haspopup="menu"
@@ -75,32 +166,79 @@ function OverflowMenu({
         <MoreHorizontal size={16} aria-hidden="true" />
       </button>
       {open && (
-        <div className="reader-menu" role="menu">
+        <div className="reader-menu" role="menu" ref={menuRef}>
           {showFormatGroup && (
             <>
               <div className="reader-menu-group-label">Format</div>
-              <MenuItem
+              <MenuCheckItem
                 checked={format === 'rich'}
                 onClick={() => choose('rich')}
               >
                 Rich (HTML)
-              </MenuItem>
-              <MenuItem
+              </MenuCheckItem>
+              <MenuCheckItem
                 checked={format === 'plain'}
                 onClick={() => choose('plain')}
               >
                 Plain text alternative
-              </MenuItem>
+              </MenuCheckItem>
+              <Separator />
             </>
           )}
-          {!showFormatGroup && (
-            <div
-              className="reader-menu-group-label"
-              style={{ color: 'var(--ink-quiet)', cursor: 'default' }}
-            >
-              No actions available
-            </div>
+
+          {inRichMode && setMatchTheme && (
+            <>
+              <MenuCheckItem
+                checked={!!matchTheme}
+                onClick={toggleMatch}
+              >
+                Match app theme
+              </MenuCheckItem>
+              <Separator />
+            </>
           )}
+
+          <MenuActionItem icon={Code} onClick={run(onViewSource)}>
+            View source
+          </MenuActionItem>
+          <MenuActionItem icon={Info} onClick={run(onShowHeaders)}>
+            Show original headers
+          </MenuActionItem>
+          <MenuActionItem
+            icon={Forward}
+            onClick={run(onForwardAsAttachment)}
+            disabled={!onForwardAsAttachment}
+          >
+            Forward as attachment
+          </MenuActionItem>
+          <MenuActionItem icon={Printer} onClick={run(onPrint)} hint="⌘P">
+            Print…
+          </MenuActionItem>
+          <Separator />
+
+          <MenuActionItem
+            icon={Archive}
+            onClick={run(onArchive)}
+            disabled={!onArchive}
+          >
+            Archive
+          </MenuActionItem>
+          <MenuActionItem
+            icon={Ban}
+            onClick={run(onMarkSpam)}
+            disabled={!onMarkSpam}
+          >
+            Mark as spam
+          </MenuActionItem>
+          <Separator />
+          <MenuActionItem
+            icon={ShieldOff}
+            onClick={run(onBlockSender)}
+            disabled={!onBlockSender}
+            danger
+          >
+            Block sender
+          </MenuActionItem>
         </div>
       )}
     </div>

--- a/react/admin/src/Email/MessageOverlay/ReaderBody.jsx
+++ b/react/admin/src/Email/MessageOverlay/ReaderBody.jsx
@@ -6,15 +6,23 @@ import useApi from '../../hooks/useApi';
    Rich mode: sandboxed srcdoc iframe, height-probed post-load.
    Plain mode: <pre> with white-space: pre-wrap.
 
+   Match theme (Phase 5): when enabled in Rich mode, we inject a <style>
+   block into the iframe's <head> that sets body background / color /
+   font-family using *resolved literal values* — CSS custom properties do
+   not cross the iframe boundary, so we read them from the parent's
+   documentElement via getComputedStyle and write them in verbatim.
+
    Per Preflight (4), the server returns raw HTML — sanitization happens
-   client-side. For Phase 4 the sanitization posture is "render inside a
-   sandbox without allow-scripts so the HTML cannot execute JS, navigate
-   the top frame, or phone home". `allow-same-origin` is enabled so the
-   parent can measure `scrollHeight` to size the iframe to content. A
-   deeper sanitization pass and Match-theme injection land in Phase 5.
+   client-side. The sandbox denies script execution; `allow-same-origin`
+   is retained so the parent can measure scrollHeight.
    ========================================================================= */
 
 const IFRAME_SANDBOX = 'allow-same-origin allow-popups allow-popups-to-escape-sandbox';
+
+/* Tokens we pull from the parent's computed style for Match theme. These
+   are the ones we inline — keep the list short so we don't cascade the
+   entire design system into sender-written HTML. */
+const MATCH_THEME_TOKENS = ['--reader-bg', '--ink', '--font-reader'];
 
 function blockTrackingImages(html) {
   // Defuse http(s) <img> srcs so remote images don't load until the user
@@ -27,8 +35,62 @@ function restoreTrackingImages(html) {
   return html.replace(/(<img\b[^>]*?\bsrc=["'])disabled-(https?:)/gi, '$1$2');
 }
 
+function resolveMatchThemeTokens() {
+  if (typeof window === 'undefined' || !window.getComputedStyle) return null;
+  const cs = window.getComputedStyle(document.documentElement);
+  const out = {};
+  for (const name of MATCH_THEME_TOKENS) {
+    const v = cs.getPropertyValue(name).trim();
+    if (v) out[name] = v;
+  }
+  return out;
+}
+
+function buildMatchThemeStyle(tokens) {
+  if (!tokens) return '';
+  const bg = tokens['--reader-bg'] || 'transparent';
+  const ink = tokens['--ink'] || 'inherit';
+  const font = tokens['--font-reader'] || 'serif';
+  /* The naive background-neutralization pass from the README: any inline
+     `background: #fff` or `background-color: #ffffff` gets swapped to the
+     reader background token so white islands inside dark mode don't look
+     marooned. Production-grade sanitization is flagged in the plan as a
+     v1-follow-up. */
+  return `
+<style data-cabal-match-theme>
+  html, body { background: ${bg} !important; color: ${ink} !important; font-family: ${font}; }
+  [style*="background: #fff"],
+  [style*="background:#fff"],
+  [style*="background-color: #fff"],
+  [style*="background-color:#fff"],
+  [style*="background: #ffffff"],
+  [style*="background-color: #ffffff"],
+  [style*="background: white"],
+  [style*="background-color: white"] {
+    background: ${bg} !important;
+    background-color: ${bg} !important;
+  }
+</style>`;
+}
+
+/* Prepend the Match theme <style> block to the srcdoc. If the HTML has a
+   <head>, slot it in there; otherwise drop it at the start so the
+   browser's implicit head-promotion picks it up. */
+function injectMatchThemeStyle(html, styleBlock) {
+  if (!styleBlock) return html;
+  if (!html) return `<html><head>${styleBlock}</head><body></body></html>`;
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/<head([^>]*)>/i, `<head$1>${styleBlock}`);
+  }
+  if (/<html[^>]*>/i.test(html)) {
+    return html.replace(/<html([^>]*)>/i, `<html$1><head>${styleBlock}</head>`);
+  }
+  return `${styleBlock}${html}`;
+}
+
 function ReaderBody({
   format, html, plain, folder, messageId, seen, setMessage,
+  matchTheme = false, themeKey,
 }) {
   const api = useApi();
   const iframeRef = useRef(null);
@@ -42,7 +104,9 @@ function ReaderBody({
   );
 
   // Compose the srcdoc. Tracking images are defused unless the user opted
-  // in; cid: references are resolved to presigned URLs asynchronously.
+  // in; cid: references are resolved to presigned URLs asynchronously;
+  // the Match-theme style block (if on) is prepended last so its rules
+  // win over anything the sender wrote.
   const [resolvedHtml, setResolvedHtml] = useState('');
 
   useEffect(() => {
@@ -55,8 +119,16 @@ function ReaderBody({
       (base || '').matchAll(/(<img\b[^>]*?\bsrc=["'])cid:([^"']+)(["'])/gi),
     ).map((m) => m[2]);
 
+    const finalize = (htmlStr) => {
+      if (cancelled) return;
+      const styleBlock = matchTheme
+        ? buildMatchThemeStyle(resolveMatchThemeTokens())
+        : '';
+      setResolvedHtml(injectMatchThemeStyle(htmlStr || '', styleBlock));
+    };
+
     if (cids.length === 0) {
-      setResolvedHtml(base || '');
+      finalize(base || '');
       return undefined;
     }
 
@@ -79,13 +151,13 @@ function ReaderBody({
           `$1${url}$2`,
         );
       }
-      setResolvedHtml(out);
+      finalize(out);
     }).catch(() => {
       if (setMessage) setMessage('Unable to load inline image.', true);
     });
 
     return () => { cancelled = true; };
-  }, [format, html, imagesLoaded, folder, messageId, seen, api, setMessage]);
+  }, [format, html, imagesLoaded, folder, messageId, seen, api, setMessage, matchTheme, themeKey]);
 
   // Height probe on load. The sandbox allows same-origin so we can read
   // scrollHeight directly. Re-probe after late image loads settle.
@@ -153,6 +225,7 @@ function ReaderBody({
           sandbox={IFRAME_SANDBOX}
           srcDoc={resolvedHtml || '<html><body></body></html>'}
           style={{ height: `${iframeHeight}px` }}
+          data-match-theme={matchTheme ? 'on' : 'off'}
         />
       </div>
     </>

--- a/react/admin/src/Email/MessageOverlay/ViewSourceModal.jsx
+++ b/react/admin/src/Email/MessageOverlay/ViewSourceModal.jsx
@@ -1,0 +1,188 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { parseEmlSource } from '../../utils/emlSource';
+
+/* =========================================================================
+   Reader — View source modal (§4d, Phase 5).
+
+   A 880px × 80vh modal that renders the raw RFC-822 source of the current
+   message in three views via the segmented control:
+
+     - Full:    colored headers + separator + raw body
+     - Headers: colored headers only
+     - Body:    raw body only
+
+   Copy puts the raw text (always the Full view's source, regardless of
+   tab) on the clipboard. Save downloads `<subject>.eml` with the
+   message/rfc822 MIME type. The modal also doubles as the "Show original
+   headers" target when opened with initialTab="headers".
+   ========================================================================= */
+
+const TABS = ['full', 'headers', 'body'];
+const TAB_LABELS = { full: 'Full', headers: 'Headers', body: 'Body' };
+
+function sanitizeFilename(subject) {
+  const base = (subject || 'message').trim().slice(0, 80);
+  const cleaned = base.replace(/[\\/:*?"<>|\n\r\t]+/g, '_').replace(/^\.+/, '');
+  return `${cleaned || 'message'}.eml`;
+}
+
+function downloadEml(subject, rawText) {
+  if (typeof window === 'undefined') return;
+  const blob = new Blob([rawText], { type: 'message/rfc822' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = sanitizeFilename(subject);
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function ViewSourceModal({
+  open, subject, rawText, loading, error, onClose, initialTab = 'full',
+}) {
+  const [tab, setTab] = useState(initialTab);
+  const [copied, setCopied] = useState(false);
+  const closeRef = useRef(null);
+
+  // Re-sync the tab whenever the modal is (re)opened — the same component
+  // is reused for both "View source" and "Show original headers" entry
+  // points and they default to different initial tabs.
+  useEffect(() => {
+    if (open) setTab(initialTab);
+  }, [open, initialTab]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (open && closeRef.current) closeRef.current.focus();
+  }, [open]);
+
+  const { headers, body } = useMemo(() => parseEmlSource(rawText), [rawText]);
+
+  const onScrimMouseDown = useCallback((e) => {
+    if (e.target === e.currentTarget) onClose();
+  }, [onClose]);
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(rawText || '');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* clipboard blocked — no-op */
+    }
+  }, [rawText]);
+
+  const save = useCallback(() => {
+    downloadEml(subject, rawText || '');
+  }, [subject, rawText]);
+
+  if (!open) return null;
+
+  const renderHeaders = () => headers.map(([name, value], i) => (
+    <div key={`${name}-${i}`} className="source-hdr-row">
+      <span className="hdr-name">{name}:</span>
+      {' '}
+      <span>{value}</span>
+    </div>
+  ));
+
+  const renderBody = () => (
+    <span className="source-body-text">{body}</span>
+  );
+
+  let inner;
+  if (loading) {
+    inner = <div className="source-status">Loading source…</div>;
+  } else if (error) {
+    inner = <div className="source-status">Unable to load raw source.</div>;
+  } else if (tab === 'headers') {
+    inner = renderHeaders();
+  } else if (tab === 'body') {
+    inner = renderBody();
+  } else {
+    inner = (
+      <>
+        {renderHeaders()}
+        <div className="hdr-sep" role="separator" />
+        {renderBody()}
+      </>
+    );
+  }
+
+  return (
+    <div
+      className="source-scrim"
+      onMouseDown={onScrimMouseDown}
+      role="presentation"
+    >
+      <div
+        className="source-window"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Message source"
+      >
+        <div className="source-header">
+          <div className="source-header-title">
+            <span className="source-header-label">Message source</span>
+            <span className="source-header-subject" title={subject}>
+              {subject || '(no subject)'}
+            </span>
+          </div>
+          <div className="source-header-tools">
+            <div className="source-seg" role="tablist" aria-label="View">
+              {TABS.map((key) => (
+                <button
+                  key={key}
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === key}
+                  className={`source-seg-btn ${tab === key ? 'active' : ''}`}
+                  onClick={() => setTab(key)}
+                >
+                  {TAB_LABELS[key]}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="source-tool"
+              onClick={copy}
+              disabled={!rawText}
+            >
+              {copied ? '✓ Copied' : 'Copy'}
+            </button>
+            <button
+              type="button"
+              className="source-tool"
+              onClick={save}
+              disabled={!rawText}
+            >
+              Save .eml
+            </button>
+            <button
+              type="button"
+              className="source-close"
+              ref={closeRef}
+              onClick={onClose}
+              aria-label="Close message source"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+        <pre className="source-body">{inner}</pre>
+      </div>
+    </div>
+  );
+}
+
+export default ViewSourceModal;

--- a/react/admin/src/Email/MessageOverlay/ViewSourceModal.test.jsx
+++ b/react/admin/src/Email/MessageOverlay/ViewSourceModal.test.jsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import ViewSourceModal from './ViewSourceModal';
+
+const RAW = [
+  'From: Alice <a@example.com>',
+  'Subject: Hello',
+  'Date: Thu, 17 Apr 2025 12:00:00 +0000',
+  '',
+  'This is the body.',
+  'Second line.',
+].join('\r\n');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ViewSourceModal', () => {
+  it('returns nothing when closed', () => {
+    const { container } = render(
+      <ViewSourceModal open={false} subject="x" rawText={RAW} onClose={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the header label, subject, and action buttons', () => {
+    const { container } = render(
+      <ViewSourceModal open subject="Hello subject" rawText={RAW} onClose={vi.fn()} />,
+    );
+    expect(screen.getByText('Message source')).toBeInTheDocument();
+    expect(container.querySelector('.source-header-subject').textContent).toBe('Hello subject');
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save .eml' })).toBeInTheDocument();
+  });
+
+  it('shows Full view with colorized header names and body', () => {
+    const { container } = render(
+      <ViewSourceModal open subject="Hello" rawText={RAW} onClose={vi.fn()} />,
+    );
+    const names = container.querySelectorAll('.hdr-name');
+    const labels = Array.from(names).map((el) => el.textContent);
+    expect(labels).toEqual(['From:', 'Subject:', 'Date:']);
+    expect(container.textContent).toContain('This is the body.');
+    expect(container.querySelector('.hdr-sep')).toBeInTheDocument();
+  });
+
+  it('Headers tab hides the body', () => {
+    const { container } = render(
+      <ViewSourceModal open subject="Hello" rawText={RAW} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Headers' }));
+    expect(container.textContent).not.toContain('This is the body.');
+    expect(container.querySelectorAll('.hdr-name').length).toBe(3);
+  });
+
+  it('Body tab hides the headers', () => {
+    const { container } = render(
+      <ViewSourceModal open subject="Hello" rawText={RAW} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Body' }));
+    expect(container.querySelectorAll('.hdr-name').length).toBe(0);
+    expect(container.textContent).toContain('This is the body.');
+  });
+
+  it('respects initialTab="headers" when opened from Show original headers', () => {
+    const { container } = render(
+      <ViewSourceModal
+        open
+        subject="Hello"
+        rawText={RAW}
+        onClose={vi.fn()}
+        initialTab="headers"
+      />,
+    );
+    expect(screen.getByRole('tab', { name: 'Headers' }).getAttribute('aria-selected')).toBe('true');
+    expect(container.textContent).not.toContain('This is the body.');
+  });
+
+  it('Copy puts the raw text on the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue();
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(
+      <ViewSourceModal open subject="Hello" rawText={RAW} onClose={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith(RAW);
+  });
+
+  it('Save .eml triggers an anchor download with message/rfc822 mime', () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    const revokeObjectURL = vi.fn();
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+
+    const blobs = [];
+    const origBlob = global.Blob;
+    global.Blob = function Blob(parts, opts) {
+      blobs.push({ parts, opts });
+      return new origBlob(parts, opts);
+    };
+
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    try {
+      render(
+        <ViewSourceModal open subject="Hello world" rawText={RAW} onClose={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Save .eml' }));
+      expect(clickSpy).toHaveBeenCalled();
+      expect(createObjectURL).toHaveBeenCalled();
+      expect(blobs[0].opts.type).toBe('message/rfc822');
+    } finally {
+      clickSpy.mockRestore();
+      global.Blob = origBlob;
+    }
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <ViewSourceModal open subject="Hello" rawText={RAW} onClose={onClose} />,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows a loading state while raw source is still in flight', () => {
+    render(
+      <ViewSourceModal open subject="Hi" rawText="" loading onClose={vi.fn()} />,
+    );
+    expect(screen.getByText(/Loading source/i)).toBeInTheDocument();
+  });
+
+  it('shows an error state when raw source cannot be fetched', () => {
+    render(
+      <ViewSourceModal open subject="Hi" rawText="" error onClose={vi.fn()} />,
+    );
+    expect(screen.getByText(/Unable to load raw source/i)).toBeInTheDocument();
+  });
+});

--- a/react/admin/src/Email/MessageOverlay/index.jsx
+++ b/react/admin/src/Email/MessageOverlay/index.jsx
@@ -1,11 +1,13 @@
 /**
- * Reader — §4d (Phase 4).
- * Action bar + header block + body + attachments, with the overflow
- * menu's FORMAT group (Rich / Plain). View-source modal, Match theme,
- * and destructive overflow items are deferred to Phase 5.
+ * Reader — §4d. Phase 5 adds:
+ *   - View source modal (Full / Headers / Body, Copy, Save .eml),
+ *   - Match theme toggle + iframe style injection,
+ *   - the remaining overflow-menu items.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback, useEffect, useMemo, useState,
+} from 'react';
 import {
   Reply, ReplyAll, Forward,
   Archive, FolderInput, Trash2, Flag, MailOpen, X,
@@ -13,6 +15,7 @@ import {
 import ReaderBody from './ReaderBody';
 import Attachments from './Attachments';
 import OverflowMenu from './OverflowMenu';
+import ViewSourceModal from './ViewSourceModal';
 import useApi from '../../hooks/useApi';
 import { useAppMessage } from '../../contexts/AppMessageContext';
 import {
@@ -40,6 +43,20 @@ function MessageOverlay({
   const [messageId, setMessageId] = useState([]);
   const [inReplyTo, setInReplyTo] = useState([]);
   const [references, setReferences] = useState([]);
+  const [messageRawUrl, setMessageRawUrl] = useState(null);
+
+  // Match theme (§4d, Phase 5). Local — one toggle per reader session.
+  // Only meaningful in Rich mode; the OverflowMenu hides it otherwise.
+  const [matchTheme, setMatchTheme] = useState(false);
+
+  // View source modal state. `initialTab` is 'full' when triggered from
+  // "View source" and 'headers' when triggered from "Show original
+  // headers". `rawText` is lazy-loaded the first time the modal opens.
+  const [sourceOpen, setSourceOpen] = useState(false);
+  const [sourceInitialTab, setSourceInitialTab] = useState('full');
+  const [rawText, setRawText] = useState('');
+  const [rawLoading, setRawLoading] = useState(false);
+  const [rawError, setRawError] = useState(false);
 
   const envelopeId = envelope && envelope.id;
   const seen = envelope && envelope.flags
@@ -54,6 +71,11 @@ function MessageOverlay({
     setMessageBodyHtml('');
     setMessageBodyPlain('');
     setAttachments([]);
+    setMessageRawUrl(null);
+    setRawText('');
+    setRawError(false);
+    setSourceOpen(false);
+    setMatchTheme(false);
 
     api.getMessage(folder, envelopeId, seen).then((data) => {
       setMessageBodyPlain(data.data.message_body_plain || '');
@@ -62,6 +84,7 @@ function MessageOverlay({
       setMessageId(data.data.message_id || []);
       setInReplyTo(data.data.in_reply_to || []);
       setReferences(data.data.references || []);
+      setMessageRawUrl(data.data.message_raw || null);
       setLoading(false);
     }).catch((e) => {
       setMessage('Unable to get message.', true);
@@ -132,6 +155,16 @@ function MessageOverlay({
       });
   }, [api, folder, envelopeId, hide, setMessage]);
 
+  const doMarkSpam = useCallback(() => {
+    if (!envelopeId) return;
+    api.moveMessages(folder, 'Junk', [envelopeId], '', ARRIVAL.imap)
+      .then(() => hide())
+      .catch((err) => {
+        setMessage('Unable to mark as spam.', true);
+        console.log(err);
+      });
+  }, [api, folder, envelopeId, hide, setMessage]);
+
   const toggleFlagged = useCallback(() => {
     runFlag(isFlagged ? { ...FLAGGED, op: 'unset' } : FLAGGED);
   }, [isFlagged, runFlag]);
@@ -175,6 +208,66 @@ function MessageOverlay({
       .then((data) => window.open(data.data.url))
       .catch(() => setMessage('Unable to download attachment.', true));
   }, [api, attachments, folder, envelopeId, seen, setMessage]);
+
+  /* Fetch the raw .eml on first open of the View source modal and cache
+     it. Subsequent opens (for the same envelope) reuse the cached text;
+     `rawText` is cleared whenever the envelope changes. */
+  const ensureRawText = useCallback(() => {
+    if (rawText || rawLoading) return;
+    if (!messageRawUrl) {
+      setRawError(true);
+      return;
+    }
+    setRawLoading(true);
+    setRawError(false);
+    api.getRawMessage(messageRawUrl)
+      .then((r) => {
+        setRawText(typeof r.data === 'string' ? r.data : String(r.data || ''));
+      })
+      .catch(() => {
+        setRawError(true);
+        setMessage('Unable to load message source.', true);
+      })
+      .finally(() => setRawLoading(false));
+  }, [rawText, rawLoading, messageRawUrl, api, setMessage]);
+
+  const openViewSource = useCallback(() => {
+    setSourceInitialTab('full');
+    setSourceOpen(true);
+    ensureRawText();
+  }, [ensureRawText]);
+
+  const openHeaders = useCallback(() => {
+    setSourceInitialTab('headers');
+    setSourceOpen(true);
+    ensureRawText();
+  }, [ensureRawText]);
+
+  const closeSource = useCallback(() => setSourceOpen(false), []);
+
+  const forwardAsAttachment = useCallback(() => {
+    /* Forward-as-attachment is called out in the plan as a stub — the
+       backing flow (attach raw .eml to a new compose) lands later. For
+       now we surface an informational toast so the button is non-silent
+       but does nothing destructive. */
+    setMessage('Forward as attachment is not available yet.', false);
+  }, [setMessage]);
+
+  const doPrint = useCallback(() => {
+    if (typeof window !== 'undefined' && window.print) window.print();
+  }, []);
+
+  const blockSender = useCallback(() => {
+    /* Block sender is a gating feature that needs server-side support
+       (filter rules per §1.3). Until that lands, show a toast instead
+       of a no-op. */
+    setMessage('Block sender is not available yet.', false);
+  }, [setMessage]);
+
+  const sourceSubject = useMemo(
+    () => (envelope && envelope.subject) || '',
+    [envelope],
+  );
 
   if (!visible) {
     return <div className="reader overlay_hidden" />;
@@ -274,6 +367,15 @@ function MessageOverlay({
           setFormat={setReaderFormat}
           hasRich={hasRich}
           hasPlain={hasPlain}
+          matchTheme={matchTheme}
+          setMatchTheme={setMatchTheme}
+          onViewSource={openViewSource}
+          onShowHeaders={openHeaders}
+          onForwardAsAttachment={forwardAsAttachment}
+          onPrint={doPrint}
+          onArchive={doArchive}
+          onMarkSpam={doMarkSpam}
+          onBlockSender={blockSender}
         />
 
         <button
@@ -312,6 +414,7 @@ function MessageOverlay({
           messageId={envelopeId}
           seen={seen}
           setMessage={setMessage}
+          matchTheme={matchTheme && effectiveFormat === 'rich'}
         />
 
         <Attachments
@@ -319,6 +422,16 @@ function MessageOverlay({
           onDownload={downloadAttachment}
         />
       </div>
+
+      <ViewSourceModal
+        open={sourceOpen}
+        subject={sourceSubject}
+        rawText={rawText}
+        loading={rawLoading}
+        error={rawError}
+        onClose={closeSource}
+        initialTab={sourceInitialTab}
+      />
     </div>
   );
 }

--- a/react/admin/src/utils/emlSource.js
+++ b/react/admin/src/utils/emlSource.js
@@ -1,0 +1,41 @@
+/**
+ * Split a raw RFC-822 message into a parsed header list + body text.
+ *
+ * Used by the reader's View source modal — §4d. We need headers as
+ * `[name, value]` pairs so we can colorize the "Name:" span per the
+ * design, and we need the body separately so the three segmented-control
+ * views (Full / Headers / Body) can render without replaying string-
+ * reconstruction tricks.
+ *
+ * Header continuation lines (RFC 5322 §2.2.3: lines that begin with a
+ * space or tab are folded into the preceding header value) are preserved
+ * with their leading whitespace so the modal can show them verbatim.
+ *
+ * Boundary handling: the separator between headers and body is the first
+ * CRLF CRLF (or LF LF). Everything before is headers; everything after is
+ * body. If no separator exists we treat the whole payload as headers —
+ * there is no body.
+ */
+export function parseEmlSource(raw) {
+  const text = (raw || '').replace(/\r\n/g, '\n');
+  if (!text) return { headers: [], body: '' };
+
+  const sep = text.indexOf('\n\n');
+  const headerSection = sep >= 0 ? text.slice(0, sep) : text;
+  const body = sep >= 0 ? text.slice(sep + 2) : '';
+
+  const headers = [];
+  for (const line of headerSection.split('\n')) {
+    if (/^[ \t]/.test(line) && headers.length > 0) {
+      headers[headers.length - 1][1] += `\n${line}`;
+      continue;
+    }
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const name = line.slice(0, colon);
+    const value = line.slice(colon + 1).replace(/^[ \t]+/, '');
+    headers.push([name, value]);
+  }
+
+  return { headers, body };
+}

--- a/react/admin/src/utils/emlSource.test.js
+++ b/react/admin/src/utils/emlSource.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseEmlSource } from './emlSource';
+
+describe('parseEmlSource', () => {
+  it('returns empty result for empty input', () => {
+    expect(parseEmlSource('')).toEqual({ headers: [], body: '' });
+    expect(parseEmlSource(null)).toEqual({ headers: [], body: '' });
+  });
+
+  it('splits headers from body at the first blank line', () => {
+    const raw = 'From: a@b.com\r\nSubject: hi\r\n\r\nBody line 1\r\nBody line 2';
+    const { headers, body } = parseEmlSource(raw);
+    expect(headers).toEqual([
+      ['From', 'a@b.com'],
+      ['Subject', 'hi'],
+    ]);
+    expect(body).toBe('Body line 1\nBody line 2');
+  });
+
+  it('folds continuation lines into the preceding header value', () => {
+    const raw = 'Received: from mx1\n\tby mx2\n\tfor <you@host>;\nDate: now\n\nbody';
+    const { headers, body } = parseEmlSource(raw);
+    expect(headers).toEqual([
+      ['Received', 'from mx1\n\tby mx2\n\tfor <you@host>;'],
+      ['Date', 'now'],
+    ]);
+    expect(body).toBe('body');
+  });
+
+  it('treats a payload with no blank separator as headers-only', () => {
+    const { headers, body } = parseEmlSource('From: a@b\nSubject: s');
+    expect(headers).toEqual([['From', 'a@b'], ['Subject', 's']]);
+    expect(body).toBe('');
+  });
+
+  it('preserves colons inside header values', () => {
+    const { headers } = parseEmlSource('Date: Thu, 17 Apr 2025 12:34:56 +0000\n\n');
+    expect(headers).toEqual([['Date', 'Thu, 17 Apr 2025 12:34:56 +0000']]);
+  });
+});


### PR DESCRIPTION
## Summary

Lands Phase 5 of [docs/0.8.0/redesign-plan.md](docs/0.8.0/redesign-plan.md) — the last of the reader work. Two net-new surfaces and the rest of the overflow menu per §4d of the handoff README.

- **View source modal** (880×80vh, `--shadow-modal`, `--radius-lg`): Full / Headers / Body segmented control, Copy, Save .eml. Header colorization via `<span class="hdr-name">`. RFC-822 parsing factored into `utils/emlSource.js`.
- **Match theme** injection: in Rich mode, a `<style>` block is prepended to the iframe `srcdoc` with literal token values resolved via `getComputedStyle(document.documentElement)` — CSS custom properties don't cross the iframe boundary. Includes the README's naive background-neutralization rule (acceptable-for-v1).
- **Overflow menu** completed: View source, Show original headers (opens the same modal pre-set to Headers), Forward as attachment (informational stub — backing flow lands later), Print…, Archive, Mark as spam, Block sender (danger, informational stub). Arrow-key / Home / End keyboard navigation, focus returns to the trigger on close.

Raw source is lazy-loaded on first modal open using the pre-signed URL already returned by `fetch_message` (`message_raw`); `ApiClient.getRawMessage` ensures axios doesn't JSON-parse the eml bytes.

## Scope notes

- Forward as attachment and Block sender surface informational toasts — the backing flows need compose-attachment wiring (Phase 6) and server-side filter rules (§1.3) respectively. Flagged in the plan as stubs.
- Match theme is local state on MessageOverlay — one toggle per reader session. Deferred cross-message persistence.
- No existing tests regressed; +13 new tests across `utils/emlSource.test.js`, `ViewSourceModal.test.jsx`, and `MessageOverlay.test.jsx`.

## Test plan

- [x] `npm run test` — 125/125 pass (was 103; +22 new)
- [x] `npm run build` — clean
- [ ] Manual: open a multipart/alternative message in the web client, switch Rich/Plain, toggle Match theme in light + dark, open View source and cycle tabs, Copy, Save .eml
- [ ] Manual: "Show original headers" opens the modal pre-set to Headers
- [ ] Manual: Archive / Mark as spam from the overflow menu route messages to the right folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)