### PR TITLE
Add use_eum_sms flag; fix terraform apply freeze on missing Twilio creds

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -295,13 +295,9 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      # Twilio: the first three are picked up by the twilio Terraform
-      # provider; the TF_VAR_* values feed the sms_sender module's SSM
-      # SecureString params. Empty defaults in variables.tf keep envs
-      # without Twilio secrets working.
-      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
-      TWILIO_API_KEY: ${{ secrets.TWILIO_API_KEY }}
-      TWILIO_API_SECRET: ${{ secrets.TWILIO_API_SECRET }}
+      # Twilio: TF_VAR_* values feed the sms_sender module's SSM
+      # SecureString params. Only consumed when var.use_twilio_sms
+      # is true; harmless empty strings otherwise.
       TF_VAR_twilio_account_sid: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TF_VAR_twilio_api_key: ${{ secrets.TWILIO_API_KEY }}
       TF_VAR_twilio_api_secret: ${{ secrets.TWILIO_API_SECRET }}
@@ -350,6 +346,7 @@ jobs:
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
         echo "quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}" >> terraform.tfvars
         echo "use_twilio_sms = ${{ vars.TF_VAR_USE_TWILIO_SMS || 'false' }}" >> terraform.tfvars
+        echo "use_eum_sms = ${{ vars.TF_VAR_USE_EUM_SMS || 'false' }}" >> terraform.tfvars
     - name: init-terraform
       run: terraform init
     - name: record-lambda-hashes
@@ -416,6 +413,7 @@ jobs:
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
         echo "quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}" >> terraform.tfvars
         echo "use_twilio_sms = ${{ vars.TF_VAR_USE_TWILIO_SMS || 'false' }}" >> terraform.tfvars
+        echo "use_eum_sms = ${{ vars.TF_VAR_USE_EUM_SMS || 'false' }}" >> terraform.tfvars
     - name: init-terraform
       run: terraform init
     - name: record-lambda-hashes
@@ -432,7 +430,7 @@ jobs:
         if [ $TF_EXIT -ne 0 ]; then
           if grep -q 'aws_pinpointsmsvoicev2_phone_number.sms' /tmp/tf-apply.log && grep -q "timeout while waiting for state to become 'ACTIVE'" /tmp/tf-apply.log; then
             echo "::warning::Toll-free number provisioning timed out. Untainting resource for next run."
-            terraform untaint 'module.pool.aws_pinpointsmsvoicev2_phone_number.sms'
+            terraform untaint 'module.pool.aws_pinpointsmsvoicev2_phone_number.sms[0]'
             exit 0
           fi
           exit $TF_EXIT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.21] - Unreleased
 
+### Added
+- `TF_VAR_USE_EUM_SMS` feature flag gates provisioning of the AWS End
+  User Messaging toll-free phone number (`aws_pinpointsmsvoicev2_phone_number.sms`).
+  Defaults to `false`. Mirrors `TF_VAR_USE_TWILIO_SMS` so the two SMS
+  delivery paths can be toggled independently per environment. See
+  `docs/twilio.md` for the four-state matrix and rollback semantics.
+  Existing EUM phone numbers are migrated to the indexed state
+  address via a `moved {}` block; `deletion_protection_enabled = true`
+  is preserved.
+
 ### Changed
+- The `sms_sender` module (KMS key, SSM SecureString parameters for
+  Twilio credentials, Lambda, IAM role) is now gated on
+  `TF_VAR_USE_TWILIO_SMS`. Previously the module was always
+  provisioned regardless of the flag, which forced every environment
+  to set non-empty `TWILIO_*` secrets even when the Twilio path
+  wasn't being used. Existing state is migrated via a `moved {}`
+  block so envs already running with `USE_TWILIO_SMS=true` are
+  unaffected.
 - Cleared Terraform deprecation warnings against AWS provider v6:
   switched `data.aws_region.current.name` to `.region` in the `app`,
   `user_pool`, and `sms_sender` modules; dropped the deprecated
@@ -18,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that guarded it; and removed `public_ip` / `public_dns` from the NAT
   instance's `ignore_changes` since computed-only attributes can't
   drift against configured values.
+
+### Fixed
+- `terraform apply` no longer hangs waiting for stdin when
+  `TF_VAR_USE_TWILIO_SMS=false` and the `TWILIO_*` GitHub Environment
+  secrets are unset. The `twilio` Terraform provider was declared in
+  `terraform/infra/providers.tf` (and `required_providers` in
+  `terraform.tf`) but never consumed by any resource; with
+  credentials absent the provider blocked on interactive prompts.
+  The provider declaration is removed - the `sms_sender` Lambda
+  talks to the Twilio API directly via the Python SDK, not through
+  Terraform.
 
 ## [0.9.20] - 2026-05-16
 

