### PR TITLE
IaC decay: clear EFS-in-backup false positive (CKV2_AWS_18)

### DIFF
--- a/changelog.d/iac-decay-efs-backup.changed.md
+++ b/changelog.d/iac-decay-efs-backup.changed.md
@@ -1,0 +1,7 @@
+- The EFS mailstore's `CKV2_AWS_18` scanner finding (Backup-plan
+  membership) moved from an opaque per-resource baseline grandfather to
+  a co-located inline `#checkov:skip` with rationale. The mailstore is
+  already in the AWS Backup selection when `var.backup` is set; the
+  graph check cannot trace that count-gated, cross-module reference, so
+  the finding is a false positive. The infra checkov baseline shrinks by
+  one entry. No infrastructure change.

--- a/terraform/infra/.checkov.baseline
+++ b/terraform/infra/.checkov.baseline
@@ -269,12 +269,6 @@
                     "check_ids": [
                         "CKV_AWS_330"
                     ]
-                },
-                {
-                    "resource": "module.efs.aws_efs_file_system.mailstore",
-                    "check_ids": [
-                        "CKV2_AWS_18"
-                    ]
                 }
             ]
         },

--- a/terraform/infra/BASELINE.md
+++ b/terraform/infra/BASELINE.md
@@ -18,7 +18,7 @@ Counts reflect **pip checkov** (what CI runs). See the [graph-check note](#graph
 
 | Tool | Total | CMK global-suppress | Baselined | Fixed / inline-suppressed (2.5) | Residual |
 | ---- | ----- | ------------------- | --------- | ------------------------------- | -------- |
-| Checkov | 243 | 76 (12 ids) | 154 (47 ids) | 13 (276, 51, 8, 341, 26, 27x3, 103, 74, 12 fixed; 111, 356 inline) | 0 |
+| Checkov | 243 | 76 (12 ids) | 153 (46 ids) | 14 (276, 51, 8, 341, 26, 27x3, 103, 74, 12 fixed; 111, 356, 2_18 inline) | 0 |
 | Trivy   | 50  | 26 (5 ids)  | 20 (10 ids) | 4 (AWS-0031, 0095, 0096, 0131 fixed) | 0 |
 | tflint  | 6   | 0           | 0 (never baselined) | 6 fixed (`tls` version + 5 unused decls) | 0 |
 
@@ -37,6 +37,12 @@ The resilience/continuity hardening work ([`docs/0.10.x/resilience-continuity-ha
 - **AWS-0025** (DynamoDB SSE/CMK, Trivy) - cleared from `.trivyignore`: the counter table was the only table without an explicit `server_side_encryption` block; with it in place no table trips the rule.
 - **CKV2_AWS_38** on `module.domains.aws_route53_zone.mail_dns` - cleared: DNSSEC signing exists behind `var.dnssec_enabled` (default false; see `docs/dnssec.md`). The graph check connects zone to `aws_route53_hosted_zone_dnssec` without evaluating the count gate, so it passes even while the flag is off; the entry had to come out to keep the drift check green. The real signing posture is per-environment (`TF_VAR_DNSSEC_ENABLED`). CKV2_AWS_39 (query logging) remains baselined.
 - **OAC migration (Phase 5)**: both CloudFront distributions moved from OAI to origin access control and the viewer TLS floor rose to `TLSv1.2_2025`. The admin bucket policy moved from the s3 module to the app module - Terraform tolerates the mutual module reference the OAC SourceArn would otherwise need (acyclic at the resource level), but checkov's graph renderer does not: it stops resolving unrelated variables and reports phantom findings on count-gated resources (observed on the sinkhole SG rule and log group). Keep cross-module references one-directional.
+
+### Decay clears (Phase 4)
+
+The weekly decay task walks the grandfathered findings down one at a time:
+
+- **CKV2_AWS_18** on `module.efs.aws_efs_file_system.mailstore` - cleared via inline skip (not a code change): the mailstore *is* in the AWS Backup selection (`module.backup` `aws_backup_selection.resources` includes `var.efs`), so the finding is a false positive. The backup module is count-gated on `var.backup` and the EFS ARN crosses the module boundary as a variable, neither of which the graph check can trace, so it reports the mailstore as unbacked even when backups are on. Replaced the opaque baseline entry with a co-located `#checkov:skip` carrying the rationale; baseline entry removed. Per-environment backup posture is still governed by `TF_VAR_BACKUP` (off in non-prod for cost, on in prod) - that gating is the design choice, documented in the `backup` module.
 
 ### NAT-mode refactor re-key (0.10.x)
 

--- a/terraform/infra/modules/efs/main.tf
+++ b/terraform/infra/modules/efs/main.tf
@@ -3,6 +3,7 @@
 */
 
 resource "aws_efs_file_system" "mailstore" {
+  #checkov:skip=CKV2_AWS_18:mailstore is in the AWS Backup selection (module.backup aws_backup_selection.resources) when var.backup is set; the backup module is count-gated and the EFS ARN crosses the module boundary as a variable, which checkov graph checks cannot trace
   encrypted = true
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"


### PR DESCRIPTION
## Weekly IaC decay

Top backlog item: **EFS mailstore in the AWS Backup plan** (`CKV2_AWS_18`, `module.efs.aws_efs_file_system.mailstore`).

### Disposition: false positive, cleared via inline skip
The mailstore is **already** in the AWS Backup selection - `module.backup`'s `aws_backup_selection.resources` includes `var.efs` whenever `var.backup` is set. Checkov's graph check can't see it because the `backup` module is `count`-gated on `var.backup` and the EFS ARN crosses the module boundary as a variable; neither is statically traceable.

Replaced the opaque per-resource baseline grandfather with a co-located `#checkov:skip` carrying that rationale, and regenerated the infra checkov baseline (shrinks by one entry, 151 -> 150 occurrences). **No infrastructure change** - purely a scanner-gate representation change.

### Files
- `terraform/infra/modules/efs/main.tf` - inline `#checkov:skip=CKV2_AWS_18` with rationale
- `terraform/infra/.checkov.baseline` - regenerated (one entry removed)
- `terraform/infra/BASELINE.md` - counts + "Decay clears (Phase 4)" note
- `changelog.d/iac-decay-efs-backup.changed.md` - changelog fragment

### Stage validation
**Not required.** No data-plane, IAM, message-flow, or running-system impact - only a scanner suppression and docs.

### Verification
- `make scan` -> exit 0
- `make drift` -> exit 0 (no stale baseline/ignore entries)
- `terraform fmt -check -recursive terraform/infra` -> clean
- `terraform validate` -> Success (pre-existing `ignore_changes` warnings unrelated)

### Next backlog item
**Lambda dead-letter queues** (`CKV_AWS_116`, 9 occurrences) - touches IAM + message-flow, so better suited to a human-attended run.

(Item 2, DynamoDB PITR / `CKV_AWS_28`, was already cleared from the gate in 0.10.x resilience hardening - stale backlog entry, closed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)