### PR TITLE
iOS: fix archive-then-background watchdog crash (hand-rolled swipe)

### DIFF
--- a/apple/Cabalmail/Views/MessageListView+Selection.swift
+++ b/apple/Cabalmail/Views/MessageListView+Selection.swift
@@ -209,20 +209,14 @@ extension MessageListView {
                     .frame(height: rowHeight, alignment: .center)
                     .background(background)
             } else {
-                // `draggableRow` (drag-to-folder) wraps OUTSIDE `SwipeActionRow`
-                // so the drag sits on the row container, not inside the embedded
-                // List that owns the swipe -- a `.draggable` within that List row
-                // is swallowed on macOS and never lifts.
+                // `draggableRow` (drag-to-folder) wraps OUTSIDE the swipe row
+                // so the drag sits on the row container, not inside the swipe
+                // mechanism -- a `.draggable` within the embedded List the
+                // macOS path uses is swallowed and never lifts.
                 draggableRow(for: envelope, model: model) {
-                    SwipeActionRow(
-                        height: rowHeight,
-                        rowBackground: background,
-                        leading: toggleReadSwipe(for: envelope, model: model),
-                        trailing: disposeSwipe(for: envelope, model: model),
-                        onSelect: { selectRow(envelope, model: model, ordered: visible) },
-                        content: {
-                            row(for: envelope, model: model, isSelected: selected, orderedVisible: visible)
-                        }
+                    swipeRow(
+                        for: envelope, model: model,
+                        background: background, visible: visible, selected: selected
                     )
                 }
             }
@@ -238,6 +232,49 @@ extension MessageListView {
             }
         }
         .overlay(alignment: .bottom) { rowSeparator() }
+    }
+
+    /// The swipe-actions wrapper for a loaded row. Touch platforms (iOS /
+    /// iPadOS / visionOS) use the hand-rolled `SwipeRow` -- a `ZStack` +
+    /// `DragGesture`, no nested scroll view. The per-row embedded `List` that
+    /// borrowing native `.swipeActions` requires made a background scene-update
+    /// relayout exceed the 10-second watchdog (0x8BADF00D), killing the app a
+    /// second or two after an archive-then-background even on a folder of fewer
+    /// than 30 messages. macOS keeps the native `.swipeActions` via
+    /// `SwipeActionRow`: there the swipe is a two-finger trackpad scroll gesture
+    /// a `DragGesture` can't read, and the Mac has no scene-update watchdog.
+    @ViewBuilder
+    private func swipeRow(
+        for envelope: Envelope,
+        model: MessageListViewModel,
+        background: Color,
+        visible: [Envelope],
+        selected: Bool
+    ) -> some View {
+        #if os(macOS)
+        SwipeActionRow(
+            height: rowHeight,
+            rowBackground: background,
+            leading: toggleReadSwipe(for: envelope, model: model),
+            trailing: disposeSwipe(for: envelope, model: model),
+            onSelect: { selectRow(envelope, model: model, ordered: visible) },
+            content: {
+                row(for: envelope, model: model, isSelected: selected, orderedVisible: visible)
+            }
+        )
+        #else
+        SwipeRow(
+            height: rowHeight,
+            rowBackground: background,
+            leading: toggleReadSwipe(for: envelope, model: model),
+            trailing: disposeSwipe(for: envelope, model: model),
+            onSelect: { selectRow(envelope, model: model, ordered: visible) },
+            resetKey: envelope.uid,
+            content: {
+                row(for: envelope, model: model, isSelected: selected, orderedVisible: visible)
+            }
+        )
+        #endif
     }
 
     /// Thin hairline between rows. Drawn as a bottom `.overlay` (not a stack

