### PR TITLE
Phase 3 of build/deploy simplification: app.yml

### DIFF
--- a/.github/scripts/deploy-ecs-service.sh
+++ b/.github/scripts/deploy-ecs-service.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Out-of-band ECS application deploy. Clones the running task definition
+# of cabal-${TIER} on cluster cabal-mail, rewrites every container image
+# whose repo basename is cabal-${TIER} to point at the freshly-pushed
+# tag, registers a new task-def revision, and rolls the service to it.
+#
+# Phase 3 of docs/0.9.0/build-deploy-simplification-plan.md introduces
+# this path: app.yml mutates ECS directly via the AWS CLI instead of
+# routing through Terraform. The phase 1 lifecycle clause
+# (ignore_changes = [container_definitions]) protects the new revision
+# from being clobbered by a topology-only Terraform apply, and the
+# phase 1 .github/scripts/refresh-ssm-from-running.sh keeps SSM
+# /cabal/deployed_image_tag in lockstep with whatever app.yml just
+# deployed so a Terraform-driven topology change re-pins to reality
+# rather than to a stale SSM value.
+#
+# Usage:
+#   deploy-ecs-service.sh <tier> <image_tag> [cluster]
+#
+# Args:
+#   tier       e.g. imap, smtp-in, prometheus. Maps to ECS service
+#              cabal-<tier> and ECR repo cabal-<tier>.
+#   image_tag  e.g. sha-abc12345. Must already exist in ECR.
+#   cluster    Optional; defaults to cabal-mail.
+#
+# Exit codes:
+#   0  rolled the service successfully (or service already up to date)
+#   1  required arg missing, service not found, or no container in the
+#      task def references cabal-<tier>:<anything>
+#   non-0 from aws CLI on any other failure
+
+set -euo pipefail
+
+TIER="${1:?tier required}"
+TAG="${2:?image_tag required}"
+CLUSTER="${3:-cabal-mail}"
+SERVICE="cabal-${TIER}"
+REPO_BASENAME="cabal-${TIER}"
+
+log() { echo "[deploy-ecs-service] $*"; }
+
+td_arn="$(aws ecs describe-services \
+  --cluster "${CLUSTER}" \
+  --services "${SERVICE}" \
+  --query 'services[0].taskDefinition' \
+  --output text 2>/dev/null || echo "None")"
+
+if [ -z "${td_arn}" ] || [ "${td_arn}" = "None" ]; then
+  log "service ${SERVICE} not found on ${CLUSTER}; cannot deploy ${TIER}"
+  exit 1
+fi
+
+log "current task def for ${SERVICE}: ${td_arn}"
+
+td_json="$(aws ecs describe-task-definition \
+  --task-definition "${td_arn}" \
+  --query 'taskDefinition' \
+  --output json)"
+
+# Rewrite every container image whose repo basename matches REPO_BASENAME.
+# The repo basename is the path component after the last '/' in the
+# image reference. For ECR images that is the repository name itself;
+# for non-ECR placeholder images (e.g. public.ecr.aws/nginx/nginx) it
+# will be 'nginx', which does not match cabal-<tier>, so those are left
+# alone. Read-only fields are stripped so the result is a valid input
+# to register-task-definition.
+new_td_json="$(echo "${td_json}" | jq \
+  --arg basename "${REPO_BASENAME}" \
+  --arg tag "${TAG}" '
+  def repo_base(img):
+    img | split(":")[0] | split("@")[0] | split("/") | .[-1];
+  .containerDefinitions = (
+    .containerDefinitions | map(
+      if repo_base(.image) == $basename
+      then .image = ((.image | split(":")[0] | split("@")[0]) + ":" + $tag)
+      else .
+      end
+    )
+  )
+  | del(
+      .taskDefinitionArn,
+      .revision,
+      .status,
+      .requiresAttributes,
+      .compatibilities,
+      .registeredAt,
+      .registeredBy
+    )
+')"
+
+matched_image="$(echo "${new_td_json}" | jq -r \
+  --arg basename "${REPO_BASENAME}" '
+  def repo_base(img):
+    img | split(":")[0] | split("@")[0] | split("/") | .[-1];
+  [.containerDefinitions[] | select(repo_base(.image) == $basename) | .image] | first // ""
+')"
+
+if [ -z "${matched_image}" ]; then
+  log "no container in ${td_arn} has repo basename ${REPO_BASENAME}; refusing to deploy"
+  exit 1
+fi
+
+log "rewrote container image to: ${matched_image}"
+
+new_td_arn="$(aws ecs register-task-definition \
+  --cli-input-json "${new_td_json}" \
+  --query 'taskDefinition.taskDefinitionArn' \
+  --output text)"
+log "registered new task def: ${new_td_arn}"
+
+aws ecs update-service \
+  --cluster "${CLUSTER}" \
+  --service "${SERVICE}" \
+  --task-definition "${new_td_arn}" >/dev/null
+log "service ${SERVICE} rolling to ${new_td_arn}"

