### PR TITLE
Add explicit log group + retention to assign_osid Lambda

### DIFF
--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -90,6 +90,23 @@ import {
   id = "/aws/lambda/sms_sender"
 }
 
+# Adopt the auto-created CloudWatch log group for the assign_osid
+# Lambda (Cognito post-confirmation trigger). AWS creates
+# /aws/lambda/assign_osid automatically on first invocation with
+# "Never Expire" retention; the user_pool module now declares it as a
+# Terraform resource (with retention_in_days = 14) so the auto-created
+# group has to be imported on first apply, otherwise Terraform fails
+# with ResourceAlreadyExistsException. import blocks have to live in
+# the root module per Terraform's rules.
+#
+# Fresh environments (no prior Lambda invocation) will fail this
+# import. Remove the import block for those envs - the resource will
+# create from scratch.
+import {
+  to = module.pool.aws_cloudwatch_log_group.assign_osid
+  id = "/aws/lambda/assign_osid"
+}
+
 # Creates a Cognito User Pool
 module "pool" {
   source                 = "./modules/user_pool"

--- a/terraform/infra/modules/user_pool/counter.tf
+++ b/terraform/infra/modules/user_pool/counter.tf
@@ -78,6 +78,21 @@ resource "aws_iam_role_policy" "lambda" {
   })
 }
 
+# CloudWatch log group for the Lambda. Declared explicitly so the
+# retention is bounded (14 days is plenty - the function fires only at
+# Cognito signup confirmation). Without this resource AWS auto-creates
+# the log group on first invocation with "Never Expire" retention,
+# leaving the last "Never Expire" log-group gap in the repo.
+#
+# Existing environments (stage, prod) already have an auto-created log
+# group; an `import` block at the root (terraform/infra/main.tf) adopts
+# it on first apply. Terraform requires `import` blocks to live in the
+# root module, hence the split.
+resource "aws_cloudwatch_log_group" "assign_osid" {
+  name              = "/aws/lambda/assign_osid"
+  retention_in_days = 14
+}
+
 resource "aws_lambda_function" "assign_osid" {
   s3_bucket        = var.bucket
   s3_key           = "lambda/assign_osid.zip"
@@ -88,6 +103,11 @@ resource "aws_lambda_function" "assign_osid" {
   runtime          = "python3.13"
   architectures    = ["arm64"]
   timeout          = 30
+
+  # Ensure the log group exists (with our retention setting) before
+  # the Lambda is created, so AWS does not auto-create one with the
+  # default "Never Expire" retention on first invocation.
+  depends_on = [aws_cloudwatch_log_group.assign_osid]
 
   environment {
     variables = {


### PR DESCRIPTION
## Summary

- Adds `aws_cloudwatch_log_group.assign_osid` to `terraform/infra/modules/user_pool/counter.tf` with `retention_in_days = 14` (matches the operational profile - the function only fires at Cognito signup confirmation, so two weeks of investigation window is plenty).
- Wires `depends_on = [aws_cloudwatch_log_group.assign_osid]` on the Lambda so fresh deploys create the group before the first invocation.
- Adds a root-module `import` block in `terraform/infra/main.tf` to adopt the auto-created log group in stage and prod (same pattern as #411 for `sms_sender`). Existing envs definitely have the group - every signup confirmation invokes `assign_osid`.

Closes the last "Never Expire" log-group gap in the repo. The existing IAM policy on the Lambda role already scopes `logs:CreateLogStream` + `logs:PutLogEvents` to the specific `/aws/lambda/assign_osid` group ARN, so no IAM change is needed. `logs:CreateLogGroup` is no longer strictly required but is left in place.

No CHANGELOG entry: operational hygiene, no user-visible behavior change.

If a fresh environment is ever stood up that does not have the auto-created group, the operator removes the import block for that env's first apply (the resource then creates from scratch).

## Test plan

- [ ] `infra.yml` plan on stage shows the new log group as an import (not a create), no destroys.
- [ ] After apply: `aws logs describe-log-groups --log-group-name-prefix /aws/lambda/assign_osid --region us-east-1` reports `retentionInDays: 14`.

Generated with [Claude Code](https://claude.com/claude-code)