### PR TITLE
Add quiesce workflow to scale non-prod environments to zero

### DIFF
--- a/.github/workflows/quiesce.yml
+++ b/.github/workflows/quiesce.yml
@@ -10,6 +10,10 @@
 
 name: Quiesce Infrastructure
 
+permissions:
+  contents: read
+  actions: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/quiesce.yml
+++ b/.github/workflows/quiesce.yml
@@ -1,0 +1,117 @@
+---
+# Scale a non-prod environment's running compute (ECS services, the
+# ECS-instance ASG, and NAT instances) to zero - or restore it. Refuses
+# to run against prod. State-bearing resources (DynamoDB, EFS, S3,
+# Cognito, Route 53, ACM, NLB, EFS, EIPs) are left alone.
+#
+# After running with action=down, set TF_VAR_QUIESCED=true on the
+# matching GitHub Environment so the regular terraform workflow does
+# not resurrect the compute. See docs/quiesce.md.
+
+name: Quiesce Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment. Prod is not selectable."
+        required: true
+        type: choice
+        options:
+          - development
+          - stage
+      action:
+        description: "down: scale running compute to zero. up: restore."
+        required: true
+        type: choice
+        options:
+          - down
+          - up
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: refuse-prod-and-mismatched-branch
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "::error::quiesce.yml refuses to run from main (prod)."
+            exit 1
+          fi
+          DERIVED_ENV="${{ github.ref_name == 'stage' && 'stage' || 'development' }}"
+          if [[ "$DERIVED_ENV" != "${{ inputs.environment }}" ]]; then
+            echo "::error::Branch ${{ github.ref_name }} maps to '$DERIVED_ENV', but you selected '${{ inputs.environment }}'. Re-run from the correct branch."
+            exit 1
+          fi
+
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - guard
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: generate-versions
+        run: env TF_MODULE=infra TF_ENVIRONMENT="${{ vars.TF_VAR_ENVIRONMENT }}" ./.github/scripts/make-terraform.sh
+      - name: store-artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: backend.tf
+          path: ./terraform/infra/backend.tf
+
+  apply:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    defaults:
+      run:
+        working-directory: ./terraform/infra
+    environment: ${{ inputs.environment }}
+    env:
+      TF_API_TOKEN: ${{ secrets.TF_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+      - name: retrieve-artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: backend.tf
+      - name: move
+        run: mv ../../backend.tf backend.tf
+      - name: install-terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
+      - name: tfvars-terraform
+        # Forced literal for `quiesced` regardless of the env-level
+        # TF_VAR_QUIESCED, so down/up always applies the requested state.
+        run: |
+          echo "availability_zones = ${{ vars.TF_VAR_AVAILABILITY_ZONES }}" > terraform.tfvars
+          echo "aws_region = \"${{ vars.TF_VAR_AWS_REGION }}\"" >> terraform.tfvars
+          echo "cidr_block = \"${{ vars.TF_VAR_CIDR_BLOCK }}\"" >> terraform.tfvars
+          echo "control_domain = \"${{ vars.TF_VAR_CONTROL_DOMAIN }}\"" >> terraform.tfvars
+          echo "email = \"${{ vars.TF_VAR_EMAIL }}\"" >> terraform.tfvars
+          echo "environment = \"${{ vars.TF_VAR_ENVIRONMENT }}\"" >> terraform.tfvars
+          echo "mail_domains = ${{ vars.TF_VAR_MAIL_DOMAINS }}" >> terraform.tfvars
+          echo "repo = \"${{ vars.TF_VAR_REPO }}\"" >> terraform.tfvars
+          echo "backup = ${{ vars.TF_VAR_BACKUP }}" >> terraform.tfvars
+          echo "monitoring = ${{ vars.TF_VAR_MONITORING }}" >> terraform.tfvars
+          echo "healthchecks_registration_open = ${{ vars.TF_VAR_HEALTHCHECKS_REGISTRATION_OPEN || 'false' }}" >> terraform.tfvars
+          echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
+          echo "quiesced = ${{ inputs.action == 'down' && 'true' || 'false' }}" >> terraform.tfvars
+      - name: init-terraform
+        run: terraform init
+      - name: apply-terraform
+        run: terraform apply -auto-approve -lock-timeout=30m -var-file="terraform.tfvars"
+      - name: durability-reminder
+        if: inputs.action == 'down'
+        run: |
+          echo "::warning::Quiesce applied to ${{ inputs.environment }}. For durability across other terraform workflow runs, set TF_VAR_QUIESCED=true on the '${{ inputs.environment }}' GitHub Environment. Otherwise the next terraform.yml run will resurrect compute. See docs/quiesce.md."
+      - name: resume-reminder
+        if: inputs.action == 'up'
+        run: |
+          echo "::warning::Resume applied to ${{ inputs.environment }}. Remember to clear TF_VAR_QUIESCED on the '${{ inputs.environment }}' GitHub Environment (set to false or remove the variable) so subsequent terraform.yml runs do not re-quiesce."

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -176,6 +176,7 @@ jobs:
         echo "monitoring = ${{ vars.TF_VAR_MONITORING }}" >> terraform.tfvars
         echo "healthchecks_registration_open = ${{ vars.TF_VAR_HEALTHCHECKS_REGISTRATION_OPEN || 'false' }}" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
+        echo "quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}" >> terraform.tfvars
     - name: init-terraform
       run: terraform init
     - name: plan-terraform
@@ -226,6 +227,7 @@ jobs:
         echo "monitoring = ${{ vars.TF_VAR_MONITORING }}" >> terraform.tfvars
         echo "healthchecks_registration_open = ${{ vars.TF_VAR_HEALTHCHECKS_REGISTRATION_OPEN || 'false' }}" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
+        echo "quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}" >> terraform.tfvars
     - name: init-terraform
       run: terraform init
     - name: apply-terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-29
+
+### Added
+- `quiesce` GitHub workflow (`.github/workflows/quiesce.yml`)
+  scales a non-prod environment's running compute to zero to save
+  cost, or restores it. `workflow_dispatch` only, with `environment`
+  (development | stage) and `action` (down | up) inputs. Refuses to
+  run from `main` and refuses any branch/environment mismatch. New
+  root-level Terraform variable `quiesced` (default `false`) is
+  threaded through the `ecs`, `monitoring`, and `vpc` modules and
+  gates: every mail-tier and monitoring ECS service `desired_count`,
+  the `smtp_in` and `smtp_out` Application Auto Scaling target
+  bounds, the ECS-instance ASG `min_size`/`desired_capacity`/
+  `max_size` and `protect_from_scale_in`, the ECS capacity provider
+  `managed_termination_protection`, the NAT instances and NAT
+  gateway counts, and the private subnet default route. State-bearing
+  resources (DynamoDB, EFS, S3, Cognito, Route 53, ACM, NLB,
+  CloudFront, Lambda) are unaffected. New operations doc at
+  `docs/quiesce.md`, linked from `docs/operations.md`.
+- `terraform.yml` tfvars step now writes `quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}`,
+  so setting `TF_VAR_QUIESCED=true` on a GitHub Environment makes the
+  quiesced state durable across pushes and other terraform workflow
+  runs.
+
 ## [0.8.2] - 2026-04-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ docs/               Architecture docs, migration plans, setup guides
 .github/scripts/    Shared build/deploy helper scripts
 ```
 
+### Docs convention
+
+Versioned subdirectories of `docs/` (e.g. `docs/0.4.0/`, `docs/0.7.0/`, `docs/0.9.0/`) are forward-looking plans for the corresponding roadmap version - design proposals written before or during implementation. Once a feature ships, its as-implemented documentation lives at the top level of `docs/`, not inside the version directory. When you write operator-facing or reference documentation for something that has already shipped, put it in `docs/<topic>.md` and link it from the relevant index (`docs/operations.md`, `docs/setup.md`, etc.). Leave the version directory alone; it is part of the historical planning record.
+
 ## Build/Lint/Test Commands
 
 ### React App (`react/admin`)
@@ -59,8 +63,9 @@ docs/               Architecture docs, migration plans, setup guides
 | `lambda_api_python.yml` | `lambda/api/**` | Pylint, build zips, upload to S3, trigger terraform |
 | `lambda_counter.yml` | `lambda/counter/**` | Pylint, build zip, upload to S3, trigger terraform |
 | `docker.yml` | `docker/**` | Build 3 mail tier images + certbot, push to ECR, trigger terraform |
-| `terraform.yml` | `terraform/infra/**` | Checkov/tflint/tfsec, plan, apply. Also runs weekly (Wednesday) |
+| `terraform.yml` | `terraform/infra/**` | Checkov/tflint/tfsec, plan, apply |
 | `bootstrap.yml` | Manual/workflow_call | Applies `terraform/dns` stack (Route 53 zone) |
+| `quiesce.yml` | Manual (`workflow_dispatch`) | Scales a non-prod env's ECS services, ECS-instance ASG, and NAT instances to zero (or restores them). Refuses to run against prod. See `docs/quiesce.md`. |
 All workflows select environment based on branch: `main`=prod, `stage`=stage, other=development.
 
 ## Architecture Details

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,3 +17,7 @@ You also _could_ create a single address on a Cabalmail system and just give tha
 # Monitoring
 
 Setting `TF_VAR_MONITORING` to `true` in a GitHub environment adds [monitoring](./monitoring.md) infrastructure. Setting up monitoring is not turn-key. There are many manual steps involved in establishing alert thresholds, communication, configuration, etc. Once established, there are some run books in [the operations/runbooks directory](./operations/runbooks) that you can use as the basis for incident response. These are provided as templates. You should modify them as appropriate for your use cases and requirements.
+
+# Quiescing a non-prod environment
+
+The `quiesce` GitHub workflow scales a development or stage environment's running compute (ECS services, the ECS-instance ASG, NAT instances) to zero so it stops accruing hourly charges. Data is preserved. The workflow refuses to run against prod. See [Quiesce: scale a non-prod environment to zero](./quiesce.md) for the full list of what gets scaled, what is preserved, and how to make the quiesce durable across other Terraform runs.

--- a/docs/quiesce.md
+++ b/docs/quiesce.md
@@ -1,0 +1,62 @@
+# Quiesce: scale a non-prod environment to zero
+
+The `quiesce` workflow scales a development or stage environment's running compute to zero so it stops accruing hourly charges. Mail data, address data, and other state-bearing resources are left alone, so the environment can be brought back up with a single workflow run.
+
+## What gets quiesced
+
+| Resource | Behavior when quiesced |
+|---|---|
+| ECS services for `imap`, `smtp-in`, `smtp-out` | `desired_count = 0` |
+| ECS services for the monitoring stack (Prometheus, Alertmanager, Grafana, Uptime Kuma, Healthchecks, ntfy, cloudwatch-exporter, blackbox-exporter) | `desired_count = 0` |
+| ECS Application Auto Scaling targets for `smtp-in` and `smtp-out` | `min_capacity = 0`, `max_capacity = 0` |
+| ECS-instance Auto Scaling Group | `min_size = 0`, `desired_capacity = 0`, `max_size = 0` |
+| ASG instance scale-in protection (`protect_from_scale_in`) | Disabled, so the running instance can actually be terminated |
+| ECS capacity provider `managed_termination_protection` | Disabled, so the capacity provider stops fighting the ASG drain |
+| NAT instances | `count = 0`. The Elastic IPs are kept, so SMTP allow-lists do not need to be re-issued on resume. |
+| Private subnet default route | Removed. The NAT-instance NIC it pointed to is gone, and nothing runs in private subnets while quiesced. |
+
+The DAEMON `node-exporter` ECS service is not gated explicitly. It places one task per EC2 instance in the cluster; with the ASG at zero, it has no instances to schedule on and naturally goes to zero with the rest of the compute.
+
+## What is preserved
+
+- DynamoDB tables (`cabal-addresses`, `cabal-user-preferences`, `cabal-dmarc-reports`, the Cognito counter table)
+- EFS file system and mount targets (the mailstore and monitoring persistence volumes)
+- S3 buckets (React app, Lambda artifacts)
+- Cognito user pool and clients
+- Route 53 zones, records, and the EIP-keyed `smtp.<control-domain>` record
+- ACM certificate
+- The Network Load Balancer and its target groups
+- The CloudFront distribution
+- All Lambda functions (API, certbot-renewal, DMARC ingest, alert sink), their event sources, and SSM-stored config
+
+A quiesced environment will fail TCP health checks on IMAP/SMTP and serve no monitoring UI. DNS still resolves; clients see connection timeouts rather than NXDOMAIN.
+
+## Running the workflow
+
+The workflow is in [.github/workflows/quiesce.yml](../../.github/workflows/quiesce.yml). It is `workflow_dispatch` only.
+
+1. Switch to the branch that maps to your target environment (`stage` for the `stage` environment, anything else for `development`). The `main` branch is rejected outright.
+2. From the GitHub Actions UI, run **Quiesce Infrastructure** with:
+   - `environment` = `development` or `stage`
+   - `action` = `down` to scale to zero, or `up` to restore
+3. The job validates that the branch matches the chosen environment, generates the same backend config and tfvars that `terraform.yml` does, and runs `terraform apply` with `quiesced = true|false` written directly into the tfvars file.
+
+## Durability across other Terraform runs
+
+`terraform.yml` runs on any push that touches `terraform/infra/**`, on `workflow_dispatch`, and on `repository_dispatch`. It writes `quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}` to its tfvars, so by default it un-quiesces.
+
+To keep an environment quiesced across other runs:
+
+- After running `quiesce` with `action: down`, set `TF_VAR_QUIESCED=true` on the matching GitHub Environment (`development` or `stage`) under **Settings -> Environments**.
+- After running `quiesce` with `action: up`, clear `TF_VAR_QUIESCED` (set to `false` or remove the variable).
+
+Forgetting this step is recoverable: the next `terraform.yml` run will simply restore compute. The state-bearing resources are unaffected either way.
+
+## Caveats
+
+- Resume time is bounded by EC2 instance bootstrap and ECS task startup. Expect a few minutes before mail tiers are healthy again.
+- Active connections to `imap.<control-domain>` and `smtp.<control-domain>` are dropped at the NLB once tasks deregister.
+- Alarms wired to `UnHealthyHostCount` on the NLB target groups will fire continuously while quiesced. This is expected; suppress or accept the noise on non-prod.
+- The NLB itself is not torn down. It costs roughly $16/month idle. Tearing it down was considered but rejected for v1: it triggers Route 53 alias re-resolution on resume and adds non-trivial cascade.
+- The monitoring ALB is also kept up when `monitoring = true`. Same rationale.
+- The certbot-renewal Lambda continues to run on its 60-day schedule and will renew certificates while the environment is quiesced. This is intentional - it avoids cert expiry during long quiesce periods.

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -108,6 +108,7 @@ module "vpc" {
   control_domain   = var.control_domain
   az_list          = var.availability_zones
   zone_id          = data.terraform_remote_state.zone.outputs.control_domain_zone_id
+  quiesced         = var.quiesced
 }
 
 # Creates a network load balancer shared by machines in the stack
@@ -184,6 +185,8 @@ module "ecs" {
 
   healthcheck_ping_param = local.hc_ping_ecs_reconfigure
 
+  quiesced = var.quiesced
+
   depends_on = [module.cert]
 }
 
@@ -253,4 +256,6 @@ module "monitoring" {
 
   mail_domains                   = var.mail_domains
   healthchecks_registration_open = var.healthchecks_registration_open
+
+  quiesced = var.quiesced
 }

--- a/terraform/infra/modules/ecs/main.tf
+++ b/terraform/infra/modules/ecs/main.tf
@@ -87,12 +87,15 @@ resource "aws_launch_template" "ecs" {
 # -- ASG for ECS instances -------------------------------------
 
 resource "aws_autoscaling_group" "ecs" {
-  name_prefix               = "cabal-ecs-"
-  vpc_zone_identifier       = var.private_subnets[*].id
-  desired_capacity          = 1
-  max_size                  = 3
-  min_size                  = 1
-  protect_from_scale_in     = true
+  name_prefix         = "cabal-ecs-"
+  vpc_zone_identifier = var.private_subnets[*].id
+  desired_capacity    = var.quiesced ? 0 : 1
+  max_size            = var.quiesced ? 0 : 3
+  min_size            = var.quiesced ? 0 : 1
+  # Disabled while quiesced so the running instance can actually be
+  # terminated. Re-enabled on resume so the capacity provider's
+  # managed termination protection has its required precondition.
+  protect_from_scale_in     = !var.quiesced
   wait_for_capacity_timeout = "0" # ECS capacity provider manages health
 
   launch_template {
@@ -123,8 +126,11 @@ resource "aws_ecs_capacity_provider" "ec2" {
   name = "cabal-ec2"
 
   auto_scaling_group_provider {
-    auto_scaling_group_arn         = aws_autoscaling_group.ecs.arn
-    managed_termination_protection = "ENABLED"
+    auto_scaling_group_arn = aws_autoscaling_group.ecs.arn
+    # AWS requires ASG instance scale-in protection to be enabled
+    # before this can be ENABLED, so it tracks aws_autoscaling_group.ecs
+    # protect_from_scale_in.
+    managed_termination_protection = var.quiesced ? "DISABLED" : "ENABLED"
 
     managed_scaling {
       status          = "ENABLED"

--- a/terraform/infra/modules/ecs/services.tf
+++ b/terraform/infra/modules/ecs/services.tf
@@ -14,7 +14,7 @@ resource "aws_ecs_service" "imap" {
   name            = "cabal-imap"
   cluster         = aws_ecs_cluster.mail.id
   task_definition = aws_ecs_task_definition.imap.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 
@@ -53,7 +53,7 @@ resource "aws_ecs_service" "smtp_in" {
   name            = "cabal-smtp-in"
   cluster         = aws_ecs_cluster.mail.id
   task_definition = aws_ecs_task_definition.smtp_in.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 
@@ -85,7 +85,7 @@ resource "aws_ecs_service" "smtp_out" {
   name            = "cabal-smtp-out"
   cluster         = aws_ecs_cluster.mail.id
   task_definition = aws_ecs_task_definition.smtp_out.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 
@@ -120,8 +120,11 @@ resource "aws_ecs_service" "smtp_out" {
 # -- Auto-scaling: SMTP-IN ------------------------------------
 
 resource "aws_appautoscaling_target" "smtp_in" {
-  max_capacity       = 3
-  min_capacity       = 1
+  # When quiesced, both bounds are zero so target tracking can't pull
+  # the service's desired_count back up off zero. Kept as attribute
+  # changes (not count) to avoid resource recreation on resume.
+  max_capacity       = var.quiesced ? 0 : 3
+  min_capacity       = var.quiesced ? 0 : 1
   resource_id        = "service/${aws_ecs_cluster.mail.name}/${aws_ecs_service.smtp_in.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
@@ -145,8 +148,8 @@ resource "aws_appautoscaling_policy" "smtp_in_cpu" {
 # -- Auto-scaling: SMTP-OUT -----------------------------------
 
 resource "aws_appautoscaling_target" "smtp_out" {
-  max_capacity       = 3
-  min_capacity       = 1
+  max_capacity       = var.quiesced ? 0 : 3
+  min_capacity       = var.quiesced ? 0 : 1
   resource_id        = "service/${aws_ecs_cluster.mail.name}/${aws_ecs_service.smtp_out.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"

--- a/terraform/infra/modules/ecs/variables.tf
+++ b/terraform/infra/modules/ecs/variables.tf
@@ -115,3 +115,11 @@ variable "healthcheck_ping_param" {
   description = "SSM Parameter Store name holding the Healthchecks ping URL for the reconfigure.sh loop. Empty string disables the heartbeat (used when var.monitoring is false in the parent stack)."
   default     = ""
 }
+
+# -- Quiesce ----------------------------------------------------
+
+variable "quiesced" {
+  type        = bool
+  description = "When true, set ECS service desired_count and the ECS-instance ASG to zero. Capacity-provider managed termination protection and ASG instance scale-in protection are also disabled so the running instance can be terminated."
+  default     = false
+}

--- a/terraform/infra/modules/monitoring/alertmanager.tf
+++ b/terraform/infra/modules/monitoring/alertmanager.tf
@@ -154,7 +154,7 @@ resource "aws_ecs_service" "alertmanager" {
   name            = "cabal-alertmanager"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.alertmanager.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 

--- a/terraform/infra/modules/monitoring/exporters.tf
+++ b/terraform/infra/modules/monitoring/exporters.tf
@@ -112,7 +112,7 @@ resource "aws_ecs_service" "cloudwatch_exporter" {
   name            = "cabal-cloudwatch-exporter"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.cloudwatch_exporter.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 100
@@ -204,7 +204,7 @@ resource "aws_ecs_service" "blackbox_exporter" {
   name            = "cabal-blackbox-exporter"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.blackbox_exporter.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   deployment_maximum_percent         = 200
   deployment_minimum_healthy_percent = 100

--- a/terraform/infra/modules/monitoring/grafana.tf
+++ b/terraform/infra/modules/monitoring/grafana.tf
@@ -195,7 +195,7 @@ resource "aws_ecs_service" "grafana" {
   name            = "cabal-grafana"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.grafana.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 

--- a/terraform/infra/modules/monitoring/healthchecks.tf
+++ b/terraform/infra/modules/monitoring/healthchecks.tf
@@ -247,7 +247,7 @@ resource "aws_ecs_service" "healthchecks" {
   name            = "cabal-healthchecks"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.healthchecks.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 

--- a/terraform/infra/modules/monitoring/kuma.tf
+++ b/terraform/infra/modules/monitoring/kuma.tf
@@ -148,7 +148,7 @@ resource "aws_ecs_service" "kuma" {
   name            = "cabal-uptime-kuma"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.kuma.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 

--- a/terraform/infra/modules/monitoring/ntfy.tf
+++ b/terraform/infra/modules/monitoring/ntfy.tf
@@ -167,7 +167,7 @@ resource "aws_ecs_service" "ntfy" {
   name            = "cabal-ntfy"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.ntfy.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 

--- a/terraform/infra/modules/monitoring/prometheus.tf
+++ b/terraform/infra/modules/monitoring/prometheus.tf
@@ -139,7 +139,7 @@ resource "aws_ecs_service" "prometheus" {
   name            = "cabal-prometheus"
   cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.prometheus.arn
-  desired_count   = 1
+  desired_count   = var.quiesced ? 0 : 1
 
   enable_execute_command = true
 

--- a/terraform/infra/modules/monitoring/variables.tf
+++ b/terraform/infra/modules/monitoring/variables.tf
@@ -154,3 +154,9 @@ variable "healthchecks_registration_open" {
   description = "Whether the Healthchecks signup form is open. True at bootstrap to let the operator sign up the first user via the magic-link flow; false the rest of the time."
   default     = false
 }
+
+variable "quiesced" {
+  type        = bool
+  description = "When true, set every monitoring ECS service desired_count to zero. The DAEMON node-exporter naturally goes to zero with the underlying ASG and is not gated explicitly."
+  default     = false
+}

--- a/terraform/infra/modules/vpc/nat.tf
+++ b/terraform/infra/modules/vpc/nat.tf
@@ -34,7 +34,7 @@ resource "aws_eip_domain_name" "smtp" {
 # =============================================================================
 
 resource "aws_nat_gateway" "nat" {
-  count         = var.use_nat_instance ? 0 : length(var.az_list)
+  count         = var.use_nat_instance || var.quiesced ? 0 : length(var.az_list)
   allocation_id = aws_eip.nat_eip[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
   tags = {
@@ -112,7 +112,7 @@ resource "aws_iam_instance_profile" "nat" {
 }
 
 resource "aws_instance" "nat" {
-  count                  = var.use_nat_instance ? length(var.az_list) : 0
+  count                  = var.use_nat_instance && !var.quiesced ? length(var.az_list) : 0
   ami                    = data.aws_ami.amazon_linux_2[0].id
   instance_type          = var.nat_instance_type
   subnet_id              = aws_subnet.public[count.index].id
@@ -170,7 +170,7 @@ resource "aws_instance" "nat" {
 }
 
 resource "aws_eip_association" "nat" {
-  count         = var.use_nat_instance ? length(var.az_list) : 0
+  count         = var.use_nat_instance && !var.quiesced ? length(var.az_list) : 0
   instance_id   = aws_instance.nat[count.index].id
   allocation_id = aws_eip.nat_eip[count.index].id
 }

--- a/terraform/infra/modules/vpc/route.tf
+++ b/terraform/infra/modules/vpc/route.tf
@@ -7,7 +7,10 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "private" {
-  count                  = length(var.az_list)
+  # The route's target (NAT instance NIC or NAT gateway) is gone while
+  # the env is quiesced, so the route is removed too. Private subnets
+  # have no internet egress when quiesced; nothing runs in them.
+  count                  = var.quiesced ? 0 : length(var.az_list)
   route_table_id         = aws_route_table.private[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = var.use_nat_instance ? null : aws_nat_gateway.nat[count.index].id

--- a/terraform/infra/modules/vpc/variables.tf
+++ b/terraform/infra/modules/vpc/variables.tf
@@ -34,3 +34,9 @@ variable "nat_instance_type" {
   description = "Instance type for NAT instances (when use_nat_instance = true)."
   default     = "t3.micro"
 }
+
+variable "quiesced" {
+  type        = bool
+  description = "When true, do not provision NAT instances. Private-subnet egress goes away while the environment is quiesced; ECS tasks needing egress are also at zero, so this is safe. NAT EIPs and the public Route 53 record for them are kept so SMTP relay IP allow-lists do not need to be re-issued on resume."
+  default     = false
+}

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -95,4 +95,10 @@ variable "healthchecks_registration_open" {
   default     = false
 }
 
+variable "quiesced" {
+  type        = bool
+  description = "When true, scale all running compute (ECS service desired counts, the ECS-instance ASG, and NAT instances) to zero to save cost. State-bearing resources (DynamoDB, EFS, S3, Cognito, Route 53, ACM, NLB) are unaffected. Intended for non-prod environments only; the quiesce workflow refuses to run against prod."
+  default     = false
+}
+
 


### PR DESCRIPTION
Introduces a `workflow_dispatch`-only "Quiesce Infrastructure" workflow that drives a non-prod environment's running compute to zero (or restores it) via a new var.quiesced threaded through the ecs, monitoring, and vpc modules. Refuses to run from main and rejects any branch/environment mismatch. State-bearing resources are unaffected; durable across other terraform runs by setting TF_VAR_QUIESCED on the GitHub Environment.