### PR TITLE
Phase 3 follow-ups: ECS service ignore_changes + deterministic builds

### DIFF
--- a/.github/scripts/build-api.sh
+++ b/.github/scripts/build-api.sh
@@ -1,12 +1,58 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Build a deterministic zip per lambda/api/<func> dir and upload it
+# to s3://admin.${TF_VAR_CONTROL_DOMAIN}/lambda/<func>.zip alongside
+# a base64sha256 sidecar.
+#
+# The "python" dir is the shared Lambda layer; its zip becomes a new
+# aws_lambda_layer_version every time its sha256 changes, which then
+# forces every aws_lambda_function that consumes the layer to rotate
+# its `layers` attribute. The build therefore has to be byte-stable
+# - same source in, same zip out - or every CI run produces a layer
+# version bump and Terraform churns through 30+ in-place Lambda
+# updates on the next plan.
+#
+# Sources of non-determinism we control here:
+#   - SOURCE_DATE_EPOCH: honored by zip, pip wheel builds, and most
+#     reproducible-build tooling.
+#   - --no-compile: stops pip from generating .pyc files, whose binary
+#     headers contain magic numbers that vary across Python builds.
+#   - PYTHONDONTWRITEBYTECODE=1: belt-and-braces against any import
+#     during install that might trigger compilation.
+#   - __pycache__/*.pyc purge: removes anything pip compiled despite
+#     the flags above.
+#   - direct_url.json purge: pip writes this per-package and it
+#     records the wheel's source URL, which differs between cache hits
+#     and cache misses.
+#   - chmod normalisation: ensures the zip's external-attribute field
+#     is identical regardless of what umask the runner started with.
+#   - LC_ALL=C sort: locale-stable filename ordering inside the zip.
+#   - touch -h: sets every entry's mtime to SOURCE_DATE_EPOCH without
+#     following symlinks.
+
+set -euo pipefail
+
 cd ./lambda/api
 AWS_S3_BUCKET="admin.${TF_VAR_CONTROL_DOMAIN}"
+
+# 2000-01-01 00:00 UTC. Any value past 1980 (zip's lower bound) works.
+export SOURCE_DATE_EPOCH=946684800
+export PYTHONDONTWRITEBYTECODE=1
+
 for FUNC in * ; do
-  pushd "${FUNC}"
-  pip install -r requirements.txt -t ./python 2>/dev/null || true
-  find . -exec touch -d "2004-02-29 16:21:42" \{\} \; -print | sort | zip -X -D ../$FUNC.zip -@
-  popd
-  openssl dgst -sha256 -binary "$FUNC.zip" | openssl enc -base64 | tr -d "\n" > "$FUNC.zip.base64sha256"
-  aws s3 cp "$FUNC.zip.base64sha256" "s3://${AWS_S3_BUCKET}/lambda/$FUNC.zip.base64sha256" --profile deploy_lambda --no-progress --acl private --content-type text/plain
+  [ -d "${FUNC}" ] || continue
+  pushd "${FUNC}" >/dev/null
+  rm -rf ./python
+  pip install --no-compile -r requirements.txt -t ./python 2>/dev/null || true
+  find . -depth -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+  find . -name '*.pyc' -delete 2>/dev/null || true
+  find . -name 'direct_url.json' -delete 2>/dev/null || true
+  find . -type d -exec chmod 0755 {} +
+  find . -type f -exec chmod 0644 {} +
+  find . -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
+  find . -type f -print | LC_ALL=C sort | zip -X -D -@ ../"${FUNC}.zip" >/dev/null
+  popd >/dev/null
+  openssl dgst -sha256 -binary "${FUNC}.zip" | openssl enc -base64 | tr -d "\n" > "${FUNC}.zip.base64sha256"
+  aws s3 cp "${FUNC}.zip.base64sha256" "s3://${AWS_S3_BUCKET}/lambda/${FUNC}.zip.base64sha256" --profile deploy_lambda --no-progress --acl private --content-type text/plain
   aws s3 cp "${FUNC}.zip" "s3://${AWS_S3_BUCKET}/lambda/${FUNC}.zip" --profile deploy_lambda --no-progress --acl private
 done

--- a/.github/scripts/build-counter.sh
+++ b/.github/scripts/build-counter.sh
@@ -1,11 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Build a deterministic zip for the assign_osid Cognito post-confirm
+# trigger and upload it to s3://admin.${TF_VAR_CONTROL_DOMAIN}/lambda/
+# alongside a base64sha256 sidecar. See build-api.sh for the rationale
+# behind each determinism knob.
+
+set -euo pipefail
+
 cd ./lambda/counter
 AWS_S3_BUCKET="admin.${TF_VAR_CONTROL_DOMAIN}"