--- a/.github/scripts/deploy-lambda-image.sh
+++ b/.github/scripts/deploy-lambda-image.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Out-of-band Lambda deploy for container-image functions. Calls
+# aws lambda update-function-code --image-uri to point the function at
+# the freshly-pushed image, then waits for the update to complete.
+#
+# Phase 3 of docs/0.9.0/build-deploy-simplification-plan.md uses this
+# for cabal-certbot-renewal. The phase 2 lifecycle clause on that
+# function (ignore_changes = [image_uri]) protects the new image from
+# being clobbered by a topology-only Terraform apply.
+#
+# Usage:
+#   deploy-lambda-image.sh <function_name> <image_uri>
+#
+# Args:
+#   function_name  e.g. cabal-certbot-renewal
+#   image_uri      Full image URI including tag, e.g.
+#                  123.dkr.ecr.us-west-2.amazonaws.com/cabal/certbot-renewal:sha-abc12345
+#
+# Exit codes:
+#   0  function updated successfully
+#   1  required arg missing or function does not exist in AWS
+#   non-0 from aws CLI on any other failure
+
+set -euo pipefail
+
+FUNC="${1:?function_name required}"
+URI="${2:?image_uri required}"
+
+log() { echo "[deploy-lambda-image] $*"; }
+
+if ! aws lambda get-function --function-name "${FUNC}" >/dev/null 2>&1; then
+  log "function ${FUNC} does not exist in this account; refusing to deploy"
+  exit 1
+fi
+
+log "updating ${FUNC} -> ${URI}"
+
+aws lambda update-function-code \
+  --function-name "${FUNC}" \
+  --image-uri "${URI}" \
+  --no-publish \
+  --output text \
+  --query 'LastUpdateStatus' >/dev/null
+
+aws lambda wait function-updated --function-name "${FUNC}"
+log "${FUNC} update complete"

