### PR TITLE
Open new draft version when registration is in REQUIRES_UPDATES

### DIFF
--- a/docs/sms-tfv-setup.md
+++ b/docs/sms-tfv-setup.md
@@ -16,6 +16,37 @@ Before you trigger the workflow:
    - **Commit it to the repo.** Save the file as `front-door/opt-in-screenshot.png`. The workflow picks it up automatically.
    - **Host it elsewhere.** Pass an HTTPS URL via the `opt_in_image_url` workflow input. The workflow fetches it at run time. This avoids committing a binary that may need to be regenerated whenever the signup screen changes.
 
+4. **IAM permissions on the `terraform` user.** The workflow re-uses the existing `terraform` IAM user's credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) from the `infra.yml` workflow. That user does not have `sms-voice:*` permissions by default; attach the inline policy below before triggering the workflow for the first time on each AWS account. The policy is intentionally action-scoped rather than wildcarded so future API additions are reviewable.
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "CabalmailTFVSubmission",
+         "Effect": "Allow",
+         "Action": [
+           "sms-voice:DescribePhoneNumbers",
+           "sms-voice:DescribeRegistrations",
+           "sms-voice:DescribeRegistrationFieldDefinitions",
+           "sms-voice:DescribeRegistrationVersions",
+           "sms-voice:DescribeRegistrationFieldValues",
+           "sms-voice:ListRegistrationAssociations",
+           "sms-voice:CreateRegistration",
+           "sms-voice:CreateRegistrationVersion",
+           "sms-voice:CreateRegistrationAttachment",
+           "sms-voice:PutRegistrationFieldValue",
+           "sms-voice:CreateRegistrationAssociation",
+           "sms-voice:SubmitRegistrationVersion"
+         ],
+         "Resource": "*"
+       }
+     ]
+   }
+   ```
+
+   AWS Console -> IAM -> Users -> `terraform` -> **Add permissions -> Create inline policy** -> JSON tab -> paste -> name it `CabalmailTFVSubmission`. Same procedure on each AWS account you intend to submit a TFV registration from (stage, prod).
+
 ## GitHub Environment configuration
 
 For each environment you want to enable TFV in (typically `stage` first, then `prod`), set the following under Settings -> Environments -> [environment name].

--- a/scripts/submit-tfv-registration.py
+++ b/scripts/submit-tfv-registration.py
@@ -187,6 +187,23 @@ def create_registration(client):
     return reg_id
 
 
+def create_registration_version(client, reg_id):
+    """Open a new draft version on an existing registration so field
+    values can be edited.
+
+    A registration in REQUIRES_UPDATES status has a rejected (frozen)
+    most-recent version. PutRegistrationFieldValue against the frozen
+    version errors with ConflictException
+    EDIT_REGISTRATION_FIELD_VALUES_NOT_ALLOWED. Calling
+    CreateRegistrationVersion produces a fresh draft that inherits
+    the prior version's field values; subsequent
+    PutRegistrationFieldValue calls land on the new draft.
+    """
+    resp = client.create_registration_version(RegistrationId=reg_id)
+    version = resp.get("VersionNumber", "?")
+    print(f"[version] opened draft version {version} on {reg_id}")
+
+
 def upload_opt_in_image(client, reg_id, image_path):
     """Upload the opt-in screenshot, return RegistrationAttachmentId."""
     with open(image_path, "rb") as fh:
@@ -406,11 +423,24 @@ def main():
     if not phone_number_id:
         phone_number_id = discover_phone_number_id(client)
 
-    # 3. Find or create the registration
+    # 3. Find or create the registration. Status drives the next move:
+    #   - none           -> create from scratch
+    #   - DRAFT          -> edit the existing draft (normal re-run case)
+    #   - REQUIRES_UPDATES -> open a fresh draft version; the rejected
+    #                        version is frozen and PutRegistrationFieldValue
+    #                        on it errors with ConflictException
+    #                        EDIT_REGISTRATION_FIELD_VALUES_NOT_ALLOWED.
+    #   - anything else  -> exit. SUBMITTED / REVIEWING / COMPLETE / CLOSED
+    #                       are non-editable states; the operator should
+    #                       wait for AWS to flip status before re-running.
     reg_id, status = find_existing_registration(client, phone_number_id)
     if reg_id is None:
         reg_id = create_registration(client)
-    elif status in ("REVIEWING", "COMPLETE"):
+    elif status == "DRAFT":
+        pass
+    elif status == "REQUIRES_UPDATES":
+        create_registration_version(client, reg_id)
+    else:
         sys.exit(
             f"error: registration {reg_id} is in status {status}; cannot "
             "modify or resubmit. Wait for the review to complete (or "


### PR DESCRIPTION
## Summary

Re-running the workflow against the existing stage registration (now in `REQUIRES_UPDATES` after the prior submission was rejected for the missing fields) failed with:

```
ConflictException Reason=\"EDIT_REGISTRATION_FIELD_VALUES_NOT_ALLOWED\"
ResourceType=\"registration\" ResourceId=\"registration-6f49b9b1...\"
```

A registration's rejected version is **frozen**. `PutRegistrationFieldValue` against it errors as above. AWS expects the caller to first open a fresh draft via `CreateRegistrationVersion` (which inherits the prior version's field values), and then edit on the new draft.

The script's previous `find_existing_registration` branch only blocked `REVIEWING` and `COMPLETE` - everything else fell through to the edit path, so `REQUIRES_UPDATES` silently took the wrong route.

## Changes

### 1. Status-driven branch in main()

Restructured into an explicit state machine:

```python
if reg_id is None:
    reg_id = create_registration(client)
elif status == \"DRAFT\":
    pass                                                # normal re-run
elif status == \"REQUIRES_UPDATES\":
    create_registration_version(client, reg_id)         # opens new draft
else:
    sys.exit(...)                                       # SUBMITTED/REVIEWING/COMPLETE/CLOSED
```

New `create_registration_version()` helper logs `[version] opened draft version N on ...`.

### 2. Document the full IAM policy

We've widened the `terraform` user's inline policy three times now, once per missing action discovered the hard way. New `Prerequisites` step 4 in [docs/sms-tfv-setup.md](docs/sms-tfv-setup.md) lists the full canonical action set (adds `sms-voice:CreateRegistrationVersion` for this PR), so the next operator setting this up on prod doesn't repeat the iteration.

## Operator action required before re-running

Add `sms-voice:CreateRegistrationVersion` to the existing `CabalmailTFVSubmission` inline policy on the `terraform` user in the stage AWS account. The full updated policy is in [docs/sms-tfv-setup.md](docs/sms-tfv-setup.md#prerequisites).

## Test plan

- [x] Syntax check passes.
- [ ] After IAM update + merge, re-run `register-tfv` on stage. `[lookup]` shows REQUIRES_UPDATES, `[version]` opens a new draft, `[field]` lines proceed without ConflictException, `[submit]` completes. AWS console shows the registration in SUBMITTED/REVIEWING state with no missing-field issues.

Generated with [Claude Code](https://claude.com/claude-code)