### PR TITLE
Scale message list row height with Dynamic Type

### DIFF
--- a/apple/Cabalmail/Views/MessageListView+Selection.swift
+++ b/apple/Cabalmail/Views/MessageListView+Selection.swift
@@ -18,7 +18,7 @@ extension MessageListView {
     /// envelope via `model.envelope(at:)` and renders a placeholder until the
     /// loaded window covers it; `ensureLoaded(around:)` (on each row's `.task`)
     /// slides/jumps the window to follow the scroll. All rows are pinned to
-    /// `MessageListView.rowHeight`, so the extent is exactly `rowCount * height`
+    /// `rowHeight`, so the extent is exactly `rowCount * height`
     /// -- a stable, true-to-size scrollbar with no spacer cells. A tap
     /// selects/opens; the per-row context menu and drag come from `row(...)`.
     /// Swipe-to-dispose, native multi-select, and keyboard nav are Stage B.
@@ -206,7 +206,7 @@ extension MessageListView {
             if model.bulkMode {
                 row(for: envelope, model: model, isSelected: selected, orderedVisible: visible)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .frame(height: MessageListView.rowHeight, alignment: .center)
+                    .frame(height: rowHeight, alignment: .center)
                     .background(background)
             } else {
                 // `draggableRow` (drag-to-folder) wraps OUTSIDE `SwipeActionRow`
@@ -215,7 +215,7 @@ extension MessageListView {
                 // is swallowed on macOS and never lifts.
                 draggableRow(for: envelope, model: model) {
                     SwipeActionRow(
-                        height: MessageListView.rowHeight,
+                        height: rowHeight,
                         rowBackground: background,
                         leading: toggleReadSwipe(for: envelope, model: model),
                         trailing: disposeSwipe(for: envelope, model: model),
@@ -242,7 +242,7 @@ extension MessageListView {
 
     /// Thin hairline between rows. Drawn as a bottom `.overlay` (not a stack
     /// member) so it adds NO height: index-addressed virtualization pins every
-    /// row to `MessageListView.rowHeight` and the scroll extent is
+    /// row to `rowHeight` and the scroll extent is
     /// `rowCount * rowHeight`, so a row that grew by a divider's height would
     /// drift the placeholder rows out of alignment with their slots (see
     /// `virtualizedList`). `Divider` carries the platform's system separator
@@ -265,7 +265,7 @@ extension MessageListView {
             Spacer()
         }
         .padding(.horizontal, 16)
-        .frame(height: MessageListView.rowHeight, alignment: .center)
+        .frame(height: rowHeight, alignment: .center)
         .redacted(reason: .placeholder)
         .accessibilityHidden(true)
         .overlay(alignment: .bottom) { rowSeparator() }

--- a/apple/Cabalmail/Views/MessageListView.swift
+++ b/apple/Cabalmail/Views/MessageListView.swift
@@ -49,18 +49,27 @@ struct MessageListView: View {
     // can read them without round-tripping through accessors.
     @State var model: MessageListViewModel?
     @State private var composeSeed: Draft?
-    /// Fixed list-row height. Rows are pinned to this so the virtualized list
+    /// List-row height. Rows are pinned to this so the virtualized list
     /// (`+Selection`'s `virtualizedList`) can reserve the off-window rows as
     /// exact blank space: the scroll extent then reflects the whole folder, the
     /// scrollbar is true-to-size, and each row keeps its absolute position.
-    /// The index-addressed virtualization needs ONE uniform height, so this has
-    /// to clear the tallest row -- a sender line plus a two-line subject. A
-    /// one-line subject (the common case) keeps the height with a little
-    /// whitespace below; that slack is the price of uniform rows. Trimmed from
-    /// 72 (which left far more gap than the content needs) toward that 2-line
-    /// floor; lower it further only if two-line subjects still fit without
-    /// clipping.
-    static let rowHeight: CGFloat = 58
+    ///
+    /// The index-addressed virtualization needs ONE *uniform* height -- but
+    /// uniform doesn't mean constant. `@ScaledMetric` scales the base value with
+    /// the user's Dynamic Type setting (relative to `.subheadline`, the text
+    /// style the row's two lines use), so every row and every placeholder reads
+    /// the same height at any given setting -- the invariant holds -- and they
+    /// all recompute together when the accessibility size changes. Without this,
+    /// larger accessibility fonts overflowed the fixed height and the per-row
+    /// `SwipeActionRow` List began scrolling its own clipped content, capturing
+    /// the drag meant to scroll the whole list.
+    ///
+    /// The base 58 clears the row's two `.subheadline` lines (sender route +
+    /// one-line subject) at the default size with a little slack; scaling
+    /// preserves that slack proportionally. Instance (not `static`) because
+    /// `@ScaledMetric` reads the environment; module-internal so the
+    /// `+Selection` extension can pin rows and placeholders to it.
+    @ScaledMetric(relativeTo: .subheadline) var rowHeight: CGFloat = 58
     /// `true` while the filter sheet is presented over the message list.
     @State var filtersPresented = false
     /// Set by the row context menu's "Move to folder…" item; presents the

--- a/changelog.d/ios-list-dynamic-type-row-height.fixed.md
+++ b/changelog.d/ios-list-dynamic-type-row-height.fixed.md
@@ -1,0 +1,4 @@
+- Fixed the message list at large accessibility text sizes: row height now
+  scales with Dynamic Type, so message details no longer overflow the row
+  and dragging scrolls the whole list again instead of getting trapped
+  scrolling a single row's content.


### PR DESCRIPTION
## Problem
At large iOS accessibility text sizes the message list broke: the fixed 58pt row height clipped the row content, and the per-row `SwipeActionRow` embedded `List` then scrolled its own overflow — capturing drags meant to scroll the whole list (hard to scroll the list vs. a single row's content).

## Fix
Make `MessageListView.rowHeight` an `@ScaledMetric(relativeTo: .subheadline)` instance property (was a `static let 58`). It now scales with the user's Dynamic Type setting while staying **uniform** across every row and placeholder — preserving the index-addressed virtualization's extent (`rowCount × rowHeight`) and placeholder-alignment invariant. Two `.subheadline` lines scale proportionally, so the slack is preserved and the content no longer overflows; with no overflow, `SwipeActionRow`'s vertical-pass-through to the outer `ScrollView` works again. References updated from the former static to the instance property; no model/extent math changed.

## Verification
- ✅ Builds: macOS, iOS, visionOS (iPadOS rides iOS) — all `BUILD SUCCEEDED`
- ✅ `swiftlint --strict` — 0 violations
- 🔲 **On-device Dynamic Type validation pending** (these list/UI changes need real-device confirmation before merge; the `@ScaledMetric` factor may want tuning at the largest AX sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)