--- a/apple/Cabalmail/Views/SwipeRow.swift
+++ b/apple/Cabalmail/Views/SwipeRow.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
+
+// Hand-rolled swipe-actions row for the virtualized message list on touch
+// platforms (iOS / iPadOS / visionOS). It replaces the per-row embedded `List`
+// that `SwipeActionRow` borrows native `.swipeActions` from: a stack of
+// UICollectionView-backed Lists nested in the outer `LazyVStack` made a
+// background scene-update relayout exceed the 10-second watchdog (0x8BADF00D),
+// killing the app a second or two after the user archived a message and
+// backgrounded the app -- even for a folder of fewer than 30 messages.
+//
+// This draws the reveal with a plain `ZStack` + a `DragGesture`, so a row is
+// just views: no nested scroll view, no collection view, nothing to lay out
+// beyond the row content itself.
+//
+// macOS keeps `SwipeActionRow` (native `.swipeActions`): there the swipe is a
+// two-finger trackpad SCROLL gesture a SwiftUI `DragGesture` can't read, and
+// the Mac has no scene-update watchdog pressure. The platform split lives in
+// `messageRow` (see `MessageListView+Selection`).
+
+/// Resting (open) width of a single action button.
+private let swipeButtonWidth: CGFloat = 74
+/// Past this fraction of the row's width, releasing fires the action directly
+/// (the system list's full-swipe behavior).
+private let swipeFullFraction: CGFloat = 0.5
+/// Minimum open travel before a release rests open rather than snapping shut.
+private let swipeOpenThreshold: CGFloat = swipeButtonWidth * 0.6
+
+struct SwipeRow<Content: View>: View {
+    let height: CGFloat
+    let rowBackground: Color
+    let leading: SwipeActionSpec?
+    let trailing: SwipeActionSpec?
+    let onSelect: () -> Void
+    /// Identity of the row's current content (the envelope UID in the real
+    /// list). When it changes, a recycled `LazyVStack` row slot is now showing
+    /// a different message, so any open/translated state is reset.
+    let resetKey: AnyHashable
+    @ViewBuilder let content: () -> Content
+
+    @State private var offset: CGFloat = 0   // live content x-translation
+    @State private var rest: CGFloat = 0     // resting offset: 0 or ±buttonWidth
+    @State private var axis: Axis?           // locked once the drag's direction is known
+    @State private var armed = false         // crossed the full-swipe line this drag
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = geo.size.width
+            ZStack {
+                actionLayer(width: width)
+                content()
+                    // Match the 16pt horizontal inset the embedded-List path
+                    // gave rows via `listRowInsets`, so the content lines up
+                    // with `placeholderRow` (also inset 16). The tint
+                    // background still fills the full row width.
+                    .padding(.horizontal, 16)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                    .background(rowBackground)
+                    .contentShape(Rectangle())
+                    .offset(x: offset)
+                    .onTapGesture { tapContent() }
+                    .simultaneousGesture(dragGesture(width: width))
+            }
+        }
+        .frame(height: height)
+        .clipped()
+        .onChange(of: resetKey) { _, _ in close(animated: false) }
+    }
+
+    // MARK: Reveal
+
+    /// The colored action sitting behind the content. It's anchored to the
+    /// edge the swipe exposes and grows with the drag so the color fills the
+    /// row on a full swipe -- the system list's look.
+    @ViewBuilder
+    private func actionLayer(width: CGFloat) -> some View {
+        HStack(spacing: 0) {
+            if offset > 0, let leading {
+                actionButton(leading, width: width)
+                Spacer(minLength: 0)
+            } else if offset < 0, let trailing {
+                Spacer(minLength: 0)
+                actionButton(trailing, width: width)
+            }
+        }
+    }
+
+    private func actionButton(_ spec: SwipeActionSpec, width: CGFloat) -> some View {
+        Button { fire(spec, width: width) } label: {
+            VStack(spacing: 2) {
+                Image(systemName: spec.systemImage)
+                    .font(.body)
+                Text(spec.title)
+                    .font(.caption2)
+            }
+            .foregroundStyle(.white)
+            .frame(width: max(swipeButtonWidth, abs(offset)))
+            .frame(maxHeight: .infinity)
+            .background(spec.tint)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Gesture
+
+    private func dragGesture(width: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 8, coordinateSpace: .local)
+            .onChanged { value in
+                if axis == nil {
+                    axis = abs(value.translation.width) > abs(value.translation.height)
+                        ? .horizontal : .vertical
+                }
+                guard axis == .horizontal else { return }
+                offset = resist(rest + value.translation.width)
+                updateArm(width: width)
+            }
+            .onEnded { _ in
+                let wasHorizontal = axis == .horizontal
+                axis = nil
+                guard wasHorizontal else { return }
+                let full = width * swipeFullFraction
+                if abs(offset) >= full, let spec = action(for: offset) {
+                    fire(spec, width: width)
+                } else if abs(offset) >= swipeOpenThreshold, action(for: offset) != nil {
+                    openRest()
+                } else {
+                    close(animated: true)
+                }
+            }
+    }
+
+    /// Clamp the live offset to a side that actually has an action, with a
+    /// little rubber-band give past a full reveal so it never feels stuck.
+    private func resist(_ proposed: CGFloat) -> CGFloat {
+        if proposed > 0, leading == nil { return rubberBand(proposed) }
+        if proposed < 0, trailing == nil { return -rubberBand(-proposed) }
+        return proposed
+    }
+
+    private func rubberBand(_ distance: CGFloat) -> CGFloat {
+        // Heavily damped travel toward an edge with no action.
+        min(distance, 16) + max(0, distance - 16) * 0.1
+    }
+
+    private func updateArm(width: CGFloat) {
+        let full = width * swipeFullFraction
+        let nowArmed = abs(offset) >= full && action(for: offset) != nil
+        if nowArmed != armed {
+            armed = nowArmed
+            if nowArmed { impact() }
+        }
+    }
+
+    private func action(for offset: CGFloat) -> SwipeActionSpec? {
+        if offset > 0 { return leading }
+        if offset < 0 { return trailing }
+        return nil
+    }
+
+    // MARK: Transitions
+
+    private func tapContent() {
+        if rest != 0 {
+            close(animated: true)
+        } else {
+            onSelect()
+        }
+    }
+
+    private func openRest() {
+        let target: CGFloat = offset > 0 ? swipeButtonWidth : -swipeButtonWidth
+        withAnimation(.snappy(duration: 0.2)) {
+            offset = target
+            rest = target
+        }
+    }
+
+    private func close(animated: Bool) {
+        armed = false
+        if animated {
+            withAnimation(.snappy(duration: 0.2)) { offset = 0; rest = 0 }
+        } else {
+            offset = 0
+            rest = 0
+        }
+    }
+
+    /// Fire the action: slide the content off in the swipe direction (the row
+    /// is typically removed by the action), buzz, run it, then reset so a
+    /// recycled slot starts closed.
+    private func fire(_ spec: SwipeActionSpec, width: CGFloat) {
+        impact()
+        withAnimation(.easeOut(duration: 0.2)) {
+            offset = offset > 0 ? width : -width
+        }
+        spec.perform()
+        // Reset after the slide so the same `@State` reused for the next
+        // envelope in this slot doesn't inherit the offset.
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(220))
+            offset = 0
+            rest = 0
+            armed = false
+        }
+    }
+
+    private func impact() {
+        #if os(iOS)
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        #endif
+    }
+}

