### PR TITLE
Send Healthchecks mail FROM noreply@mail-admin.<first-mail-domain>

### DIFF
--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -230,4 +230,6 @@ module "monitoring" {
   user_pool_domain = module.pool.user_pool_domain
 
   lambda_bucket = module.bucket.bucket
+
+  mail_domains = var.mail_domains
 }

--- a/terraform/infra/modules/monitoring/healthchecks.tf
+++ b/terraform/infra/modules/monitoring/healthchecks.tf
@@ -151,7 +151,18 @@ resource "aws_ecs_task_definition" "healthchecks" {
       { name = "ALLOWED_HOSTS", value = "*" },
       { name = "SITE_ROOT", value = "https://heartbeat.${var.control_domain}" },
       { name = "SITE_NAME", value = "Cabalmail Healthchecks" },
-      { name = "DEFAULT_FROM_EMAIL", value = "noreply@${var.control_domain}" },
+      # From: domain piggy-backs on the `mail-admin.<first-mail-domain>`
+      # subdomain that the DMARC ingestion infrastructure already
+      # provisions (see terraform/infra/modules/app/dmarc_user.tf):
+      # MX, SPF, DKIM and DMARC records all land there as part of the
+      # standard apply. Cabalmail does not allow addressing on the
+      # apex of a mail domain by design, so neither <control-domain>
+      # nor mail_domains[0] itself resolves to MX/A — both fail
+      # sendmail's check_mail with `Domain of sender ... does not
+      # exist`. mail-admin.<first-mail-domain> has full DNS, so it's
+      # the natural place for system-originated mail like the
+      # Healthchecks magic-link FROM. Local part is free to vary.
+      { name = "DEFAULT_FROM_EMAIL", value = "noreply@mail-admin.${var.mail_domains[0]}" },
       { name = "DEBUG", value = "False" },
       { name = "REGISTRATION_OPEN", value = "True" },
       { name = "USE_PAYMENTS", value = "False" },

--- a/terraform/infra/modules/monitoring/variables.tf
+++ b/terraform/infra/modules/monitoring/variables.tf
@@ -103,3 +103,8 @@ variable "ntfy_topic" {
   description = "ntfy topic name that alert_sink publishes to. Must match the topic the admin user has publish access on."
   default     = "alerts"
 }
+
+variable "mail_domains" {
+  type        = list(string)
+  description = "List of Cabalmail-hosted mail domains. The first entry is used as the From: domain for Healthchecks-originated mail (control_domain typically has no MX at the apex, so noreply@<control-domain> gets rejected by sendmail's sender-domain check)."
+}


### PR DESCRIPTION
Sendmail's check_mail rule on the IMAP tier does an MX-then-A lookup on the envelope sender's domain and 553-rejects when neither resolves. The previous DEFAULT_FROM_EMAIL of noreply@<control-domain> hit that — control_domain has no MX/A at the apex, only subdomains. Mail domain apexes are likewise empty by design (Cabalmail does not allow addressing on the apex of a mail domain), so mail_domains[0] isn't a valid FROM either.

The DMARC ingestion infrastructure already provisions a `mail-admin.<first-mail-domain>` subdomain with full MX, SPF, DKIM and DMARC records — see modules/app/dmarc_user.tf. It's the natural place for system-originated mail. Reusing it for Healthchecks magic-link FROM avoids creating yet another subdomain and keeps the sender-domain DNS plumbing in one place. Local part is `noreply` to distinguish from the existing dmarc-reports@ recipient address.

Thread mail_domains through main.tf into the monitoring module so healthchecks.tf can compose the FROM. The list is guaranteed non- empty by the existing root-level validation on var.mail_domains.