### PR TITLE
Skip tax fields when TFV_BUSINESS_TYPE=SOLE_PROPRIETOR

### DIFF
--- a/docs/sms-tfv-setup.md
+++ b/docs/sms-tfv-setup.md
@@ -82,7 +82,7 @@ For each environment you want to enable TFV in (typically `stage` first, then `p
 | --- | --- | --- |
 | `TFV_CONTACT_EMAIL`       | `support@example.com`               | Goes on the public TFV submission. Use an alias you don't mind being on a regulatory form. |
 | `TFV_CONTACT_PHONE`       | `+15551234567`                      | E.164 format. Same caveat as email. |
-| `TFV_TAX_ID`              | `12-3456789`                        | Business identification number (EIN for a US LLC). AWS marks this optional in the field metadata but carrier reviewers require it for `PRIVATE_PROFIT` and `PUBLIC_PROFIT` entities. Leave unset for `SOLE_PROPRIETOR` or `GOVERNMENT` entities that legitimately don't have one. Stored as a secret rather than a variable so it stays out of workflow logs (the value still appears on the public TFV submission to carriers). |
+| `TFV_TAX_ID`              | `12-3456789`                        | Business identification number (EIN for a US LLC). AWS marks this optional in the field metadata but carrier reviewers require it for `PRIVATE_PROFIT` and `PUBLIC_PROFIT` entities. Leave unset for `SOLE_PROPRIETOR` entities - carriers actively reject sole-proprietor submissions that include tax fields, and the script ignores `TFV_TAX_ID` (with a `[warn]` log line) when `TFV_BUSINESS_TYPE=SOLE_PROPRIETOR`. Stored as a secret rather than a variable so it stays out of workflow logs (the value still appears on the public TFV submission to carriers). |
 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` | (existing) | Already configured for `infra.yml`. The TFV workflow reuses them. |
 
 ## Triggering the workflow

--- a/scripts/submit-tfv-registration.py
+++ b/scripts/submit-tfv-registration.py
@@ -58,8 +58,11 @@ Optional env vars:
   TFV_TAX_ID                       Business identification number (EIN for a US LLC).
                                    AWS marks this optional in the field metadata but
                                    carrier reviewers require it for PRIVATE_PROFIT /
-                                   PUBLIC_PROFIT entities. SOLE_PROPRIETOR /
-                                   GOVERNMENT entities can leave it unset.
+                                   PUBLIC_PROFIT entities. SOLE_PROPRIETOR entities
+                                   should leave it unset; if set anyway it is
+                                   ignored with a warning, because carriers reject
+                                   sole-proprietor submissions that include tax
+                                   fields.
   TFV_TAX_ID_AUTHORITY             Default "EIN". Only used when TFV_TAX_ID is set.
                                    Allowed: EIN, CBN, CRN, PROVINCIAL_NUMBER, VAT,
                                    ACN, ABN, BRN, SIREN, SIRET, NZBN, USt-IdNr, CIF,
@@ -414,27 +417,38 @@ def main():
     if address2:
         fields_text["companyInfo.address2"] = address2
 
+    business_type = env("TFV_BUSINESS_TYPE", default="PRIVATE_PROFIT")
     fields_choice = {
         "messagingUseCase.monthlyMessageVolume": env("TFV_MONTHLY_VOLUME",    default="10"),
         "messagingUseCase.useCaseCategory":      env("TFV_USE_CASE_CATEGORY", default="ONE_TIME_PASSCODES"),
-        "companyInfo.businessType":              env("TFV_BUSINESS_TYPE",     default="PRIVATE_PROFIT"),
+        "companyInfo.businessType":              business_type,
         "messagingUseCase.optInType":            env("TFV_OPT_IN_TYPE",       default="DIGITAL_FORM"),
     }
 
     # Tax / business identifier. AWS marks taxId, taxIdAuthority, and
     # taxIdCountry as OPTIONAL in the field metadata, but in practice
     # carrier reviewers require them for PRIVATE_PROFIT and
-    # PUBLIC_PROFIT entities. The conditionality isn't exposed via
+    # PUBLIC_PROFIT entities and *reject* their presence on
+    # SOLE_PROPRIETOR submissions (a sole proprietor's only
+    # candidate is an SSN, which carriers don't want in this
+    # workflow). The conditionality isn't exposed via
     # describe-registration-field-definitions, so check_required_coverage
-    # cannot catch their absence.
+    # cannot catch either case.
     #
-    # Treat all three as a unit: if the operator supplies TFV_TAX_ID,
-    # also set authority + country (with sensible US-LLC defaults);
-    # otherwise skip all three. SOLE_PROPRIETOR / GOVERNMENT entities
-    # that legitimately don't have a business identifier just leave
-    # TFV_TAX_ID unset.
+    # Treat the three fields as a unit and gate on business type. If
+    # the operator has TFV_TAX_ID set but business type is
+    # SOLE_PROPRIETOR, log a warning and skip - the operator's
+    # leftover env-var value is suppressed rather than producing a
+    # rejection on resubmit.
     tax_id = env("TFV_TAX_ID")
-    if tax_id:
+    if business_type == "SOLE_PROPRIETOR":
+        if tax_id:
+            print(
+                "[warn] TFV_TAX_ID is set but TFV_BUSINESS_TYPE=SOLE_PROPRIETOR; "
+                "skipping companyInfo.taxId / taxIdAuthority / taxIdCountry "
+                "(carriers reject tax fields on sole-proprietor submissions)"
+            )
+    elif tax_id:
         fields_text["companyInfo.taxId"]        = tax_id
         fields_text["companyInfo.taxIdCountry"] = env("TFV_TAX_ID_COUNTRY",   default="US")
         fields_choice["companyInfo.taxIdAuthority"] = env("TFV_TAX_ID_AUTHORITY", default="EIN")


### PR DESCRIPTION
## Summary

Carriers reject toll-free verification submissions from `SOLE_PROPRIETOR` entities that include `companyInfo.taxId` / `taxIdAuthority` / `taxIdCountry` - a sole proprietor's only candidate identifier is an SSN and carriers don't want SSNs on this workflow. The conditionality is the *inverse* of the `PRIVATE_PROFIT` case from #429: AWS marks the fields optional, but for sole proprietors *presence is disqualifying*.

## Behavior change

When `TFV_BUSINESS_TYPE=SOLE_PROPRIETOR`, the script unconditionally skips the three tax fields regardless of whether `TFV_TAX_ID` is set. If it is set, the script logs:

```
[warn] TFV_TAX_ID is set but TFV_BUSINESS_TYPE=SOLE_PROPRIETOR; skipping companyInfo.taxId / taxIdAuthority / taxIdCountry (carriers reject tax fields on sole-proprietor submissions)
```

This handles the case where an operator switches their environment from `PRIVATE_PROFIT` to `SOLE_PROPRIETOR` and forgets to clear the leftover `TFV_TAX_ID` secret. The script suppresses the value rather than producing a carrier-rejected submission.

`business_type` is now read once before the `fields_choice` block so the gating logic and the field value share one source of truth.

## No operator action required

`PRIVATE_PROFIT` operators are unaffected - this is purely a defensive no-op against a misconfigured sole-proprietor instance. Stage currently uses `PRIVATE_PROFIT`, so the existing in-flight submission isn't touched.

## Test plan

- [x] Syntax check passes.
- [ ] On a hypothetical sole-prop instance with `TFV_TAX_ID` accidentally set, workflow logs the `[warn]` line and the three tax fields are absent from `[field]` lines.
- [ ] On a `PRIVATE_PROFIT` instance (stage), nothing changes - tax fields are still set as before.

Generated with [Claude Code](https://claude.com/claude-code)