--- a/changelog.d/ios-swipe-watchdog-crash.fixed.md
+++ b/changelog.d/ios-swipe-watchdog-crash.fixed.md
@@ -1,0 +1,6 @@
+- Fixed an iOS crash that could kill the app a second or two after you
+  archived a message and sent the app to the background. The message
+  list's per-row swipe actions were rebuilt with a lighter-weight
+  implementation on iOS, iPadOS, and visionOS, so laying the list out for
+  the background snapshot no longer risks the system watchdog. The macOS
+  two-finger trackpad swipe is unchanged.


### PR DESCRIPTION
## Summary

Fixes an iOS crash where archiving a message and then sending the app to the background could kill it a second or two later (reported on **0.10.29**, TestFlight). The fix replaces the message list's per-row swipe mechanism on touch platforms; **macOS is unchanged**.

## Root cause

The shared `.ips` is a **scene-update watchdog termination**, not a logic crash:

```
exception: EXC_CRASH (SIGKILL)
termination: FRONTBOARD 0x8BADF00D
  "scene-update watchdog transgression: ... exhausted real (wall clock)
   time allowance of 10.00 seconds"
  ProcessVisibility: Background   WatchdogEvent: scene-update
```

The faulting (main) thread backtrace is pure SwiftUI display-list layout — `_ShapeStyle_RenderedShape.render`, `Color.ResolvedHDR.==`, `renderKeyedText`, `ViewGraph.updateOutputs`, `_UIHostingView.layoutSubviews`, `CA::Transaction::commit`. So iOS killed the app for spending **>10s on the main thread rendering the message list during the forced background snapshot.**

