### PR TITLE
IaC decay: S3 bucket versioning; reclassify Lambda DLQ gate (CKV_AWS_21, CKV_AWS_116)

### DIFF
--- a/changelog.d/s3-bucket-versioning.changed.md
+++ b/changelog.d/s3-bucket-versioning.changed.md
@@ -1,0 +1,6 @@
+- Enabled S3 versioning on the two infra buckets holding durable
+  content - the admin bucket (React bundle plus Lambda deploy
+  artifacts) and the public front-door site - so an accidental
+  overwrite or delete can be rolled back. The transient cache bucket
+  (two-day object expiry) is intentionally left unversioned. Clears the
+  `CKV_AWS_21` / `AWS-0090` scanner findings.

--- a/terraform/infra/.checkov.baseline
+++ b/terraform/infra/.checkov.baseline
@@ -154,8 +154,7 @@
                     "check_ids": [
                         "CKV2_AWS_62",
                         "CKV_AWS_144",
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 },
                 {
@@ -303,8 +302,7 @@
                         "CKV2_AWS_61",
                         "CKV2_AWS_62",
                         "CKV_AWS_144",
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 },
                 {
@@ -631,8 +629,7 @@
                         "CKV2_AWS_61",
                         "CKV2_AWS_62",
                         "CKV_AWS_144",
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 }
             ]

--- a/terraform/infra/.trivyignore
+++ b/terraform/infra/.trivyignore
@@ -25,6 +25,7 @@ AWS-0104  # Unrestricted egress: ECS tasks and the NAT instance need broad outbo
 AWS-0320  # S3 bucket names not DNS-compliant: names are stable identifiers; renaming means a data migration
 AWS-0178  # VPC flow logs disabled: deliberate cost choice, consistent with monitoring being off in every environment
 AWS-0190  # API Gateway response caching disabled: caching is undesirable for this mailbox API
+AWS-0090  # S3 versioning: the durable buckets (modules/s3, modules/front_door) now version; this id remains only for cache.<control_domain>, a transient cache whose objects expire after two days (Trivy ignores by id, not per resource)
 
 # --- Must-fix in Phase 2.5 (all cleared) -------------------------------
 # AWS-0031 (ECR mutable) fixed in the safe batch; AWS-0095 (SNS unencrypted),
@@ -35,7 +36,9 @@ AWS-0190  # API Gateway response caching disabled: caching is undesirable for th
 # --- Decay: low/medium hygiene, walk down over time --------------------
 # AWS-0024 (DynamoDB PITR) cleared in 0.10.x: every table now enables
 # point_in_time_recovery (the counter table was the last holdout).
-AWS-0090  # S3 data versioning (transient cache/artifact buckets)
+# AWS-0090 (S3 versioning) reclassified in Phase 4: the durable buckets
+# now version; the residual is the transient cache, moved to the
+# design-driven section above.
 AWS-0089  # S3 bucket access logging
 AWS-0066  # Lambda X-Ray tracing
 AWS-0124  # Security group rule missing description