+
+export SOURCE_DATE_EPOCH=946684800
+export PYTHONDONTWRITEBYTECODE=1
+
 FUNC=assign_osid
-pushd $FUNC
-pip install -r requirements.txt -t ./python 2>/dev/null || true
-find . -exec touch -d "2004-02-29 16:21:42" \{\} \; -print | sort | zip -X -D ../$FUNC.zip -@
-popd
-openssl dgst -sha256 -binary "$FUNC.zip" | openssl enc -base64 | tr -d "\n" > "$FUNC.zip.base64sha256"
-aws s3 cp "$FUNC.zip.base64sha256" "s3://${AWS_S3_BUCKET}/lambda/$FUNC.zip.base64sha256" --profile deploy_lambda --no-progress --acl private --content-type text/plain
+pushd "${FUNC}" >/dev/null
+rm -rf ./python
+pip install --no-compile -r requirements.txt -t ./python 2>/dev/null || true
+find . -depth -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+find . -name '*.pyc' -delete 2>/dev/null || true
+find . -name 'direct_url.json' -delete 2>/dev/null || true
+find . -type d -exec chmod 0755 {} +
+find . -type f -exec chmod 0644 {} +
+find . -exec touch -h -d "@${SOURCE_DATE_EPOCH}" {} +
+find . -type f -print | LC_ALL=C sort | zip -X -D -@ ../"${FUNC}.zip" >/dev/null
+popd >/dev/null
+openssl dgst -sha256 -binary "${FUNC}.zip" | openssl enc -base64 | tr -d "\n" > "${FUNC}.zip.base64sha256"
+aws s3 cp "${FUNC}.zip.base64sha256" "s3://${AWS_S3_BUCKET}/lambda/${FUNC}.zip.base64sha256" --profile deploy_lambda --no-progress --acl private --content-type text/plain
 aws s3 cp "${FUNC}.zip" "s3://${AWS_S3_BUCKET}/lambda/${FUNC}.zip" --profile deploy_lambda --no-progress --acl private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.3] - 2026-04-29
+## [0.9.3] - 2026-04-30
+
+### Changed
+- Phase 1 follow-up: every `aws_ecs_service` (3 mail-tier services in
+  `terraform/infra/modules/ecs/services.tf` plus 9 monitoring
+  services across `modules/monitoring/`) now has `lifecycle {
+  ignore_changes = [task_definition] }`. Phase 1 ignored
+  `container_definitions` on the task-def resources, but the
+  services still referenced `aws_ecs_task_definition.<name>.arn`,
+  so after `app.yml` registered a new revision out-of-band and
+  rolled the service forward, every subsequent Terraform plan
+  wanted to roll the service back to the (state-bound) revision the
+  task-def resource was last applied at. Trade-off: a Terraform
+  topology change (cpu/memory/env/IAM) that registers a new
+  revision will not auto-roll the service either; phase 5's
+  `infra.yml` will add a post-apply `update-service` step keyed off
+  the freshly-registered revision.
+- `build-api.sh` and `build-counter.sh` now produce byte-stable zips
+  for the same source tree across runs. The python Lambda layer
+  (`lambda/api/python/`) was the chokepoint: a non-deterministic
+  zip meant the layer's `source_code_hash` changed on every CI run,
+  forcing a new `aws_lambda_layer_version` and a 30+ Lambda
+  in-place update on the next Terraform plan to rotate every
+  function's `layers` attribute. Build now sets
+  `SOURCE_DATE_EPOCH`, passes `pip install --no-compile`, scrubs
+  `__pycache__/*.pyc/direct_url.json`, normalises file modes
+  (0755 dirs / 0644 files), and sorts under `LC_ALL=C`. Same
+  source-and-pinned-deps now yields the same zip bytes.
 
 ### Added
 - Phase 3 of the build/deploy simplification plan

--- a/terraform/infra/modules/ecs/services.tf
+++ b/terraform/infra/modules/ecs/services.tf
@@ -45,6 +45,20 @@ resource "aws_ecs_service" "imap" {
   }
 
   depends_on = [aws_ecs_cluster_capacity_providers.mail]
+
+  # Phase 1 follow-up of docs/0.9.0/build-deploy-simplification-plan.md:
+  # app.yml registers a new task-def revision out-of-band and rolls
+  # the service to it via aws ecs update-service. Without this clause
+  # Terraform sees AWS on revision N+1 and the (state-bound) reference
+  # aws_ecs_task_definition.imap.arn at revision N, and plans to roll
+  # the service back. Trade-off: a Terraform-driven topology change
+  # (cpu/memory/env/IAM) that registers a new revision will not
+  # auto-roll the service either; phase 5's infra.yml will add a
+  # post-apply update-service step keyed off the freshly-registered
+  # revision.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }
 
 # -- SMTP-IN service -------------------------------------------