--- a/.github/scripts/deploy-lambda-zip.sh
+++ b/.github/scripts/deploy-lambda-zip.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Out-of-band Lambda deploy for S3-source (zip) functions. Calls
+# aws lambda update-function-code with the freshly-uploaded S3 key,
+# then waits for the function update to finish so the caller can roll
+# the next deploy without racing against an in-flight publish.
+#
+# Phase 3 of docs/0.9.0/build-deploy-simplification-plan.md introduces
+# this path: app.yml mutates the running function directly instead of
+# letting Terraform pick up the new code on the next plan. The phase 2
+# lifecycle clause (ignore_changes on s3_key, s3_object_version,
+# source_code_hash) protects the new code from being clobbered by a
+# topology-only Terraform apply, and the phase 2
+# .github/scripts/record-lambda-hashes.sh records the deployed
+# CodeSha256 so a Terraform-driven recreate starts from the running
+# code identity.
+#
+# The zip and its sidecar checksum must already be at
+#   s3://${bucket}/lambda/${function}.zip
+#   s3://${bucket}/lambda/${function}.zip.base64sha256
+# build-api.sh and build-counter.sh both produce that layout.
+#
+# Usage:
+#   deploy-lambda-zip.sh <function_name> <s3_bucket> [s3_key]
+#
+# Args:
+#   function_name  Lambda function name in AWS (often matches the
+#                  source dir, but not always - e.g. cabal-healthchecks-iac
+#                  vs lambda/api/healthchecks_iac).
+#   s3_bucket      Bucket the zip is in. Typically admin.${TF_VAR_CONTROL_DOMAIN}.
+#   s3_key         Optional; defaults to lambda/<function_name>.zip.
+#
+# Exit codes:
+#   0  function updated successfully
+#   1  required arg missing or function does not exist in AWS
+#   non-0 from aws CLI on any other failure
+
+set -euo pipefail
+
+FUNC="${1:?function_name required}"
+BUCKET="${2:?s3_bucket required}"
+KEY="${3:-lambda/${FUNC}.zip}"
+
+log() { echo "[deploy-lambda-zip] $*"; }
+
+if ! aws lambda get-function --function-name "${FUNC}" >/dev/null 2>&1; then
+  log "function ${FUNC} does not exist in this account; refusing to deploy"
+  exit 1
+fi
+
+log "updating ${FUNC} from s3://${BUCKET}/${KEY}"
+
+aws lambda update-function-code \
+  --function-name "${FUNC}" \
+  --s3-bucket "${BUCKET}" \
+  --s3-key "${KEY}" \
+  --no-publish \
+  --output text \
+  --query 'LastUpdateStatus' >/dev/null
+
+aws lambda wait function-updated --function-name "${FUNC}"
+
+new_sha="$(aws lambda get-function-configuration \
+  --function-name "${FUNC}" \
+  --query 'CodeSha256' \
+  --output text)"
+log "${FUNC} now at CodeSha256=${new_sha}"

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -1,0 +1,336 @@
+---
+name: Build and Deploy Application
+
+# Phase 3 of docs/0.9.0/build-deploy-simplification-plan.md introduces
+# this workflow alongside the legacy docker.yml / lambda_api_python.yml
+# / lambda_counter.yml / react.yml pipeline. It builds every
+# application artifact in parallel and deploys directly to running
+# infrastructure via the AWS CLI - no Terraform on the deploy path.
+#
+# Trigger is workflow_dispatch only at this phase: the operator runs
+# this manually on dev to validate end-to-end behavior. Phase 6 will
+# add push triggers and delete the legacy workflows. Both pipelines
+# coexist briefly in between.
+
+on:
+  workflow_dispatch:
+    inputs:
+      areas:
+        description: >-
+          Comma-separated areas to build and deploy. Allowed values:
+          all, docker, lambda_api, lambda_counter, lambda_certbot,
+          react. Defaults to "all".
+        required: false
+        default: all
+        type: string
+
+permissions:
+  contents: read
+
+# Serialize per-ref so back-to-back app deploys roll services in order
+# rather than racing each other. Phase 3 of
+# docs/0.9.0/build-deploy-simplification-plan.md.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+      tiers: ${{ steps.matrix.outputs.tiers }}
+      docker: ${{ steps.areas.outputs.docker }}
+      lambda_api: ${{ steps.areas.outputs.lambda_api }}
+      lambda_counter: ${{ steps.areas.outputs.lambda_counter }}
+      lambda_certbot: ${{ steps.areas.outputs.lambda_certbot }}
+      react: ${{ steps.areas.outputs.react }}
+    steps:
+    - name: compute-tag
+      id: tag
+      run: echo "image_tag=sha-${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+    # Build only the docker tiers actually consumed by the current
+    # environment. Per phase 3 of the simplification plan, the
+    # monitoring stack (9 tiers) is dropped from the matrix when
+    # vars.TF_VAR_MONITORING != 'true' so we stop spending arm64 build
+    # minutes on images nothing deploys.
+    - name: compute-matrix
+      id: matrix
+      env:
+        MONITORING: ${{ vars.TF_VAR_MONITORING }}
+      run: |
+        CORE='["imap","smtp-in","smtp-out"]'
+        MON='["uptime-kuma","ntfy","healthchecks","prometheus","alertmanager","grafana","cloudwatch-exporter","blackbox-exporter","node-exporter"]'
+        if [ "${MONITORING}" = "true" ]; then
+          tiers="$(jq -cn --argjson c "$CORE" --argjson m "$MON" '$c + $m')"
+        else
+          tiers="$CORE"
+        fi
+        echo "tiers=${tiers}" >> "$GITHUB_OUTPUT"
+        echo "matrix tiers: ${tiers}"
+
+    - name: resolve-areas
+      id: areas
+      env:
+        AREAS: ${{ inputs.areas }}
+      run: |
+        set -euo pipefail
+        normalised="$(echo "${AREAS}" | tr -d '[:space:]')"
+        wanted=",${normalised},"
+        is_on() {
+          [ "${normalised}" = "all" ] && return 0
+          case "${wanted}" in *",$1,"*) return 0 ;; *) return 1 ;; esac
+        }
+        for a in docker lambda_api lambda_counter lambda_certbot react; do
+          if is_on "${a}"; then
+            echo "${a}=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "${a}=false" >> "$GITHUB_OUTPUT"
+          fi
+        done
+
+  docker:
+    needs: setup
+    if: needs.setup.outputs.docker == 'true'
+    runs-on: ubuntu-24.04-arm
+    environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        tier: ${{ fromJson(needs.setup.outputs.tiers) }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v5
+
+    - name: login-to-ecr
+      id: ecr
+      run: |
+        ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+        REGION=${{ secrets.AWS_REGION }}
+        REGISTRY="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+        aws ecr get-login-password --region "${REGION}" \
+          | docker login --username AWS --password-stdin "${REGISTRY}"
+        echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+
+    - name: set-up-buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: build-and-push
+      run: |
+        IMAGE="${{ steps.ecr.outputs.registry }}/cabal-${{ matrix.tier }}"
+        TAG="${{ needs.setup.outputs.image_tag }}"
+        docker buildx build \
+          --platform linux/arm64 \
+          --provenance=false \
+          -f docker/${{ matrix.tier }}/Dockerfile \
+          -t "${IMAGE}:${TAG}" \
+          --push \
+          docker/
+
+    # Out-of-band ECS deploy: clones running task def, rewrites the
+    # image tag for cabal-${tier}, registers a new revision, and rolls
+    # the service. See .github/scripts/deploy-ecs-service.sh.
+    - name: deploy
+      run: |
+        ./.github/scripts/deploy-ecs-service.sh \
+          "${{ matrix.tier }}" \
+          "${{ needs.setup.outputs.image_tag }}"
+
+  lambda-certbot:
+    needs: setup
+    if: needs.setup.outputs.lambda_certbot == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v5
+
+    - name: login-to-ecr
+      id: ecr
+      run: |
+        ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+        REGION=${{ secrets.AWS_REGION }}
+        REGISTRY="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+        aws ecr get-login-password --region "${REGION}" \
+          | docker login --username AWS --password-stdin "${REGISTRY}"
+        echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+
+    - name: set-up-buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: build-and-push
+      id: image
+      run: |
+        IMAGE="${{ steps.ecr.outputs.registry }}/cabal/certbot-renewal"
+        TAG="${{ needs.setup.outputs.image_tag }}"
+        docker buildx build \
+          --platform linux/arm64 \
+          --provenance=false \
+          -t "${IMAGE}:${TAG}" \
+          -t "${IMAGE}:latest" \
+          --push \
+          lambda/certbot-renewal/
+        echo "uri=${IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
+
+    - name: deploy
+      run: |
+        ./.github/scripts/deploy-lambda-image.sh \
+          cabal-certbot-renewal \
+          "${{ steps.image.outputs.uri }}"
+
+  lambda-api:
+    needs: setup
+    if: needs.setup.outputs.lambda_api == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v5
+
+    - name: pylint
+      run: pip install pylint && cd ./lambda/api && pylint --rcfile .pylintrc */function.py
+
+    - name: configure-aws
+      run: |
+        aws configure --profile deploy_lambda <<-EOF > /dev/null 2>&1
+        ${{ secrets.AWS_ACCESS_KEY_ID }}
+        ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        ${{ secrets.AWS_REGION }}
+        json
+        EOF
+
+    - name: build
+      env:
+        TF_VAR_CONTROL_DOMAIN: ${{ vars.TF_VAR_CONTROL_DOMAIN }}
+      run: ./.github/scripts/build-api.sh
+
+    # Out-of-band Lambda deploy. The api functions are registered with
+    # function_name == directory name (see modules/app/modules/call), so
+    # the dir name doubles as the AWS function name. The 'python' dir
+    # is the shared Lambda layer, not a function. healthchecks_iac is
+    # excluded for now: phase 2 left it on the legacy in-Terraform
+    # invocation flow because aws_lambda_invocation triggers on its
+    # source_code_hash and freezing that trigger would block config.py
+    # changes from propagating. Phase 3 leaves Terraform as the deploy
+    # path for healthchecks_iac (build-api.sh still uploads its zip);
+    # a follow-on swaps it to an explicit aws lambda invoke after a
+    # code deploy. Functions whose Terraform module is gated off in
+    # this environment (e.g. alert_sink and backup_heartbeat when
+    # vars.TF_VAR_MONITORING != 'true') do not exist in AWS; we skip
+    # them with a warning rather than fail the run, since build-api.sh
+    # uploads a zip for every directory unconditionally.
+    - name: deploy
+      env:
+        TF_VAR_CONTROL_DOMAIN: ${{ vars.TF_VAR_CONTROL_DOMAIN }}
+      run: |
+        BUCKET="admin.${TF_VAR_CONTROL_DOMAIN}"
+        FAILED=()
+        SKIPPED=()
+        for FUNC_DIR in lambda/api/*/ ; do
+          FUNC=$(basename "${FUNC_DIR}")
+          case "${FUNC}" in
+            python|healthchecks_iac) continue ;;
+          esac
+          if ! aws lambda get-function --function-name "${FUNC}" >/dev/null 2>&1; then
+            echo "::warning::function ${FUNC} not deployed in this environment; skipping"
+            SKIPPED+=("${FUNC}")
+            continue
+          fi
+          if ! ./.github/scripts/deploy-lambda-zip.sh "${FUNC}" "${BUCKET}"; then
+            FAILED+=("${FUNC}")
+          fi
+        done
+        if [ "${#SKIPPED[@]}" -gt 0 ]; then
+          echo "skipped (not deployed in this environment): ${SKIPPED[*]}"
+        fi
+        if [ "${#FAILED[@]}" -gt 0 ]; then
+          echo "::error::failed to deploy: ${FAILED[*]}"
+          exit 1
+        fi
+
+  lambda-counter:
+    needs: setup
+    if: needs.setup.outputs.lambda_counter == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v5
+
+    - name: pylint
+      run: pip install pylint && pylint --rcfile ./lambda/api/.pylintrc ./lambda/counter/*/function.py
+
+    - name: configure-aws
+      run: |
+        aws configure --profile deploy_lambda <<-EOF > /dev/null 2>&1
+        ${{ secrets.AWS_ACCESS_KEY_ID }}
+        ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        ${{ secrets.AWS_REGION }}
+        json
+        EOF
+
+    - name: build
+      env:
+        TF_VAR_CONTROL_DOMAIN: ${{ vars.TF_VAR_CONTROL_DOMAIN }}
+      run: ./.github/scripts/build-counter.sh
+
+    - name: deploy
+      env:
+        TF_VAR_CONTROL_DOMAIN: ${{ vars.TF_VAR_CONTROL_DOMAIN }}
+      run: |
+        BUCKET="admin.${TF_VAR_CONTROL_DOMAIN}"
+        ./.github/scripts/deploy-lambda-zip.sh assign_osid "${BUCKET}"
+
+  react:
+    needs: setup
+    if: needs.setup.outputs.react == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v5
+
+    - name: build
+      env:
+        NODE_ENV: ${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
+      run: cd react/admin && npm ci && npm run build
+
+    - name: upload
+      env:
+        TF_VAR_CONTROL_DOMAIN: ${{ vars.TF_VAR_CONTROL_DOMAIN }}
+      run: aws s3 sync react/admin/dist "s3://admin.${TF_VAR_CONTROL_DOMAIN}" --no-progress
+
+    - name: invalidate-cache
+      run: |
+        DIST_ID=$(aws ssm get-parameter \
+          --name "/cabal/react-config/cf-distribution" \
+          --query 'Parameter.Value' --output text)
+        aws cloudfront create-invalidation \
+          --distribution-id "${DIST_ID}" \
+          --paths '/*' >/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.2] - 2026-04-29
+## [0.9.3] - 2026-04-29
+
+### Added
+- Phase 3 of the build/deploy simplification plan
+  (`docs/0.9.0/build-deploy-simplification-plan.md`): new
+  `.github/workflows/app.yml` builds every application artifact in
+  parallel and deploys directly to running infrastructure via the AWS
+  CLI - no Terraform on the deploy path. Triggered on
+  `workflow_dispatch` only at this phase, with an `areas` input
+  (default `all`) that scopes the run to any subset of `docker`,
+  `lambda_api`, `lambda_counter`, `lambda_certbot`, `react`. The
+  legacy `docker.yml`, `lambda_api_python.yml`, `lambda_counter.yml`,
+  and `react.yml` keep running unchanged so both pipelines coexist
+  during validation; phase 6 cuts the legacy workflows over and adds
+  push triggers to `app.yml`. The docker matrix already drops the
+  nine monitoring tiers when `vars.TF_VAR_MONITORING != 'true'` so
+  manual validation does not pay arm64 build minutes for images
+  nothing deploys. `concurrency: { group: app-${{ github.ref }},
+  cancel-in-progress: false }` serialises overlapping app deploys per
+  ref so back-to-back runs roll services in order rather than racing.
+- `.github/scripts/deploy-ecs-service.sh` is the ECS half of the
+  out-of-band deploy path. Given a tier and an image tag it clones
+  the running task definition for `cabal-<tier>` on the `cabal-mail`
+  cluster, rewrites every container whose ECR repo basename is
+  `cabal-<tier>` to point at the new tag, registers a new revision
+  via `aws ecs register-task-definition`, and rolls the service via
+  `aws ecs update-service`. Phase 1's lifecycle clause
+  (`ignore_changes = [container_definitions]`) keeps a topology-only
+  Terraform apply from clobbering the new revision; phase 1's
+  `refresh-ssm-from-running.sh` keeps `/cabal/deployed_image_tag` in
+  lockstep with whatever the script just deployed.
+- `.github/scripts/deploy-lambda-zip.sh` and
+  `.github/scripts/deploy-lambda-image.sh` are the Lambda half. The
+  zip helper assumes `build-api.sh` / `build-counter.sh` has
+  uploaded `<func>.zip` and `<func>.zip.base64sha256` to
+  `s3://admin.${TF_VAR_CONTROL_DOMAIN}/lambda/`, then calls
+  `aws lambda update-function-code --s3-bucket ... --s3-key ...` and
+  waits for the update to settle. The image helper does the
+  equivalent for `cabal-certbot-renewal` via `--image-uri`. Both
+  refuse to deploy a function that does not yet exist in the account
+  so misconfigured runs fail loudly. The `lambda-api` deploy step in
+  `app.yml` walks every directory in `lambda/api/` except `python`
+  (the shared layer) and `healthchecks_iac` (kept on the legacy
+  in-Terraform invocation flow per phase 2's note).
+
+
 
 ### Changed
 - Phase 2 of the build/deploy simplification plan


### PR DESCRIPTION
Adds .github/workflows/app.yml plus three deploy helpers (deploy-ecs-service.sh, deploy-lambda-zip.sh, deploy-lambda-image.sh) so application artifacts can be built in parallel and deployed directly to running infrastructure via the AWS CLI - no Terraform on the deploy path. Trigger is workflow_dispatch only at this phase so the legacy docker.yml / lambda_api_python.yml / lambda_counter.yml / react.yml continue to handle pushes; phase 6 will cut over.