### PR TITLE
Bump actions/setup-python from v5 to v6

### DIFF
--- a/.github/workflows/register-tfv.yml
+++ b/.github/workflows/register-tfv.yml
@@ -68,7 +68,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v5
       - name: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: install-boto3


### PR DESCRIPTION
## Summary

The first successful register-tfv run logged:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-python@v5.

`actions/setup-python@v6` is the Node.js 24 release. Bumping clears the deprecation warning. From 2 June 2026 the runner will force Node.js 24 by default; on 16 September 2026 Node 20 is removed entirely, so this needs to land before then regardless.

`register-tfv.yml` is the only workflow in the repo that uses `actions/setup-python` (other workflows that need Python use other approaches or call Python via Docker), so no other files need touching.

## Test plan

- [ ] Re-run register-tfv on stage. Warning is gone; setup-python step still completes; `pip install boto3` succeeds.

Generated with [Claude Code](https://claude.com/claude-code)