--- a/terraform/infra/BASELINE.md
+++ b/terraform/infra/BASELINE.md
@@ -18,7 +18,7 @@ Counts reflect **pip checkov** (what CI runs). See the [graph-check note](#graph
 
 | Tool | Total | CMK global-suppress | Baselined | Fixed / inline-suppressed (2.5) | Residual |
 | ---- | ----- | ------------------- | --------- | ------------------------------- | -------- |
-| Checkov | 243 | 76 (12 ids) | 153 (46 ids) | 14 (276, 51, 8, 341, 26, 27x3, 103, 74, 12 fixed; 111, 356, 2_18 inline) | 0 |
+| Checkov | 243 | 76 (12 ids) | 147 (44 ids) | 14 (276, 51, 8, 341, 26, 27x3, 103, 74, 12 fixed; 111, 356, 2_18, 21 inline) | 0 |
 | Trivy   | 50  | 26 (5 ids)  | 20 (10 ids) | 4 (AWS-0031, 0095, 0096, 0131 fixed) | 0 |
 | tflint  | 6   | 0           | 0 (never baselined) | 6 fixed (`tls` version + 5 unused decls) | 0 |
 
@@ -43,6 +43,8 @@ The resilience/continuity hardening work ([`docs/0.10.x/resilience-continuity-ha
 The weekly decay task walks the grandfathered findings down one at a time:
 
 - **CKV2_AWS_18** on `module.efs.aws_efs_file_system.mailstore` - cleared via inline skip (not a code change): the mailstore *is* in the AWS Backup selection (`module.backup` `aws_backup_selection.resources` includes `var.efs`), so the finding is a false positive. The backup module is count-gated on `var.backup` and the EFS ARN crosses the module boundary as a variable, neither of which the graph check can trace, so it reports the mailstore as unbacked even when backups are on. Replaced the opaque baseline entry with a co-located `#checkov:skip` carrying the rationale; baseline entry removed. Per-environment backup posture is still governed by `TF_VAR_BACKUP` (off in non-prod for cost, on in prod) - that gating is the design choice, documented in the `backup` module.
+- **CKV_AWS_21 / AWS-0090** (S3 bucket versioning) on the three flagged buckets - split into fix + reclassify. The two buckets holding durable, hard-to-regenerate content now enable versioning: `module.bucket` (`modules/s3`, the `admin.<control_domain>` bucket that stores the React bundle and the Lambda deploy zips Terraform reads for `source_code_hash`) and `module.front_door` (the public privacy-policy / terms-of-service site). Their CKV_AWS_21 baseline entries are removed. The third, `module.admin.aws_s3_bucket.cache` (`cache.<control_domain>`), is a genuinely transient cache: every object is a regenerable derivative and a lifecycle rule expires all of them after two days, so versioning would only retain throwaway data at cost. It carries a co-located `#checkov:skip=CKV_AWS_21` instead; the Trivy id `AWS-0090` stays in `.trivyignore` (Trivy ignores by id, not per resource) but moved from its decay section to the design-driven section, since it now corresponds solely to that transient cache.
+- **CKV_AWS_116** (Lambda dead-letter queue, x9) - reclassified to design-driven (no code change), moved from the decay table to section 3. The function `dead_letter_config` block only catches *asynchronous* (Event) invocations; none of the nine functions relies on that path in a way the block would help. Full per-function rationale is in the section 3 row; the baseline entries stay (per resource, so a new async Lambda is still caught).
 
 ### NAT-mode refactor re-key (0.10.x)
 
@@ -108,6 +110,7 @@ Accepted as intentional architecture. Baselined **per resource** (not globally s
 | CKV_AWS_126 | - | EC2 detailed monitoring off - cost |
 | CKV_AWS_258, CKV_AWS_301 (x2) | - | Monitoring `alert_sink` Lambda URL - the monitoring tier is dormant (`TF_VAR_MONITORING=false` everywhere); revisit if it is ever enabled |
 | CKV_AWS_338 (x23) | - | CloudWatch retention - see decay (candidate to set an explicit retention rather than accept) |
+| CKV_AWS_116 (x9) | - | Lambda dead-letter queue - the function `dead_letter_config` block fires only on *asynchronous* (Event) invocations, which is not how these nine functions fail in a way the block would catch. `append_sent` is an SQS event-source consumer already protected by its source queue's redrive policy to `cabal-append-sent-dlq` (the check cannot see source-queue DLQs, same blind spot as the `CKV2_AWS_18` EFS clear). `api_call` (API Gateway), `check_invite` (Cognito pre-sign-up), `assign_osid` (Cognito post-confirmation), `alert_sink` (Lambda Function URL), and `healthchecks_iac` (apply-time `aws_lambda_invocation`) are all synchronous - a failure returns to the caller, nothing is silently dropped. `process_dmarc` and `certbot` are idempotent EventBridge *Scheduler* jobs that self-heal on the next run (Scheduler carries its own target DLQ, distinct from the function block). `backup_heartbeat` is the lone async (EventBridge *Rule*) invoke, but it lives in the dormant monitoring tier (`TF_VAR_MONITORING=false` everywhere) and a *missing* heartbeat is itself the intended alarm. Revisit per function if any gains a fan-out async invoker. |
 | CKV_AWS_330 | - | EFS access point user identity - mailstore needs specific uid/gid; revisit |
 | CKV2_AWS_34 (x4) | - | SSM parameters holding deploy metadata (per-tier image tags, CloudFront distribution ids, sinkhole mode) are plaintext String by design - they are not secrets |
 | CKV2_AWS_19 | - | NAT EIPs attach to whichever NAT mode is active (instance association or gateway allocation); kept unattached while quiesced for stable relay IPs |
@@ -122,12 +125,11 @@ Low-value hygiene. Each release should clear or re-justify entries whose target 
 | ------- | ----- | ---- | ------ |
 | CKV_AWS_338 (x23) | - | Set explicit CloudWatch log retention (also caps cost vs. never-expire) | 0.11.x |
 | CKV_AWS_115 (x9) | - | Lambda reserved concurrency | 1.0.0 |
-| CKV_AWS_116 (x9) | - | Lambda DLQ (where a dropped invoke matters) | 1.0.0 |
 | CKV_AWS_86, CKV_AWS_91 | AWS-0089 | CloudFront / S3 access logging (CKV_AWS_91 on the mail NLB cleared in 0.10.x - resilience plan Phase 3; the remaining CKV_AWS_91 is the dormant monitoring ALB) | 1.0.0 |
 | CKV_AWS_150 (x2) | - | Load balancer deletion protection | 0.11.x |
 | CKV_AWS_23 (x3) | AWS-0124 | Security group rule descriptions | 0.11.x |
 | CKV_AWS_300 | - | S3 lifecycle: abort incomplete multipart uploads | 0.11.x |
-| CKV_AWS_135 | AWS-0090 | EC2 EBS-optimized / S3 versioning | 1.0.0 |
+| CKV_AWS_135 | - | EC2 EBS-optimized | 1.0.0 |
 | CKV_AWS_237 | - | API Gateway create-before-destroy lifecycle | 1.0.0 |
 
 ## Notes / known limitations

--- a/terraform/infra/modules/app/s3.tf
+++ b/terraform/infra/modules/app/s3.tf
@@ -84,8 +84,16 @@ resource "aws_s3_object" "node_config" {
   )
 }
 
-# Bucket for app cache
+# Bucket for app cache.
+#
+# Versioning is intentionally off: every object here is a regenerable
+# derivative (cached .eml bodies, attachment staging, DMARC reports,
+# config.js) and the lifecycle rule below expires all of them after two
+# days, so retaining noncurrent versions would add cost with nothing to
+# recover. CKV_AWS_21 / AWS-0090 are suppressed for this bucket alone -
+# the durable buckets (modules/s3, modules/front_door) do version.
 resource "aws_s3_bucket" "cache" {
+  #checkov:skip=CKV_AWS_21:Transient cache - all objects expire after two days (lifecycle rule below); versioning would only retain regenerable derivatives.
   bucket = "cache.${var.control_domain}"
 }
 

--- a/terraform/infra/modules/front_door/main.tf
+++ b/terraform/infra/modules/front_door/main.tf
@@ -44,6 +44,17 @@ resource "aws_s3_bucket_public_access_block" "this" {
   restrict_public_buckets = true
 }
 
+# Versioning lets an accidentally overwritten or deleted published
+# object (the privacy policy / terms of service referenced by carrier
+# registration) be recovered. The site is small and rarely changes, so
+# noncurrent versions are negligible.
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 # LEGACY origin access identity, superseded by the OAC below (Phase 5
 # of docs/0.10.x/resilience-continuity-hardening-plan.md). Kept,
 # together with its bucket-policy statement, so the distribution keeps

--- a/terraform/infra/modules/s3/main.tf
+++ b/terraform/infra/modules/s3/main.tf
@@ -46,3 +46,17 @@ resource "aws_s3_bucket_public_access_block" "react_access" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+# Versioning protects the deploy artifacts this bucket holds - the
+# React bundle and the Lambda zips that Terraform reads for
+# source_code_hash and that `aws lambda update-function-code` ships
+# from - so an accidental overwrite or delete of a known-good artifact
+# can be rolled back. Churn is low (Vite emits hash-named assets as new
+# keys; only a handful of stable-named objects are ever overwritten),
+# so noncurrent versions do not meaningfully accumulate.
+resource "aws_s3_bucket_versioning" "react_app" {
+  bucket = local.bucket
+  versioning_configuration {
+    status = "Enabled"
+  }
+}


### PR DESCRIPTION
Weekly IaC quality-gates decay run. Took the top two backlog items: fixed S3 bucket versioning, and reclassified the Lambda DLQ check as design-driven after investigation showed it is not a real gap.

## CKV_AWS_21 / AWS-0090 - S3 bucket versioning (fixed + reclassified)

Three buckets were flagged. Split by whether the content is durable:

- **`module.bucket`** (`modules/s3`, the `admin.<control_domain>` bucket holding the React bundle and the Lambda deploy zips Terraform reads for `source_code_hash`) -> **versioning enabled**.
- **`module.front_door`** (public privacy-policy / terms-of-service site referenced by carrier registration) -> **versioning enabled**.
- **`module.admin.aws_s3_bucket.cache`** (`cache.<control_domain>`) -> **left unversioned, reclassified design-driven**: every object is a regenerable derivative and a lifecycle rule expires all of them after two days, so versioning would only retain throwaway data at cost. Carries a co-located `#checkov:skip=CKV_AWS_21`; `AWS-0090` stays in `.trivyignore` (Trivy ignores by id, not per resource) but moved to the design-driven section since it now matches only this bucket.

Checkov baseline regenerated (3 `CKV_AWS_21` entries removed); `BASELINE.md` counts and Phase-4 clear note updated.

## CKV_AWS_116 - Lambda dead-letter queue (reclassified, no code change)

On investigation this is design-driven across all nine functions, not a gap. The function `dead_letter_config` block fires only on **asynchronous (Event)** invocations:

| Function | Invocation | Why a function DLQ does not apply |
|---|---|---|
| `append_sent` | SQS event-source mapping | Already protected by its source queue's redrive to `cabal-append-sent-dlq` (the check cannot see source-queue DLQs) |
| `api_call` | API Gateway (sync) | Error returns to caller |
| `check_invite` / `assign_osid` | Cognito triggers (sync) | Error returns to caller |
| `alert_sink` | Lambda Function URL (sync) | Error returns to caller |
| `healthchecks_iac` | apply-time `aws_lambda_invocation` (sync) | Error returns to caller |
| `process_dmarc` / `certbot` | EventBridge Scheduler, idempotent | Self-heal on next run; Scheduler has its own target DLQ |
| `backup_heartbeat` | EventBridge Rule (async) | Only true async case, but in the dormant monitoring tier; a *missing* heartbeat is itself the intended alarm |

Baseline entries kept per resource (so a new async Lambda is still caught); the row moved from the decay table to the design-driven section in `BASELINE.md`. The external decay backlog is updated out-of-band (not part of this PR).

## Verification

- `make scan` -> exit 0 (Checkov + tflint + trivy + suppression-justification + IAM-scope checks all clean for `terraform/dns` and `terraform/infra`)
- `make drift` -> exit 0 ("no stale entries" in all four baseline/ignore files)
- `terraform fmt -check -recursive terraform/infra` -> clean
- `terraform init -backend=false && terraform validate` -> Success (two pre-existing `ignore_changes` warnings on `aws_s3_object` `version_id`, in files this PR does not touch)

## STAGE-VALIDATE (low risk, non-blocking)

Enabling versioning is transparent to `PutObject` and needs no IAM change, but it is on the artifact-deploy path, so after this merges to stage confirm:

- A React deploy (`app.yml`, `s3 sync` to the admin bucket) still publishes normally.
- A Lambda artifact upload + `aws lambda update-function-code` still works (the zips now land as new object versions).

Nothing deploys until a human reviews and merges this PR to stage. Merging to stage is the deliberate human step.