### PR TITLE
Treat empty env vars as missing in TFV submission script

### DIFF
--- a/scripts/submit-tfv-registration.py
+++ b/scripts/submit-tfv-registration.py
@@ -92,8 +92,18 @@ DEFAULT_OPT_IN_DESCRIPTION = (
 
 
 def env(name, default=None, required=False):
-    """Read an env var, optionally enforcing presence."""
-    value = os.environ.get(name, default)
+    """Read an env var, optionally enforcing presence.
+
+    Empty strings are treated as missing. GitHub Actions substitutes
+    `${{ vars.FOO }}` with an empty string when `vars.FOO` is unset
+    rather than leaving the env var unset, so os.environ.get(name,
+    default) returns "" instead of the default for an unset GHA var.
+    Coercing empty strings to the default fixes that asymmetry and
+    matches what the AWS pinpoint-sms-voice-v2 API actually accepts
+    (it rejects TextValue="" at parameter validation, before the
+    request ever hits the service).
+    """
+    value = os.environ.get(name, "") or default
     if required and not value:
         sys.exit(f"error: required env var {name} is not set")
     return value


### PR DESCRIPTION
## Summary

First real run of the `register-tfv` workflow against stage failed on `messagingUseCase.useCaseDetails` with:

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid length for parameter TextValue, value: 0, valid min length: 1
```

Root cause: GitHub Actions substitutes `\${{ vars.FOO }}` with an empty string when `vars.FOO` is unset on the target Environment - it doesn't leave the env var unset. The script's `env()` helper used `os.environ.get(name, default)`, which only returns the default when the key is missing entirely. So optional vars the operator hadn't set (`TFV_USE_CASE_DETAILS`, `TFV_OPT_IN_DESCRIPTION`, `TFV_SAMPLE_MESSAGE`, `TFV_MONTHLY_VOLUME`, `TFV_USE_CASE_CATEGORY`) came through as `""`, overriding the in-script defaults.

## Fix

One-line change in the `env()` helper:

```python
value = os.environ.get(name, "") or default
```

Empty strings are now coerced to the default. Required vars still error the same way if missing or empty.

## Test plan

- [x] Inline test of all four cases (unset, empty, set, empty+no-default) passes locally.
- [ ] Re-run the `register-tfv` workflow against stage. The partial registration created on the first run (`registration-99254e4ceb...`) will be picked up by `find_existing_registration()` and field values re-applied. The script gets past the use-case fields, the choice fields, the attachment binding, the phone number association, and submits.
- [ ] Status check via `describe-registrations` reports `REVIEWING` or `SUBMITTED`.

Generated with [Claude Code](https://claude.com/claude-code)