@@ -77,6 +91,11 @@ resource "aws_ecs_service" "smtp_in" {
   }
 
   depends_on = [aws_ecs_cluster_capacity_providers.mail]
+
+  # See aws_ecs_service.imap for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }
 
 # -- SMTP-OUT service ------------------------------------------
@@ -115,6 +134,11 @@ resource "aws_ecs_service" "smtp_out" {
   }
 
   depends_on = [aws_ecs_cluster_capacity_providers.mail]
+
+  # See aws_ecs_service.imap for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }
 
 # -- Auto-scaling: SMTP-IN ------------------------------------

--- a/terraform/infra/modules/monitoring/alertmanager.tf
+++ b/terraform/infra/modules/monitoring/alertmanager.tf
@@ -181,4 +181,9 @@ resource "aws_ecs_service" "alertmanager" {
   service_registries {
     registry_arn = aws_service_discovery_service.monitoring["alertmanager"].arn
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }

--- a/terraform/infra/modules/monitoring/exporters.tf
+++ b/terraform/infra/modules/monitoring/exporters.tf
@@ -137,6 +137,11 @@ resource "aws_ecs_service" "cloudwatch_exporter" {
   service_registries {
     registry_arn = aws_service_discovery_service.monitoring["cloudwatch-exporter"].arn
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }
 
 # -- blackbox_exporter ----------------------------------------
@@ -235,6 +240,11 @@ resource "aws_ecs_service" "blackbox_exporter" {
 
   service_registries {
     registry_arn = aws_service_discovery_service.monitoring["blackbox-exporter"].arn
+  }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
   }
 }
 
@@ -373,5 +383,10 @@ resource "aws_ecs_service" "node_exporter" {
     registry_arn   = aws_service_discovery_service.node_exporter.arn
     container_name = "node-exporter"
     container_port = 9100
+  }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
   }
 }

--- a/terraform/infra/modules/monitoring/grafana.tf
+++ b/terraform/infra/modules/monitoring/grafana.tf
@@ -229,4 +229,9 @@ resource "aws_ecs_service" "grafana" {
   service_registries {
     registry_arn = aws_service_discovery_service.monitoring["grafana"].arn
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }

--- a/terraform/infra/modules/monitoring/healthchecks.tf
+++ b/terraform/infra/modules/monitoring/healthchecks.tf
@@ -286,4 +286,9 @@ resource "aws_ecs_service" "healthchecks" {
   service_registries {
     registry_arn = aws_service_discovery_service.monitoring["healthchecks"].arn
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }

--- a/terraform/infra/modules/monitoring/kuma.tf
+++ b/terraform/infra/modules/monitoring/kuma.tf
@@ -178,4 +178,9 @@ resource "aws_ecs_service" "kuma" {
     container_name   = "uptime-kuma"
     container_port   = 3001
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }

--- a/terraform/infra/modules/monitoring/ntfy.tf
+++ b/terraform/infra/modules/monitoring/ntfy.tf
@@ -196,4 +196,9 @@ resource "aws_ecs_service" "ntfy" {
     container_name   = "ntfy"
     container_port   = 80
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }

--- a/terraform/infra/modules/monitoring/prometheus.tf
+++ b/terraform/infra/modules/monitoring/prometheus.tf
@@ -167,4 +167,9 @@ resource "aws_ecs_service" "prometheus" {
   service_registries {
     registry_arn = aws_service_discovery_service.monitoring["prometheus"].arn
   }
+
+  # See aws_ecs_service.imap in modules/ecs/services.tf for rationale.
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
 }


### PR DESCRIPTION
Two fixes that surfaced during phase 3 validation on dev.

The ECS half is a phase 1 gap: container_definitions ignore_changes on the task-def resources kept Terraform from re-registering on out-of-band image bumps, but the services still pointed at aws_ecs_task_definition.<name>.arn and TF wanted to roll them back to the in-state revision after app.yml rolled them forward. Adding lifecycle { ignore_changes = [task_definition] } to all 12 ECS services closes the loop. Topology-driven re-rolls become a post-apply concern for phase 5's infra.yml.

The Lambda half is build determinism: the python layer's source_code_hash drifted every CI run because pip leaves __pycache__, direct_url.json, and variable file modes behind. Each drift forced a new aws_lambda_layer_version, which in turn rotated `layers` on every consumer function and lit up 30+ in-place updates in the next plan. Builds now set SOURCE_DATE_EPOCH, --no-compile, and scrub the non-stable artifacts so the same source produces the same zip.