### PR TITLE
Move build helper out of apple/ to scripts/build-apple.sh

### DIFF
--- a/scripts/build-apple.sh
+++ b/scripts/build-apple.sh
@@ -4,13 +4,17 @@
 # in .github/workflows/apple.yml so a local "does it build?" check matches CI
 # instead of being hand-assembled each time (and drifting).
 #
-# Usage:
-#   ./build.sh                 # generate + lint + build all platforms (default)
-#   ./build.sh lint            # swiftlint --strict only
-#   ./build.sh macos|ios|visionos
-#   ./build.sh kit-test        # xcodebuild test for CabalmailKit
-#   ./build.sh all             # lint + macos + ios + visionos
-#   ./build.sh generate        # xcodegen generate only
+# Lives in scripts/ (not apple/) on purpose: a script under apple/ would trip
+# apple.yml's `apple/**` path filter and kick off a full Apple CI build on
+# every edit. It operates on the apple/ tree by cd-ing there below.
+#
+# Usage (from the repo root):
+#   scripts/build-apple.sh              # generate + lint + build all platforms (default)
+#   scripts/build-apple.sh lint         # swiftlint --strict only
+#   scripts/build-apple.sh macos|ios|visionos
+#   scripts/build-apple.sh kit-test     # xcodebuild test for CabalmailKit
+#   scripts/build-apple.sh all          # lint + macos + ios + visionos
+#   scripts/build-apple.sh generate     # xcodegen generate only
 #
 # The .xcodeproj is generated (not committed), so every target runs
 # `xcodegen generate` first. swiftlint and xcodebuild both need full Xcode
@@ -27,7 +31,8 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")"
+# This script lives in scripts/; everything below runs against the apple/ tree.
+cd "$(dirname "$0")/../apple"
 
 readonly WORKSPACE="Cabalmail.xcworkspace"
 readonly DERIVED_DATA="${DERIVED_DATA:-$PWD/.derivedData}"


### PR DESCRIPTION
Follow-up to #524 (merged).

## Why
A build *script* living under `apple/` matches `apple.yml`'s `apple/**` push path filter, so every edit to the helper would trigger a full Apple iOS+macOS build/test/lint run in CI — for a change that can't affect the build. Moving it to the top-level `scripts/` directory (dev/operator helpers; no workflow watches `scripts/**`) makes script edits CI-free.

## What
- `git mv apple/build.sh scripts/build-apple.sh` (rename matches the dir's descriptive style and disambiguates from a bare `build.sh`).
- `cd "$(dirname "$0")/../apple"` so it still operates on the `apple/` tree from its new location.
- Usage comments updated to `scripts/build-apple.sh` (run from repo root).
- No behavior change; `.derivedData` still lands in `apple/` and stays gitignored.

## Verification
- ✅ `scripts/build-apple.sh lint` from repo root — clean `xcodegen generate` + `swiftlint --strict`, 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)