The folder had **fewer than 30 messages**, so volume isn't the cause. The cost is structural: `SwipeActionRow` gives each row native `.swipeActions` by embedding a **single-row `List`** (a `UICollectionView`-backed scroll view) inside the outer `ScrollView`/`LazyVStack`. Laying out a stack of those is expensive, and archiving (which mutates the list) followed by the synchronous background scene-update pushed even a small folder's relayout past the watchdog. (This is the same fragility 0.10.29's `@ScaledMetric` row-height change was already working around — "the per-row SwipeActionRow List began scrolling its own clipped content.")

Watchdog/hang terminations are `bug_type 309`; they don't appear in TestFlight's **Crashes** organizer, which is why the report looked missing. (The app's MetricKit collector is the other place it may have been recorded.)

## Empirical confirmation

An auth-free harness replicated `ScrollView → LazyVStack → ForEach(0..<n) → row` and timed cold synchronous layout of 14 visible rows in the simulator:

| Row type | median | max |
|---|---|---|
| embedded-`List` (before) | **42.6 ms** | 62 ms |
| hand-rolled `SwipeRow` (after) | **14.2 ms** | 17 ms |

~3× faster — and it *undercounts* the gap, because it excludes each embedded List's own async `UICollectionView` layout (the hand-rolled row has none). No AttributeGraph cycles; it's raw layout cost. The simulator is too fast to fire the 10s watchdog itself (and doesn't enforce it the same way), so **on-device is the final gate.**

## Fix

- **`SwipeRow`** (new, touch platforms): hand-rolled swipe via `ZStack` + `DragGesture`, no nested scroll view. Leading = mark read, trailing = dispose (destructive), drag-to-rest-open, full-swipe-to-fire with a haptic, snap-back, tap-to-close. Vertical scroll preserved via `simultaneousGesture` + an axis lock.
- **`messageRow`** platform-splits: **macOS keeps native `.swipeActions` (`SwipeActionRow`)** so the two-finger trackpad swipe is untouched; iOS/iPadOS/visionOS use `SwipeRow`.

Verified in the simulator that rows render correctly at rest and revealed (red Archive on trailing swipe, blue Read on leading swipe), with matching 16pt insets and separators.

## Testing

- `scripts/build-apple.sh all` — swiftlint `--strict`, macOS, iOS, visionOS all ✅
- `CabalmailKit` `swift test` — 268 tests, 0 failures ✅
- Simulator: resting + revealed render confirmed via screenshots.
- ⚠️ **On-device feel not yet validated** — gesture smoothness, haptics, and scroll/swipe arbitration can only be judged on a device. Please exercise archive-swipe + background on TestFlight before promoting to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)