### PR TITLE
Grant Claude Code the tools it needs to land a Dependabot fix PR

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -73,6 +73,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # In agent mode the action ships a restrictive default tool
+          # allowlist; without explicit permission Claude can't write files,
+          # run npm, commit, or open a PR. Grant the tools needed to bump a
+          # dependency end-to-end. Show full output so denials are visible
+          # in the run log instead of silently inflating
+          # permission_denials_count.
+          show_full_output: true
+          # Single-line to avoid YAML line-folding inserting spaces into the
+          # comma-separated tool list.
+          claude_args: '--allowed-tools "Read,Edit,Write,Glob,Grep,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*),Bash(yarn:*),Bash(pnpm:*),Bash(pip:*),Bash(pip3:*),Bash(python:*),Bash(python3:*),Bash(jq:*),Bash(cat:*),Bash(ls:*),Bash(grep:*),Bash(find:*)"'
           prompt: |
             You are a security remediation assistant. The following high
             and critical Dependabot alerts were found in this repository:


### PR DESCRIPTION
The action's agent mode (workflow_dispatch / schedule) ships a restrictive default tool allowlist. Last run completed "successfully" but with permission_denials_count: 29 across 48 turns — Claude couldn't write files, run npm, commit, push, or open a PR, and the action hides full output by default so the denials were invisible.

- Set show_full_output: true so future denials are visible in the run log.
- Pass --allowed-tools via claude_args covering Read/Edit/Write, Glob/Grep, and scoped Bash for git, gh, npm/npx/yarn/pnpm, pip/python, plus a few read-only utilities. Kept Bash scoped per command rather than blanket-allowed so the bot can't run arbitrary shell.