### PR TITLE
Strip wrapping quotes from IMAP envelope display names

### DIFF
--- a/apple/Cabalmail/Views/MessageListView.swift
+++ b/apple/Cabalmail/Views/MessageListView.swift
@@ -249,7 +249,7 @@ private struct MessageRow: View {
     }
 
     private var senderLabel: String {
-        envelope.from.first?.name ?? envelope.from.first?.mailbox ?? "unknown"
+        envelope.from.first?.displayName ?? envelope.from.first?.mailbox ?? "unknown"
     }
 
     private var dateLabel: String {

--- a/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ImapParserHelpers.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ImapParserHelpers.swift
@@ -56,13 +56,26 @@ extension ImapParser {
                 return addresses
             }
             _ = tokenizer.next() // consume lparen
-            let name = readNString(&tokenizer).map(HeaderDecoder.decode)
+            let name = readNString(&tokenizer)
+                .map(HeaderDecoder.decode)
+                .map(stripSurroundingQuotes)
             _ = readNString(&tokenizer) // source-route, effectively obsolete
             let mailbox = readNString(&tokenizer) ?? ""
             let host = readNString(&tokenizer) ?? ""
             consumeClose(&tokenizer)
             addresses.append(EmailAddress(name: name, mailbox: mailbox, host: host))
         }
+    }
+
+    // Dovecot (and some other servers) return the RFC 5322 phrase verbatim in
+    // the ENVELOPE addr-name slot, so a `From: "Alice Smith" <a@x>` arrives
+    // here with literal `"` characters wrapping the name. Strip a balanced
+    // pair so display matches the React client's presentation.
+    static func stripSurroundingQuotes(_ value: String) -> String {
+        guard value.count >= 2,
+              value.first == "\"",
+              value.last == "\"" else { return value }
+        return String(value.dropFirst().dropLast())
     }
 }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/Envelope.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/Envelope.swift
@@ -12,10 +12,24 @@ public struct EmailAddress: Sendable, Codable, Hashable {
         self.host = host
     }
 
+    /// Display name with any wrapping double-quotes stripped. Some IMAP
+    /// servers return the RFC 5322 phrase verbatim in addr-name (Dovecot
+    /// for one), so a `From: "Alice Smith" <a@x>` would otherwise render
+    /// as `"Alice Smith"` in the UI. The parser also strips these on the
+    /// way in; this property is a defense for cached envelopes captured
+    /// before that change.
+    public var displayName: String? {
+        guard let name, !name.isEmpty else { return nil }
+        if name.count >= 2, name.first == "\"", name.last == "\"" {
+            return String(name.dropFirst().dropLast())
+        }
+        return name
+    }
+
     public var formatted: String {
         let addr = "\(mailbox)@\(host)"
-        if let name, !name.isEmpty {
-            return "\"\(name)\" <\(addr)>"
+        if let displayName {
+            return "\"\(displayName)\" <\(addr)>"
         }
         return addr
     }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ImapParserTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ImapParserTests.swift
@@ -102,6 +102,29 @@ final class ImapParserTests: XCTestCase {
         XCTAssertEqual(attrs.envelope?.from.first?.name, "Björn")
     }
 
+    func testFetchEnvelopeStripsWrappingQuotesFromAddressName() {
+        // Dovecot returns the RFC 5322 phrase verbatim in addr-name; the
+        // parser must strip the surrounding double-quotes so the React
+        // and Apple clients render the same display name.
+        let line = Data([
+            #"* 1 FETCH (UID 7 ENVELOPE (NIL "hi" "#,
+            #"(("\"Alice Smith\"" NIL "alice" "example.com")) "#,
+            #"NIL NIL NIL NIL NIL NIL NIL))"#,
+        ].joined().utf8)
+        guard case let .fetch(_, attrs) = ImapParser.parse(line: line, literals: []) else {
+            return XCTFail("Expected fetch response")
+        }
+        XCTAssertEqual(attrs.envelope?.from.first?.name, "Alice Smith")
+    }
+
+    func testEmailAddressDisplayNameStripsCachedQuotes() {
+        // Defends rendering against pre-fix cached envelopes whose `name`
+        // field still contains the wrapping double-quotes.
+        let address = EmailAddress(name: "\"Alice Smith\"", mailbox: "alice", host: "example.com")
+        XCTAssertEqual(address.displayName, "Alice Smith")
+        XCTAssertEqual(address.formatted, "\"Alice Smith\" <alice@example.com>")
+    }
+
     func testContinuationResponse() {
         let line = Data("+ OK continue".utf8)
         if case let .continuation(text) = ImapParser.parse(line: line, literals: []) {


### PR DESCRIPTION
Dovecot returns the RFC 5322 phrase verbatim in the ENVELOPE addr-name slot, so a `From: "Alice Smith" <a@x>` arrived in the Apple client with literal `"` characters wrapping the name and rendered as `"Alice Smith"` in the message list. The React client strips these before rendering; norm on that presentation.

Strip a balanced pair of wrapping double-quotes in the IMAP parser so the on-disk envelope cache stores clean names going forward, and add a defensive `EmailAddress.displayName` for envelopes that were cached before this change. `formatted` (used by `ReplyBuilder` for RFC 5322 header generation) routes through `displayName` so it no longer double-quotes a name that already had quotes from the cache.

Refs #376