### PR TITLE
Split MessageDetailView/-ViewModel to clear SwiftLint length caps

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageDetailViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageDetailViewModel.swift
@@ -292,10 +292,18 @@ final class MessageDetailViewModel {
     /// render the right icon and label without reaching into the preferences
     /// environment itself.
     var disposeAction: DisposeAction { preferences.disposeAction }
+}
 
-    // MARK: - Internals
+// MARK: - Internals
+//
+// Body-fetch, MIME parsing, and attachment-extraction helpers live in a
+// same-file extension so the primary class body stays under SwiftLint's
+// type_body_length cap. They remain `private` (file-scoped) and reach
+// stored properties (`client`, `folder`, `envelope`) through the type's
+// `@MainActor` isolation, inherited by the extension.
 
-    private func fetchBodyBytes() async throws -> Data {
+private extension MessageDetailViewModel {
+    func fetchBodyBytes() async throws -> Data {
         let uidValidity = try await currentUIDValidity()
         if let cached = await client.bodyCache.fetch(
             folder: folder.path,
@@ -315,7 +323,7 @@ final class MessageDetailViewModel {
         return raw.bytes
     }
 
-    private func currentUIDValidity() async throws -> UInt32 {
+    func currentUIDValidity() async throws -> UInt32 {
         if let snapshot = await client.envelopeCache.snapshot(for: folder.path) {
             return snapshot.uidValidity
         }
@@ -323,7 +331,7 @@ final class MessageDetailViewModel {
         return status.uidValidity ?? 0
     }
 
-    private func hydrate(from root: MimePart) async throws {
+    func hydrate(from root: MimePart) async throws {
         if let plain = root.firstPart(where: { $0.contentType.mimeType == "text/plain" }) {
             plainText = plain.textContent()
         }
@@ -354,7 +362,7 @@ final class MessageDetailViewModel {
         inlineImages = inlineMap
     }
 
-    private func isAttachmentLike(_ part: MimePart) -> Bool {
+    func isAttachmentLike(_ part: MimePart) -> Bool {
         if part.contentDisposition?.isAttachment == true { return true }
         if part.contentType.isText, part.contentType.subtype == "plain" { return false }
         if part.contentType.isText, part.contentType.subtype == "html" { return false }
@@ -364,7 +372,7 @@ final class MessageDetailViewModel {
     /// Writes a decoded part to the app's temp directory. Phase-7 polish can
     /// replace this with a size-bounded managed directory; for Phase 4 we
     /// rely on the OS sweeping `/tmp` between launches.
-    private func writeToTmp(data: Data, filename: String) throws -> URL {
+    func writeToTmp(data: Data, filename: String) throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cabalmail-attachments-\(envelope.uid)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/apple/Cabalmail/Views/MessageDetailView+Toolbar.swift
+++ b/apple/Cabalmail/Views/MessageDetailView+Toolbar.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import CabalmailKit
+
+// Toolbar-button builders and dispose helpers for `MessageDetailView`. Lifted
+// out of `MessageDetailView.swift` so that file stays under SwiftLint's
+// 400-line file_length cap; the buttons all read state off the view's
+// `model` and route their actions back through it.
+
+extension MessageDetailView {
+    @ViewBuilder
+    var replyButton: some View {
+        Menu {
+            Button {
+                beginCompose(.reply)
+            } label: {
+                Label("Reply", systemImage: "arrowshape.turn.up.left")
+            }
+            .keyboardShortcut("r", modifiers: .command)
+            Button {
+                beginCompose(.replyAll)
+            } label: {
+                Label("Reply All", systemImage: "arrowshape.turn.up.left.2")
+            }
+            .keyboardShortcut("d", modifiers: [.command, .shift])
+            Button {
+                beginCompose(.forward)
+            } label: {
+                Label("Forward", systemImage: "arrowshape.turn.up.forward")
+            }
+            .keyboardShortcut("j", modifiers: [.command, .shift])
+        } label: {
+            Image(systemName: "arrowshape.turn.up.left")
+                .accessibilityLabel("Reply")
+        }
+    }
+
+    @ViewBuilder
+    var seenButton: some View {
+        if let model {
+            Button {
+                Task { await model.toggleSeen() }
+            } label: {
+                // Icon reflects the current state; tap-action is the
+                // inverse. Matches Mail.app: an already-read message
+                // shows "envelope.open" and tapping marks it unread.
+                Image(systemName: model.isSeen ? "envelope.open" : "envelope.badge")
+                    .accessibilityLabel(model.isSeen ? "Mark as unread" : "Mark as read")
+            }
+        }
+    }
+
+    @ViewBuilder
+    var flagButton: some View {
+        if let model {
+            Button {
+                Task { await model.toggleFlagged() }
+            } label: {
+                Image(systemName: model.isFlagged ? "flag.slash" : "flag")
+                    .accessibilityLabel(model.isFlagged ? "Unflag" : "Flag")
+            }
+        }
+    }
+
+    @ViewBuilder
+    var remoteContentButton: some View {
+        if let model, model.htmlBody != nil {
+            Button {
+                model.toggleRemoteContent()
+            } label: {
+                Image(systemName: model.remoteContentAllowed
+                      ? "eye.fill"
+                      : "eye.slash")
+                    .accessibilityLabel(
+                        model.remoteContentAllowed
+                        ? "Hide remote content"
+                        : "Show remote content"
+                    )
+            }
+        }
+    }
+
+    @ViewBuilder
+    var readerModeButton: some View {
+        if let model, model.htmlBody != nil {
+            Button {
+                model.toggleReaderMode()
+            } label: {
+                Image(systemName: model.readerMode
+                      ? "text.alignleft"
+                      : "doc.richtext")
+                    .accessibilityLabel(
+                        model.readerMode
+                        ? "Show original formatting"
+                        : "Show reader view"
+                    )
+            }
+        }
+    }
+
+    @ViewBuilder
+    var disposeButton: some View {
+        if let model {
+            Button(role: disposeRole(for: model.disposeAction)) {
+                Task {
+                    await model.dispose(
+                        onSuccess: {
+                            // Fires before the server round trip so the
+                            // list selection advances and the row vanishes
+                            // instantly.
+                            appState.signalDisposed(
+                                folderPath: folder.path,
+                                uid: envelope.uid
+                            )
+                        },
+                        onFailure: { error in
+                            // The optimistic prune has already happened
+                            // upstream; surface a toast so the user knows
+                            // the move didn't take and can retry on the
+                            // next refresh.
+                            appState.showToast(Toast(
+                                kind: .error,
+                                message: failureMessage(for: model.disposeAction, error: error)
+                            ))
+                        }
+                    )
+                }
+            } label: {
+                disposeToolbarLabel(for: model.disposeAction)
+            }
+        }
+    }
+
+    @ViewBuilder
+    func disposeToolbarLabel(for action: DisposeAction) -> some View {
+        switch action {
+        case .archive:
+            Image(systemName: "archivebox")
+                .accessibilityLabel("Archive")
+        case .trash:
+            Image(systemName: "trash")
+                .accessibilityLabel("Delete")
+        }
+    }
+
+    func disposeRole(for action: DisposeAction) -> ButtonRole? {
+        switch action {
+        case .archive: return nil
+        case .trash:   return .destructive
+        }
+    }
+
+    func failureMessage(for action: DisposeAction, error: Error) -> String {
+        let verb: String
+        switch action {
+        case .archive: verb = "archive"
+        case .trash:   verb = "delete"
+        }
+        return "Couldn't \(verb) message: \(error.localizedDescription)"
+    }
+}

--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -17,10 +17,14 @@ struct MessageDetailView: View {
     let folder: Folder
     let envelope: Envelope
 
-    @Environment(AppState.self) private var appState
+    // `appState` and `model` are reached by the toolbar extension in
+    // `MessageDetailView+Toolbar.swift`; SwiftUI's `private` in this struct
+    // would block access from that file. Kept `internal` (default) and not
+    // exposed beyond the module.
+    @Environment(AppState.self) var appState
     @Environment(Preferences.self) private var preferences
     @Environment(\.openWindow) private var openWindow
-    @State private var model: MessageDetailViewModel?
+    @State var model: MessageDetailViewModel?
     @State private var composeSeed: Draft?
 
     var body: some View {
@@ -117,7 +121,7 @@ struct MessageDetailView: View {
     /// Pulls the user's address list so `ReplyBuilder` can pick a default
     /// From by matching the original message's recipients against owned
     /// addresses (per the React app's 0.3.0 behavior).
-    private func beginCompose(_ mode: ReplyBuilder.ReplyMode) {
+    func beginCompose(_ mode: ReplyBuilder.ReplyMode) {
         guard let client = appState.client else { return }
         Task { @MainActor in
             let addresses = (try? await client.addresses()) ?? []
@@ -248,157 +252,6 @@ struct MessageDetailView: View {
 
 }
 
-// Toolbar-button builders and dispose helpers split into an extension so the
-// primary view body stays under SwiftLint's 250-line cap.
-extension MessageDetailView {
-    @ViewBuilder
-    var replyButton: some View {
-        Menu {
-            Button {
-                beginCompose(.reply)
-            } label: {
-                Label("Reply", systemImage: "arrowshape.turn.up.left")
-            }
-            .keyboardShortcut("r", modifiers: .command)
-            Button {
-                beginCompose(.replyAll)
-            } label: {
-                Label("Reply All", systemImage: "arrowshape.turn.up.left.2")
-            }
-            .keyboardShortcut("d", modifiers: [.command, .shift])
-            Button {
-                beginCompose(.forward)
-            } label: {
-                Label("Forward", systemImage: "arrowshape.turn.up.forward")
-            }
-            .keyboardShortcut("j", modifiers: [.command, .shift])
-        } label: {
-            Image(systemName: "arrowshape.turn.up.left")
-                .accessibilityLabel("Reply")
-        }
-    }
-
-    @ViewBuilder
-    var seenButton: some View {
-        if let model {
-            Button {
-                Task { await model.toggleSeen() }
-            } label: {
-                // Icon reflects the current state; tap-action is the
-                // inverse. Matches Mail.app: an already-read message
-                // shows "envelope.open" and tapping marks it unread.
-                Image(systemName: model.isSeen ? "envelope.open" : "envelope.badge")
-                    .accessibilityLabel(model.isSeen ? "Mark as unread" : "Mark as read")
-            }
-        }
-    }
-
-    @ViewBuilder
-    var flagButton: some View {
-        if let model {
-            Button {
-                Task { await model.toggleFlagged() }
-            } label: {
-                Image(systemName: model.isFlagged ? "flag.slash" : "flag")
-                    .accessibilityLabel(model.isFlagged ? "Unflag" : "Flag")
-            }
-        }
-    }
-
-    @ViewBuilder
-    var remoteContentButton: some View {
-        if let model, model.htmlBody != nil {
-            Button {
-                model.toggleRemoteContent()
-            } label: {
-                Image(systemName: model.remoteContentAllowed
-                      ? "eye.fill"
-                      : "eye.slash")
-                    .accessibilityLabel(
-                        model.remoteContentAllowed
-                        ? "Hide remote content"
-                        : "Show remote content"
-                    )
-            }
-        }
-    }
-
-    @ViewBuilder
-    var readerModeButton: some View {
-        if let model, model.htmlBody != nil {
-            Button {
-                model.toggleReaderMode()
-            } label: {
-                Image(systemName: model.readerMode
-                      ? "text.alignleft"
-                      : "doc.richtext")
-                    .accessibilityLabel(
-                        model.readerMode
-                        ? "Show original formatting"
-                        : "Show reader view"
-                    )
-            }
-        }
-    }
-
-    @ViewBuilder
-    var disposeButton: some View {
-        if let model {
-            Button(role: disposeRole(for: model.disposeAction)) {
-                Task {
-                    await model.dispose(
-                        onSuccess: {
-                            // Fires before the server round trip so the
-                            // list selection advances and the row vanishes
-                            // instantly.
-                            appState.signalDisposed(
-                                folderPath: folder.path,
-                                uid: envelope.uid
-                            )
-                        },
-                        onFailure: { error in
-                            // The optimistic prune has already happened
-                            // upstream; surface a toast so the user knows
-                            // the move didn't take and can retry on the
-                            // next refresh.
-                            appState.showToast(Toast(
-                                kind: .error,
-                                message: failureMessage(for: model.disposeAction, error: error)
-                            ))
-                        }
-                    )
-                }
-            } label: {
-                disposeToolbarLabel(for: model.disposeAction)
-            }
-        }
-    }
-
-    @ViewBuilder
-    func disposeToolbarLabel(for action: DisposeAction) -> some View {
-        switch action {
-        case .archive:
-            Image(systemName: "archivebox")
-                .accessibilityLabel("Archive")
-        case .trash:
-            Image(systemName: "trash")
-                .accessibilityLabel("Delete")
-        }
-    }
-
-    func disposeRole(for action: DisposeAction) -> ButtonRole? {
-        switch action {
-        case .archive: return nil
-        case .trash:   return .destructive
-        }
-    }
-
-    func failureMessage(for action: DisposeAction, error: Error) -> String {
-        let verb: String
-        switch action {
-        case .archive: verb = "archive"
-        case .trash:   verb = "delete"
-        }
-        return "Couldn't \(verb) message: \(error.localizedDescription)"
-    }
-}
+// Toolbar-button builders and dispose helpers live in
+// `MessageDetailView+Toolbar.swift` so this file stays under SwiftLint's
+// 400-line file_length cap.


### PR DESCRIPTION
The PR #405 follow-up landed on stage at 404 lines for `MessageDetailView.swift` and a 251-line class body for `MessageDetailViewModel`, both 1 line over SwiftLint's defaults. The `apple.yml` job runs `swiftlint --strict`, so warnings become errors.

- Move the toolbar/dispose extension out of `MessageDetailView.swift` into a sibling `MessageDetailView+Toolbar.swift`. The view's `appState`, `model`, and `beginCompose(_:)` lose `private` so the cross-file extension can reach them (same pattern used by `MessageListViewModel+*.swift`).
- Move the private body-fetch / MIME / attachment helpers in `MessageDetailViewModel` into a same-file `private extension`. They remain file-scoped and continue to inherit `@MainActor` isolation from the type.

No behavior change. `swiftlint --strict` clean, CabalmailKit `swift test` 132/132, iOS and macOS `xcodebuild` BUILD SUCCEEDED.