--- a/docs/twilio.md
+++ b/docs/twilio.md
@@ -1,8 +1,22 @@
-# Recommended Steps for Setting Up Twilio for SMS Verification
+# Setting Up SMS Verification
 
-Cabalmail delivers SMS verification codes (signup phone verification, password reset, MFA) through Twilio by way of a [Cognito custom SMS sender Lambda](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sms-sender.html). This avoids AWS End User Messaging's toll-free verification queue, which in practice can take a month or longer. Twilio's approval flow is hours-to-days.
+Cabalmail uses SMS for signup phone verification, password reset, and MFA. Two independent delivery paths are available, each gated by its own Terraform feature flag:
 
-The Lambda, KMS key, and SSM secret parameters are all provisioned by Terraform. The manual steps below are the Twilio-side account setup, regulatory registration, and the GitHub Environment secrets that wire your Twilio credentials into the deploy pipeline.
+| Flag | What it provisions | When to use |
+| --- | --- | --- |
+| `TF_VAR_USE_TWILIO_SMS` | A [Cognito custom SMS sender Lambda](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sms-sender.html) backed by Twilio, with KMS key and SSM secret parameters for Twilio credentials. | **Recommended.** Twilio's approval flow is hours-to-days. |
+| `TF_VAR_USE_EUM_SMS` | An AWS End User Messaging toll-free phone number consumed by Cognito's built-in SNS SMS path. | Use only if you have an approved AWS toll-free verification (TFV) registration. AWS's TFV queue has been observed to take a month or longer; without an approved registration the number sits pending and the SNS path delivers nothing. |
+
+Both flags default to `false`. The four combinations:
+
+| `USE_TWILIO_SMS` | `USE_EUM_SMS` | Result |
+| --- | --- | --- |
+| `false` | `false` | No SMS delivery path provisioned. Cognito signup with `auto_verified_attributes = ["phone_number"]` still passes plan/apply but verification codes will not be delivered. Useful for `development` while you wait on regulatory approvals. |
+| `true` | `false` | **Recommended steady state.** Twilio-only. The `TWILIO_*` secrets below must be populated. |
+| `false` | `true` | EUM-only. The toll-free number is provisioned (and protected against deletion). Cognito SMS delivery depends on an approved AWS TFV registration that must be created out-of-band in the [AWS End User Messaging console](https://console.aws.amazon.com/sms-voice/home). No Terraform resource exists yet for the registration itself; see "AWS End User Messaging" below. |
+| `true` | `true` | Both provisioned. Twilio handles the Cognito hot path (the `custom_sms_sender` Lambda wins over `sms_configuration`); the EUM number sits ready as a fallback you can flip to by toggling `USE_TWILIO_SMS` back to `false`. Costs ~$1-2/month for the EUM rental on top of Twilio. |
+
+The Twilio Lambda, KMS key, and SSM secret parameters are all provisioned by Terraform when `TF_VAR_USE_TWILIO_SMS=true`. The manual steps below are the Twilio-side account setup, regulatory registration, and the GitHub Environment secrets that wire your Twilio credentials into the deploy pipeline.
 
 ## Account
 
@@ -56,10 +70,23 @@ Add the following [GitHub Environment](https://docs.github.com/en/actions/managi
 
 ## Enable the feature flag
 
-Add a [GitHub Environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows) (not a secret) named `TF_VAR_USE_TWILIO_SMS` with value `true` to each environment that should route SMS through Twilio. Default is `false`, which keeps Cognito on the legacy AWS End User Messaging / SNS path.
+Add a [GitHub Environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#defining-configuration-variables-for-multiple-workflows) (not a secret) named `TF_VAR_USE_TWILIO_SMS` with value `true` to each environment that should route SMS through Twilio. Default is `false`.
 
-Then trigger the `infra.yml` workflow (any push to the named branch, or `workflow_dispatch`). Terraform will wire the custom SMS sender Lambda into the Cognito user pool. The next signup verification, password reset, or MFA code will be delivered by Twilio.
+Then trigger the `infra.yml` workflow (any push to the named branch, or `workflow_dispatch`). Terraform will provision the `sms_sender` module (KMS key + SSM parameters + Lambda) and wire the custom SMS sender Lambda into the Cognito user pool. The next signup verification, password reset, or MFA code will be delivered by Twilio.
+
+## AWS End User Messaging (optional fallback)
+
+If you also want the EUM toll-free path provisioned - either as a fallback target or because you've already invested in getting AWS toll-free verification approved - set `TF_VAR_USE_EUM_SMS=true` as a GitHub Environment variable in the relevant environment. Terraform will provision `aws_pinpointsmsvoicev2_phone_number.sms` (a US toll-free number, transactional) with `deletion_protection_enabled = true`.
+
+Two things to know:
+
+1. **The Terraform AWS provider has no `aws_pinpointsmsvoicev2_registration` resource.** The TFV submission (use-case description, privacy policy, sample messages, opt-in flow) has to be filed in the [AWS End User Messaging console](https://console.aws.amazon.com/sms-voice/home) under **Registrations -> Create registration -> Toll-free verification**. Until that registration is approved by the carriers, the number sits in `pending` and the SNS SMS path delivers nothing.
+2. **Deletion protection means you cannot disable EUM in one step.** Flipping `TF_VAR_USE_EUM_SMS` from `true` back to `false` will fail apply because the resource is still in state and deletion-protected. To actually destroy the number, first do an apply that sets `deletion_protection_enabled = false` (currently requires editing `terraform/infra/modules/user_pool/main.tf`), then a second apply that flips the flag.
 
 ## Rollback
 
-Set `TF_VAR_USE_TWILIO_SMS=false` (or remove the variable) and re-apply `infra.yml`. Cognito reverts to the SNS / AWS End User Messaging path immediately. The Twilio Lambda, KMS key, and SSM parameters all stay in place, so re-enabling later is a single-knob flip.
+To roll back from Twilio to "no SMS": set `TF_VAR_USE_TWILIO_SMS=false` and re-apply. The `sms_sender` module is destroyed (KMS key enters its 7-day deletion window; SSM parameters and Lambda delete immediately). Cognito's `sms_configuration` block still references an SNS IAM role and AWS's shared SMS pool - sandboxed without a registered originator, so delivery is best-effort and rate-limited.
+
+To roll back from Twilio to EUM: requires `TF_VAR_USE_EUM_SMS=true` AND a TFV-approved phone number. Without the registration, "EUM" is just a pending number and SMS still does not work.
+
+The most useful steady state is `USE_TWILIO_SMS=true, USE_EUM_SMS=true` once both registrations are approved - one knob (`USE_TWILIO_SMS`) then swaps Cognito between the two delivery paths cleanly.

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -47,15 +47,31 @@ module "lambda_layers" {
   bucket = module.bucket.bucket
 }
 
-# SMS sender for Cognito via Twilio. See docs/0.9.0/twilio-sms-migration-plan.md.
+# SMS sender for Cognito via Twilio. See docs/twilio.md.
+#
+# Gated on var.use_twilio_sms so an environment that doesn't use the
+# Twilio path doesn't have to set TWILIO_* secrets just to satisfy
+# the SecureString SSM parameters this module creates. The module is
+# additive: when count = 0, nothing here exists in AWS.
 module "sms_sender" {
   source = "./modules/sms_sender"
+  count  = var.use_twilio_sms ? 1 : 0
 
   bucket             = module.bucket.bucket
   twilio_account_sid = var.twilio_account_sid
   twilio_api_key     = var.twilio_api_key
   twilio_api_secret  = var.twilio_api_secret
   twilio_from_number = var.twilio_from_number
+}
+
+# Migrate state from the pre-count module address. Without this an
+# env that already had sms_sender provisioned would see a destroy on
+# the un-indexed address and a create on the indexed one (when
+# use_twilio_sms = true), which is needlessly destructive for the
+# KMS key and SSM parameters.
+moved {
+  from = module.sms_sender
+  to   = module.sms_sender[0]
 }
 
 # Creates a Cognito User Pool
@@ -66,9 +82,10 @@ module "pool" {
   bucket_arn             = module.bucket.bucket_arn
   ecs_cluster_name       = module.ecs.cluster_name
   healthcheck_ping_param = local.hc_ping_assign_osid
-  sms_sender_arn         = module.sms_sender.lambda_arn
-  sms_kms_key_arn        = module.sms_sender.kms_key_arn
+  sms_sender_arn         = var.use_twilio_sms ? module.sms_sender[0].lambda_arn : ""
+  sms_kms_key_arn        = var.use_twilio_sms ? module.sms_sender[0].kms_key_arn : ""
   use_twilio_sms         = var.use_twilio_sms
+  use_eum_sms            = var.use_eum_sms
 }
 
 # Creates an AWS Certificate Manager certificate for use on load balancers and CloudFront

--- a/terraform/infra/modules/user_pool/main.tf
+++ b/terraform/infra/modules/user_pool/main.tf
@@ -35,7 +35,7 @@ resource "aws_cognito_user_pool" "users" {
   # provided KMS key, and bypasses the SNS hot path. The
   # sms_configuration block above stays in place because Cognito
   # still validates it whenever a phone attribute is auto-verified.
-  # See docs/0.9.0/twilio-sms-migration-plan.md.
+  # See docs/twilio.md.
   lambda_config {
     post_confirmation = aws_lambda_function.assign_osid.arn
 
@@ -51,7 +51,17 @@ resource "aws_cognito_user_pool" "users" {
   }
 }
 
+# AWS End User Messaging toll-free number used by the legacy SNS SMS
+# path. Gated on var.use_eum_sms so environments that have committed
+# to the Twilio path don't carry the EUM number (and its monthly
+# rental + pending TFV registration) as dead weight. See docs/twilio.md.
+#
+# Note: deletion_protection_enabled = true means flipping this flag
+# from true to false will fail apply until protection is disabled in
+# a prior apply. That's intentional - losing a TFV-approved number is
+# expensive.
 resource "aws_pinpointsmsvoicev2_phone_number" "sms" {
+  count                       = var.use_eum_sms ? 1 : 0
   iso_country_code            = "US"
   message_type                = "TRANSACTIONAL"
   number_capabilities         = ["SMS"]
@@ -61,6 +71,16 @@ resource "aws_pinpointsmsvoicev2_phone_number" "sms" {
   timeouts {
     create = "1m"
   }
+}
+
+# Migrate state from the pre-count resource address so an env that
+# already had a (pending or active) EUM phone number does not see a
+# destroy on the un-indexed address. Combined with
+# deletion_protection_enabled = true this means a TFV-approved
+# number cannot be lost by a flag flip alone.
+moved {
+  from = aws_pinpointsmsvoicev2_phone_number.sms
+  to   = aws_pinpointsmsvoicev2_phone_number.sms[0]
 }
 
 resource "aws_cognito_user_group" "admin" {

--- a/terraform/infra/modules/user_pool/outputs.tf
+++ b/terraform/infra/modules/user_pool/outputs.tf
@@ -19,8 +19,8 @@ output "admin_group_name" {
 }
 
 output "sms_phone_number" {
-  value       = aws_pinpointsmsvoicev2_phone_number.sms.phone_number
-  description = "Toll-free phone number used for SMS verification"
+  value       = var.use_eum_sms ? aws_pinpointsmsvoicev2_phone_number.sms[0].phone_number : ""
+  description = "AWS End User Messaging toll-free phone number for SMS verification. Empty string when var.use_eum_sms is false."
 }
 
 output "user_pool_domain" {

--- a/terraform/infra/modules/user_pool/variables.tf
+++ b/terraform/infra/modules/user_pool/variables.tf
@@ -81,6 +81,12 @@ variable "sms_kms_key_arn" {
 
 variable "use_twilio_sms" {
   type        = bool
-  description = "Feature flag: when true, wire the custom_sms_sender (Twilio) Lambda + KMS key into the user pool. When false, Cognito stays on the legacy SNS/EUM path."
+  description = "Feature flag: when true, wire the custom_sms_sender (Twilio) Lambda + KMS key into the user pool. When false, Cognito stays on the SNS/EUM path."
+  default     = false
+}
+
+variable "use_eum_sms" {
+  type        = bool
+  description = "Feature flag: when true, provision the AWS End User Messaging toll-free phone number that backs SNS-based SMS delivery. When false, no EUM phone number is created."
   default     = false
 }

--- a/terraform/infra/outputs.tf
+++ b/terraform/infra/outputs.tf
@@ -21,7 +21,7 @@ output "domains" {
 
 output "sms_phone_number" {
   value       = module.pool.sms_phone_number
-  description = "Toll-free phone number used for SMS verification."
+  description = "AWS End User Messaging toll-free phone number for SMS verification. Empty when var.use_eum_sms is false."
 }
 
 output "alert_sink_function_url" {

--- a/terraform/infra/providers.tf
+++ b/terraform/infra/providers.tf
@@ -8,8 +8,3 @@ provider "aws" {
     }
   }
 }
-
-provider "twilio" {
-  # Credentials come from environment variables:
-  # TWILIO_ACCOUNT_SID, TWILIO_API_KEY, TWILIO_API_SECRET
-}

--- a/terraform/infra/terraform.tf
+++ b/terraform/infra/terraform.tf
@@ -8,10 +8,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.5"
     }
-    twilio = {
-      source  = "twilio/twilio"
-      version = "~> 0.18.46"
-    }
   }
   required_version = ">= 1.9.0"
 }

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -146,6 +146,12 @@ variable "twilio_from_number" {
 
 variable "use_twilio_sms" {
   type        = bool
-  description = "Feature flag: when true, wire the custom_sms_sender (Twilio) Lambda + KMS key into the Cognito user pool. When false, Cognito stays on the legacy SNS/EUM SMS path. See docs/0.9.0/twilio-sms-migration-plan.md."
+  description = "Feature flag: when true, provision the Twilio sms_sender module (KMS key, SSM parameters, Lambda) and wire the custom_sms_sender into the Cognito user pool. When false, the sms_sender module is not created and Cognito does not call out to Twilio. The TWILIO_* variables only need to be set when this is true. See docs/twilio.md."
+  default     = false
+}
+
+variable "use_eum_sms" {
+  type        = bool
+  description = "Feature flag: when true, provision the AWS End User Messaging toll-free phone number for Cognito SMS via SNS. When false, the EUM phone number is not created and Cognito's sms_configuration block falls through to the shared AWS SMS pool (which is sandboxed without registration). Independent of var.use_twilio_sms; setting both true is supported but only one delivery path is on the user pool's hot path at a time (custom_sms_sender wins). See docs/twilio.md."
   default     = false
 }


### PR DESCRIPTION
## Summary

Two related Cognito SMS gating changes, motivated by `terraform apply` hanging when `TF_VAR_USE_TWILIO_SMS=false` and the `TWILIO_*` GitHub Environment secrets are unset.

### Fix the freeze (bug)
The `twilio` Terraform provider was declared in `terraform/infra/providers.tf` (and `required_providers` in `terraform.tf`) but no `twilio_*` resource was ever consumed by the stack. With credentials absent, the provider blocked on interactive credential prompts. Removed the provider; the `sms_sender` Lambda talks to the Twilio API at runtime via the Python SDK, not via Terraform.

### Gate `sms_sender` on `use_twilio_sms` (refactor)
Previously the `sms_sender` module always provisioned a KMS key, four SSM parameters (three SecureString for Twilio creds, one String for the from-number), a Lambda, and an IAM role - regardless of the flag. That forced every environment to populate non-empty `TWILIO_*` secrets or hit a SecureString-creation failure. `count = var.use_twilio_sms ? 1 : 0` plus a `moved {}` block now keeps existing state stable for envs already running with `USE_TWILIO_SMS=true`.

### Add `use_eum_sms` (new feature)
New `TF_VAR_USE_EUM_SMS` GitHub Environment variable gates `aws_pinpointsmsvoicev2_phone_number.sms`. Default `false`. The resource keeps `deletion_protection_enabled = true`, so flipping the flag from `true` to `false` cannot accidentally destroy a TFV-approved number; a separate prior apply that disables deletion protection is required. A `moved {}` block migrates existing state.

`docs/twilio.md` picks up a four-state matrix of the two flags explaining what each combination provisions and the rollback semantics for each direction.

## Manual steps for operators

When this lands on `stage` / `main`, the `infra.yml` apply will plan to **destroy** the EUM phone number in any environment where `TF_VAR_USE_EUM_SMS` is not set to `true`. Because `deletion_protection_enabled = true` is preserved, that destroy will **fail loudly** rather than silently nuke the number. Two paths for operators:

- **Keep the EUM number** (recommended while TFV is still pending): set GitHub Environment variable `TF_VAR_USE_EUM_SMS=true` in each environment that currently has the number provisioned (prod and any others), then re-run `infra.yml`.
- **Discard the EUM number**: requires a manual two-apply sequence (flip `deletion_protection_enabled` off, then flip `USE_EUM_SMS` off). Don't do this until TFV is definitively abandoned.

## Test plan

- [ ] `infra.yml` plan succeeds on `stage` with `TF_VAR_USE_TWILIO_SMS=false` and `TF_VAR_USE_EUM_SMS=false` and no `TWILIO_*` secrets - the freeze symptom no longer reproduces.
- [ ] `infra.yml` apply on `stage` shows the `moved` blocks adopt existing state (no destroy of currently-provisioned `sms_sender` resources or `aws_pinpointsmsvoicev2_phone_number.sms` where flags are set to `true`).
- [ ] `terraform validate` and `terraform fmt -check -recursive` pass locally (verified before pushing).
- [ ] checkov / tflint / tfsec gates pass in CI.

Generated with [Claude Code](https://claude.com/claude-code)