### PR TITLE
Hotfix: mail-tier task defs strand a deleted healthcheck SSM secret (prod imap down)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - Unreleased
+
+### Fixed
+- Mail-tier ECS tasks could fail to start after monitoring was turned off in an
+  environment. Turning monitoring off deletes the
+  `/cabal/healthcheck_ping_*` SSM parameters, but the `imap` and `smtp-in` task
+  definitions still referenced `/cabal/healthcheck_ping_ecs_reconfigure` as the
+  `HEALTHCHECK_PING_URL` secret. Because the mail task definitions carry
+  `lifecycle { ignore_changes = [container_definitions] }`, dropping the secret
+  from config never reached a new revision on its own, and the first image roll
+  after the monitoring removal (which clones the live task definition) produced a
+  revision the ECS agent could not start - it errored fetching the missing
+  parameter. Bumped the `imap` and `smtp-in` task-def revision markers to force a
+  clean re-registration, and keyed all three mail-tier markers on
+  `var.healthcheck_ping_param` (the `+hc` hook, mirroring the existing
+  `smtp-out` `+sinkhole` hook) so flipping monitoring in either direction now
+  forces the `HEALTHCHECK_PING_URL` secret to be added or dropped in step with
+  the SSM parameter that backs it. `smtp-out` was already clean (its v3 marker
+  re-registered it after the monitoring removal); the `+hc` hook is a no-op for
+  it today and only future-proofs it against a re-enable.
+
 ## [0.10.4] - 2026-06-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.5] - Unreleased
+## [0.10.5] - 2026-06-05
 
 ### Fixed
 - Mail-tier ECS tasks could fail to start after monitoring was turned off in an

