### PR TITLE
Restart sendmail on reconfigure to reload local-host-names

### DIFF
--- a/docker/shared/reconfigure.sh
+++ b/docker/shared/reconfigure.sh
@@ -58,23 +58,14 @@ regenerate() {
     makemap hash /etc/mail/mailertable.db  < /etc/mail/mailertable
   fi
 
-  # Signal sendmail to re-read all configuration.  SIGHUP causes
-  # sendmail to re-exec itself — same PID, same listening socket,
-  # zero downtime.  It re-reads sendmail.cf, hash databases (.db),
-  # and Fw/Fr flat files (local-host-names, relay-domains, etc.).
-  #
-  # Previously this used `supervisorctl restart sendmail`, but the
-  # full restart tears down the daemon and creates a window where
-  # port 25 is down, causing Dovecot submission relays to fail with
-  # "Connection refused".
-  if [ -f /var/run/sendmail.pid ]; then
-    SM_PID=$(head -1 /var/run/sendmail.pid)
-    echo "[reconfigure] Sending SIGHUP to sendmail (pid $SM_PID)..."
-    kill -HUP "$SM_PID" 2>/dev/null || true
-  else
-    echo "[reconfigure] WARN: no sendmail PID file, falling back to restart" >&2
-    supervisorctl restart sendmail
-  fi
+  # Restart sendmail to pick up all changes including Fw-referenced
+  # flat files (local-host-names, relay-domains).  SIGHUP does not
+  # reliably re-read these on AL2023's sendmail, so when a new
+  # subdomain is added the IMAP tier fails to recognise it as local
+  # and bounces the message back via MX → smtp-in → imap → loop.
+  # Use supervisorctl so the wrapper script and daemon are stopped
+  # and started together cleanly.
+  supervisorctl restart sendmail
 
   # For SMTP-OUT, also reload OpenDKIM tables
   if [ "$TIER" = "smtp-out" ]; then


### PR DESCRIPTION
SIGHUP does not reliably cause sendmail on AL2023 to re-read Fw-referenced flat files. When a new address with a previously unseen subdomain was created, the IMAP tier's local-host-names was updated on disk but Cw still held the old set, so sendmail treated the subdomain as remote, did an MX lookup, and forwarded to smtp-in.<control-domain> — looping back through smtp-in until the 25-hop limit aborted the message.

Switch back to `supervisorctl restart sendmail` so the wrapper and daemon cycle together and every config file is re-read. This reverts 1a1bfa61 and matches the rationale in 2a466dc7 / 07ec3f86.