### PR TITLE
Raise --max-turns for Claude Code workflow jobs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,7 +52,7 @@ jobs:
           # --permission-mode bypassPermissions: required in CI so Claude
           # can run git/gh commands without being blocked by interactive
           # permission prompts (which silently deny when no human is present).
-          claude_args: "--model claude-opus-4-7 --max-turns 75 --permission-mode bypassPermissions"
+          claude_args: "--model claude-opus-4-7 --max-turns 200 --permission-mode bypassPermissions"
 
           prompt: |
             A new issue was filed in this repository and labeled `claude`,
@@ -117,4 +117,4 @@ jobs:
 
           # Tighter turn cap for iteration: comment threads should be focused.
           # Bump if you find Claude running out of room on substantive changes.
-          claude_args: "--model claude-opus-4-7 --max-turns 75 --permission-mode bypassPermissions"
+          claude_args: "--model claude-opus-4-7 --max-turns 100 --permission-mode bypassPermissions"


### PR DESCRIPTION
The 75-turn cap was tripping the labeled-issue path on non-trivial PR drafts. Raise to 200 for issue-to-PR work and 100 for @claude mention iteration. No per-turn cost; this is a runaway-loop guardrail, not a budget.