--- a/terraform/infra/modules/ecs/task-definitions.tf
+++ b/terraform/infra/modules/ecs/task-definitions.tf
@@ -34,8 +34,23 @@ locals {
 #       (docs/0.10.x/container-runtime-hardening-plan.md phase 1)
 #   v2: runtime posture - cap drop=ALL + analyzed add set, no-new-privileges,
 #       initProcessEnabled (same plan, phase 2)
+#   v3: re-register from current config to drop a dangling HEALTHCHECK_PING_URL
+#       secret left baked in from when monitoring was enabled. Turning monitoring
+#       off deleted the SSM param /cabal/healthcheck_ping_ecs_reconfigure, but
+#       ignore_changes kept the now-broken secret reference on the running
+#       task def, so the first image roll after that (which clones the live
+#       task def) produced a revision the ECS agent could not start - it failed
+#       fetching the missing parameter.
+#
+# The +hc suffix keys this marker on whether the healthcheck secret is present
+# (var.healthcheck_ping_param != "", i.e. var.monitoring in the parent stack),
+# the same condition that gates local.healthcheck_secrets below. This mirrors
+# the smtp_out +sinkhole hook: flipping monitoring in either direction now
+# forces a task-def replacement that adds or drops the HEALTHCHECK_PING_URL
+# secret in step with the SSM param that backs it, so the secret set can never
+# again drift from the parameters that exist.
 resource "terraform_data" "imap_taskdef_revision_marker" {
-  input = "imap-taskdef-v2"
+  input = var.healthcheck_ping_param != "" ? "imap-taskdef-v3+hc" : "imap-taskdef-v3"
 }
 
 resource "aws_ecs_task_definition" "imap" {
@@ -166,8 +181,12 @@ resource "aws_ecs_task_definition" "imap" {
 #   v1: NET_ADMIN capability drop
 #       (docs/0.10.x/container-runtime-hardening-plan.md phase 1)
 #   v2: runtime posture (cap drop=ALL + adds, no-new-privileges, init) - phase 2
+#   v3: re-register from current config to drop the dangling HEALTHCHECK_PING_URL
+#       secret stranded by the monitoring removal (see the imap marker for the
+#       full story). The +hc suffix keys the marker on the healthcheck secret's
+#       presence so a future monitoring flip can't strand it again.
 resource "terraform_data" "smtp_in_taskdef_revision_marker" {
-  input = "smtp-in-taskdef-v2"
+  input = var.healthcheck_ping_param != "" ? "smtp-in-taskdef-v3+hc" : "smtp-in-taskdef-v3"
 }
 
 resource "aws_ecs_task_definition" "smtp_in" {
@@ -276,8 +295,14 @@ resource "terraform_data" "smtp_out_taskdef_revision_marker" {
   #   v2: NET_ADMIN capability drop
   #       (docs/0.10.x/container-runtime-hardening-plan.md phase 1)
   #   v3: runtime posture (cap drop=ALL + adds, no-new-privileges, init) - phase 2
-  # The +sinkhole suffix is the var.sinkhole hook described above.
-  input = var.sinkhole ? "smtp-queue-mount-v3+sinkhole" : "smtp-queue-mount-v3"
+  # The +sinkhole suffix is the var.sinkhole hook described above; the +hc
+  # suffix is the analogous var.healthcheck_ping_param hook (see the imap
+  # marker) that keeps the HEALTHCHECK_PING_URL secret in step with whether
+  # monitoring is enabled. smtp-out was already re-registered clean at v3 by
+  # the queue/sinkhole work after monitoring was removed, so appending +hc is a
+  # no-op for the current (monitoring-off) state and only future-proofs this
+  # tier against a re-enable.
+  input = "${var.sinkhole ? "smtp-queue-mount-v3+sinkhole" : "smtp-queue-mount-v3"}${var.healthcheck_ping_param != "" ? "+hc" : ""}"
 }
 
 resource "aws_ecs_task_definition" "smtp_out" {


### PR DESCRIPTION
## Summary

Prod `cabal-imap` is **down** (0/1 running, repeated task-start failures). The ECS agent cannot start the task because it tries to inject a secret from an SSM parameter that no longer exists:

```
Fetching secret data from SSM Parameter Store in us-east-1: invalid parameters: /cabal/healthcheck_ping_ecs_reconfigure
```

This is a direct-to-`main` hotfix for a prod outage.

## Root cause

- Turning monitoring off in prod destroyed the monitoring module, which **deleted** `/cabal/healthcheck_ping_*` (confirmed live: `ParameterNotFound`).
- The `imap` and `smtp-in` task definitions still referenced `/cabal/healthcheck_ping_ecs_reconfigure` as the `HEALTHCHECK_PING_URL` secret. `local.healthcheck_secrets` is `[]` when monitoring is off, but the mail task defs carry `lifecycle { ignore_changes = [container_definitions] }`, so dropping the secret from config never reached a new revision - it needed a revision-marker bump that the monitoring-removal change didn't do.
- The first image roll after the removal cloned the live (dirty) task def via `deploy-ecs-service.sh` and registered a revision the ECS agent can't start.

Contrast confirming the mechanism: `smtp-out` is clean because its marker was bumped to `v3` (queue/sinkhole work) **after** the monitoring removal; `imap`/`smtp-in` were still on `v2`, registered while monitoring was on, so both carry the dangling secret.

## Fix

- Bump the `imap` and `smtp-in` revision markers `v2 -> v3` to force a clean re-registration from config (`healthcheck_secrets = []` when monitoring is off).
- Key all three mail-tier markers on `var.healthcheck_ping_param != ""` via a `+hc` suffix - mirroring the existing `smtp-out` `+sinkhole` hook - so flipping monitoring in either direction forces the `HEALTHCHECK_PING_URL` secret to track the SSM param that backs it. Makes this class of bug self-healing instead of a manual-bump landmine.
- `smtp-out` evaluates to its current string today (monitoring off, sinkhole off) -> **no recreate**; `+hc` only future-proofs it.

## Recovery on apply

`infra.yml` recreates the `imap` and `smtp-in` task defs (image re-pinned to current by `refresh-ssm-from-running.sh`), then `post-apply-update-services.sh` rolls both services to the clean revisions. IMAP recovers; smtp-in gets a brief clean restart.

## Verification

- `terraform fmt -check` passes.
- Marker evaluation (monitoring off everywhere): `imap` `v2->v3` (recreate), `smtp-in` `v2->v3` (recreate), `smtp-out` unchanged (no recreate).
- Confirmed live in prod: SSM param absent; `cabal-imap:106` and `cabal-smtp-in:104` task defs still carry the stale secret; `cabal-smtp-out:106` is already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)