### PR TITLE
Fix SwiftLint nesting violations in URLSessionApiClient+Messages

### DIFF
--- a/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Messages.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Messages.swift
@@ -6,25 +6,30 @@ import Foundation
 // helpers (`get`, `post`, `put`, `delete`, `send`) declared on the actor
 // in that file.
 
+// MARK: - Decodable payload wrappers
+//
+// Kept at file scope rather than nested inside the extension so the
+// `CodingKeys` enums sit one level deep (the SwiftLint `nesting` rule
+// allows a single level of type nesting and counts the enclosing type
+// in the level depth).
+
+private struct MessageIdsPayload: Decodable {
+    let messageIds: [UInt32]
+
+    private enum CodingKeys: String, CodingKey {
+        case messageIds = "message_ids"
+    }
+}
+
+private struct MessageIdsOptionalPayload: Decodable {
+    let messageIds: [UInt32]?
+
+    private enum CodingKeys: String, CodingKey {
+        case messageIds = "message_ids"
+    }
+}
+
 extension URLSessionApiClient {
-    // MARK: - Decodable payload wrappers
-
-    fileprivate struct MessageIdsPayload: Decodable {
-        let messageIds: [UInt32]
-
-        private enum CodingKeys: String, CodingKey {
-            case messageIds = "message_ids"
-        }
-    }
-
-    fileprivate struct MessageIdsOptionalPayload: Decodable {
-        let messageIds: [UInt32]?
-
-        private enum CodingKeys: String, CodingKey {
-            case messageIds = "message_ids"
-        }
-    }
-
     // MARK: - Messages
 
     public func listMessageIds(


### PR DESCRIPTION
Move `MessageIdsPayload` and `MessageIdsOptionalPayload` from inside the `extension URLSessionApiClient` block to file scope so their nested `CodingKeys` enums sit at one level deep instead of two. SwiftLint's default `nesting` rule (`type_level: 1`) was flagging the enums because the parent extension type already counts as the first level.

Refs #371.