### PR TITLE
Poll Inbox every 60s and badge unread count on the app icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2026-04-22
+
+### Added
+
+- Apple client: the folder message list now refreshes on a 60-second wall-clock timer while it is on screen, in addition to the existing IMAP IDLE push. IDLE usually delivers new mail within seconds, but long-lived IDLE sockets can stall silently — iOS suspends idle connections while the app is foregrounded but network-idle, cellular ↔ WiFi handoffs drop the stream without surfacing an error, and some middleboxes time out TCP idle after a few minutes. The net effect was that users had to pull-to-refresh to see new messages even with the app in the foreground. A second SwiftUI `.task` on `MessageListView` sleeps 60 s and calls `MessageListViewModel.refresh()`; `.task` auto-cancels on `.onDisappear` so the timer starts and stops together with the IDLE watcher and doesn't hold a connection open for a mailbox the user isn't looking at.
+- Apple client: the app icon now shows a badge with the Inbox unread count on iOS / iPadOS / visionOS (home-screen icon) and macOS (dock tile). `AppState` owns an independent poller that runs while signed in, requests `.badge` authorization via `UNUserNotificationCenter` on first start (silently no-ops on denial or repeat calls), polls `STATUS (UNSEEN)` on `INBOX` every 60 seconds, and pushes the count through `UNUserNotificationCenter.setBadgeCount(_:)`. The poll is independent of which folder the user is viewing, so the badge stays current even while Drafts/Sent are on screen. Started at the `.signedIn` transition of both `signIn()` and `restoreIfPossible()`; stopped (and the badge cleared) at the start of `signOut()` so the icon doesn't keep showing the previous user's count. Transient network failures leave the prior badge value in place until the next successful poll. The authoritative count is also exposed as an `AppState.inboxUnreadCount` observable for future in-app indicators.
+
 ## [0.6.3] - 2026-04-22
 
 ### Added

--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import UserNotifications
 import CabalmailKit
 
 /// Root observable state for the Cabalmail app.
@@ -53,6 +54,13 @@ final class AppState {
     /// the observer.
     var lastDisposedEnvelope: DisposedEnvelope?
     private var disposedTick = 0
+
+    /// Authoritative Inbox unread count, refreshed by the badge poller.
+    /// Exposed as an observable so future views (e.g. a sidebar indicator)
+    /// can mirror what shows on the dock/home-screen badge.
+    private(set) var inboxUnreadCount: Int = 0
+    private var inboxBadgeTask: Task<Void, Never>?
+    private let inboxBadgePollInterval: UInt64 = 60 * 1_000_000_000
 
     func requestCompose() { composeRequestTick += 1 }
     func requestRefresh() { refreshRequestTick += 1 }
@@ -109,6 +117,7 @@ final class AppState {
             self.lastUsername = username
             self.client = newClient
             self.status = .signedIn
+            startInboxBadgePolling()
         } catch let error as CabalmailError {
             status = .error(message(for: error))
         } catch {
@@ -117,6 +126,7 @@ final class AppState {
     }
 
     func signOut() async {
+        stopInboxBadgePolling()
         guard let client else { status = .signedOut; return }
         await client.imapClient.disconnect()
         try? await client.authService.signOut()
@@ -182,6 +192,7 @@ final class AppState {
             _ = try await newClient.authService.currentIdToken()
             self.client = newClient
             self.status = .signedIn
+            startInboxBadgePolling()
         } catch let error as CabalmailError {
             switch error {
             case .authExpired, .invalidCredentials, .notSignedIn:
@@ -202,6 +213,54 @@ final class AppState {
             }
         } catch {
             status = .error(error.localizedDescription)
+        }
+    }
+
+    /// Begin the Inbox-badge polling loop. Runs while signed in and polls
+    /// `STATUS (UNSEEN)` on INBOX every 60 seconds, pushing the count to the
+    /// system badge via `UNUserNotificationCenter`. Requests `.badge`
+    /// authorization on first start — the system ignores repeat requests
+    /// once the user has responded, so calling this on every sign-in is safe.
+    /// Idempotent: subsequent calls while the task is running are no-ops.
+    func startInboxBadgePolling() {
+        guard inboxBadgeTask == nil, client != nil else { return }
+        Task {
+            _ = try? await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.badge])
+        }
+        let interval = inboxBadgePollInterval
+        inboxBadgeTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.refreshInboxUnread()
+                try? await Task.sleep(nanoseconds: interval)
+            }
+        }
+    }
+
+    /// Tear down the badge poller and clear the system badge. Called on
+    /// sign-out so the icon doesn't keep showing the last signed-in user's
+    /// count. Idempotent — safe to call even if polling never started.
+    func stopInboxBadgePolling() {
+        inboxBadgeTask?.cancel()
+        inboxBadgeTask = nil
+        inboxUnreadCount = 0
+        Task {
+            try? await UNUserNotificationCenter.current().setBadgeCount(0)
+        }
+    }
+
+    private func refreshInboxUnread() async {
+        guard let client else { return }
+        do {
+            try await client.imapClient.connectAndAuthenticate()
+            let status = try await client.imapClient.status(path: "INBOX")
+            let count = max(0, status.unseen ?? 0)
+            inboxUnreadCount = count
+            try? await UNUserNotificationCenter.current().setBadgeCount(count)
+        } catch {
+            // Best-effort: if the STATUS call fails (transient network
+            // blip, IMAP reconnection) the prior badge value stays put
+            // until the next poll succeeds.
         }
     }
 

--- a/apple/Cabalmail/Views/MessageListView.swift
+++ b/apple/Cabalmail/Views/MessageListView.swift
@@ -46,6 +46,20 @@ struct MessageListView: View {
                 await model?.startWatching()
             }
         }
+        // Wall-clock fallback refresh. IDLE usually pushes new mail within
+        // seconds, but long-lived IDLE sockets can stall silently (iOS
+        // suspends idle connections, cellular handoffs drop the stream,
+        // NAT/middleboxes time out TCP after a few minutes). Polling every
+        // 60 seconds while the list is on screen guarantees the user sees
+        // new mail without pull-to-refresh. `.task` cancels automatically
+        // on `.onDisappear`, so the timer stops with the watcher.
+        .task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled else { break }
+                await model?.refresh()
+            }
+        }
         .onDisappear {
             // Tear down the IDLE watcher when the folder drops off-screen.
             // The view is rebuilt (via `.id(folder.path)` in MailRootView)


### PR DESCRIPTION
IMAP IDLE stalls silently in the Apple client — iOS suspends idle sockets, cellular handoffs drop the stream without error, middleboxes time TCP out — leaving the message list static until pull-to-refresh. A 60s wall-clock `.task` on `MessageListView` re-invokes the existing `refresh()` path alongside IDLE; SwiftUI cancels it on `.onDisappear` so the timer tracks the watcher lifecycle. `AppState` gains an independent Inbox-status poller that requests `.badge` authorization, calls `STATUS (UNSEEN)` on INBOX every 60s, and pushes the count via `UNUserNotificationCenter.setBadgeCount(_:)`. Runs while signed in, cleared on sign-out so the icon doesn't leak the prior user's count.