### PR TITLE
Wire AuthShell footer links + status to GitHub wiki

### DIFF
--- a/react/admin/src/App.jsx
+++ b/react/admin/src/App.jsx
@@ -538,7 +538,6 @@ function App() {
             username={state.userName}
             password={state.password}
             phone={state.phone}
-            controlDomain={state.control_domain}
             onSignIn={(e) => { e.preventDefault(); setState({ view: "Login" }); }}
           />
         );
@@ -592,6 +591,7 @@ function App() {
     api_url: state.api_url,
     host: state.imap_host,
     smtp_host: `smtp-out.${state.control_domain}`,
+    control_domain: state.control_domain,
     domains: state.domains
   };
 

--- a/react/admin/src/Login/AuthShell.jsx
+++ b/react/admin/src/Login/AuthShell.jsx
@@ -1,11 +1,26 @@
 import logoMarkup from '../assets/logo.svg?raw';
+import { useAuth } from '../contexts/AuthContext';
 import './AuthShell.css';
 
+// Hardcoded. The project's status / changelog / runbook surface lives
+// on the GitHub wiki, not on the marketing site, so it doesn't follow
+// the www.<control_domain> pattern of Terms / Privacy.
+const STATUS_URL = 'https://github.com/cabalmail/cabal-infra/wiki';
+
 /**
- * Shared chrome for Login / SignUp / ForgotPassword per §§1–3:
+ * Shared chrome for Login / SignUp / ForgotPassword per sections 1-3:
  * wordmark header, centered card body, terms / privacy / status footer.
  */
 export default function AuthShell({ headerRight, children, cardSize = 'default' }) {
+  // control_domain is loaded asynchronously by App.jsx from /config.js
+  // at mount. Pre-login screens are typically reached after that load
+  // resolves, but for the brief window before it does, the legal links
+  // fall back to "#" so we don't navigate to https://www.null/...
+  const { control_domain } = useAuth();
+  const marketingOrigin = control_domain ? `https://www.${control_domain}` : null;
+  const termsHref = marketingOrigin ? `${marketingOrigin}/terms.html` : '#';
+  const privacyHref = marketingOrigin ? `${marketingOrigin}/privacy.html` : '#';
+
   const cardClass = cardSize === 'narrow'
     ? 'auth__card auth__card--narrow'
     : cardSize === 'wide'
@@ -30,9 +45,9 @@ export default function AuthShell({ headerRight, children, cardSize = 'default' 
       </main>
       <footer className="auth__footer">
         <div className="auth__footer-left">
-          <a href="#">Terms</a>
-          <a href="#">Privacy</a>
-          <a href="#">Status</a>
+          <a href={termsHref} target="_blank" rel="noopener noreferrer">Terms</a>
+          <a href={privacyHref} target="_blank" rel="noopener noreferrer">Privacy</a>
+          <a href={STATUS_URL} target="_blank" rel="noopener noreferrer">Status</a>
           <a
             href="#"
             onClick={(e) => {

--- a/react/admin/src/SignUp/index.jsx
+++ b/react/admin/src/SignUp/index.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import AuthShell from '../Login/AuthShell';
+import { useAuth } from '../contexts/AuthContext';
 
 /**
  * Strength meter per §2: four segments, each lights as a zxcvbn-style
@@ -28,14 +29,14 @@ function SignUp({
   username,
   phone,
   password,
-  controlDomain,
   onSignIn,
 }) {
   // Legal pages live on the marketing site at www.<control_domain>.
-  // controlDomain is loaded asynchronously from /config.js by App.jsx;
+  // control_domain is loaded asynchronously from /config.js by App.jsx;
   // if the signup screen renders before it resolves (rare in practice),
   // fall back to "#" so we don't navigate to https://www.null/...
-  const marketingOrigin = controlDomain ? `https://www.${controlDomain}` : null;
+  const { control_domain } = useAuth();
+  const marketingOrigin = control_domain ? `https://www.${control_domain}` : null;
   const termsHref = marketingOrigin ? `${marketingOrigin}/terms.html` : '#';
   const privacyHref = marketingOrigin ? `${marketingOrigin}/privacy.html` : '#';
   const [showPassword, setShowPassword] = useState(false);


### PR DESCRIPTION
## Summary

The auth chrome shared by Login / SignUp / Verify / ForgotPassword / ResetPassword had three placeholder `href=\"#\"` links in its footer (Terms, Privacy, Status). This PR wires them up:

- **Terms** -> `https://www.<control_domain>/terms.html`
- **Privacy** -> `https://www.<control_domain>/privacy.html`
- **Status** -> `https://github.com/cabalmail/cabal-infra/wiki` (hardcoded; the project's status / changelog / runbook surface lives there, not on the marketing site)

## Implementation note

`control_domain` is added to the existing `authValue` so `AuthShell` can read it via `useAuth()` rather than threading a prop through all six pre-login screens. `SignUp` is refactored to read the same value via `useAuth()` instead of the prop introduced in #409, so the two consumers of the marketing-site origin share one source of truth.

All three links open in a new tab via `target=\"_blank\"` + `rel=\"noopener noreferrer\"` so an in-flow signup or password reset isn't interrupted.

## Test plan

- [ ] Visit `https://admin.<control_domain>` after deploy. Footer at the bottom of every pre-login screen (Login, Sign Up, Forgot Password, etc.) shows Terms, Privacy, Status, About.
- [ ] Terms link opens `https://www.<control_domain>/terms.html` in a new tab.
- [ ] Privacy link opens `https://www.<control_domain>/privacy.html` in a new tab.
- [ ] Status link opens `https://github.com/cabalmail/cabal-infra/wiki` in a new tab.
- [ ] About link (unchanged) still dispatches the in-app About event.

Generated with [Claude Code](https://claude.com/claude-code)