### PR TITLE
Fix IMAP endpoint crash and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to just the three core docker tiers - so prod runs were quietly
   skipping all nine monitoring tier builds even with monitoring
   enabled.
+- Webmail message list (and every other IMAP-backed endpoint) was
+  failing because the deterministic-build follow-up to phase 2
+  (`bff24dcf`) added `rm -rf ./python` before each `pip install` in
+  `.github/scripts/build-api.sh`. For the shared Lambda layer at
+  `lambda/api/python/`, that wipe also deleted the layer's only
+  first-party module - `python/python/helper.py` - leaving the
+  rebuilt layer zip with only the third-party deps. Every Lambda
+  that does `from helper import …` (`list_messages`,
+  `list_envelopes`, `fetch_message`, `send`, the folder/flag/move
+  endpoints, and the IMAP-touching `revoke`) then crashed at import
+  with `ModuleNotFoundError`, while the dedicated IMAP/SMTP servers
+  - which never touched this code path - kept working. Fix moves
+  the layer's first-party sources to a sibling `lambda/api/python/src/`
+  directory that the wipe never sees and copies `./src/.` into
+  `./python/` after `pip install` finishes, so the layer ships both
+  third-party deps and `helper.py`. Issue #346.
 
 ### Changed
 - `lambda-api` build and deploy are now parallel. `build-api.sh` was
@@ -123,24 +139,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through `infra.yml` and app deploys flow through `app.yml`.
 
 ## [0.9.3] - 2026-04-30
-
-### Fixed
-- Webmail message list (and every other IMAP-backed endpoint) was
-  failing because the deterministic-build follow-up to phase 2
-  (`bff24dcf`) added `rm -rf ./python` before each `pip install` in
-  `.github/scripts/build-api.sh`. For the shared Lambda layer at
-  `lambda/api/python/`, that wipe also deleted the layer's only
-  first-party module - `python/python/helper.py` - leaving the
-  rebuilt layer zip with only the third-party deps. Every Lambda
-  that does `from helper import …` (`list_messages`,
-  `list_envelopes`, `fetch_message`, `send`, the folder/flag/move
-  endpoints, and the IMAP-touching `revoke`) then crashed at import
-  with `ModuleNotFoundError`, while the dedicated IMAP/SMTP servers
-  - which never touched this code path - kept working. Fix moves
-  the layer's first-party sources to a sibling `lambda/api/python/src/`
-  directory that the wipe never sees and copies `./src/.` into
-  `./python/` after `pip install` finishes, so the layer ships both
-  third-party deps and `helper.py`. Issue #346.
 
 ### Changed
 - Phase 1 follow-up: every `aws_ecs_service` (3 mail-tier services in


### PR DESCRIPTION
Fix issue with webmail message list and IMAP endpoints caused by removal of first-party module during build. Update changelog to reflect changes in version 0.9.3.