### PR TITLE
Apple: copy address to clipboard

### DIFF
--- a/apple/Cabalmail/AppStateSignals.swift
+++ b/apple/Cabalmail/AppStateSignals.swift
@@ -12,6 +12,33 @@ struct Toast: Equatable, Sendable {
     enum Kind: Sendable { case info, success, warning, error }
     let kind: Kind
     let message: String
+    /// When set, the banner renders a trailing "Copy" button that places this
+    /// string on the pasteboard. Modeled as data (not a closure) so `Toast`
+    /// stays `Equatable`/`Sendable` and the auto-dismiss equality check in
+    /// `AppState.showToast` keeps working.
+    var copyAddress: String?
+
+    init(kind: Kind, message: String, copyAddress: String? = nil) {
+        self.kind = kind
+        self.message = message
+        self.copyAddress = copyAddress
+    }
+
+    /// Banner shown after an address is minted, offering a one-tap copy of
+    /// the new address without re-finding it in a list.
+    static func addressCreated(_ address: String) -> Toast {
+        Toast(
+            kind: .success,
+            message: "Created \(address)",
+            copyAddress: address
+        )
+    }
+
+    /// Confirmation shown after an address lands on the pasteboard, whether
+    /// from a list's copy action or the post-creation banner's Copy button.
+    static func addressCopied(_ address: String) -> Toast {
+        Toast(kind: .success, message: "Address \(address) successfully copied")
+    }
 }
 
 /// Signal payload for a successful dispose action. Carries the folder path

--- a/apple/Cabalmail/Pasteboard.swift
+++ b/apple/Cabalmail/Pasteboard.swift
@@ -1,0 +1,20 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Copies `string` to the system pasteboard. iOS / visionOS go through
+/// `UIPasteboard`; macOS through `NSPasteboard`. Centralized here so the
+/// address copy actions and the "view source" sheet share one implementation
+/// of the platform split rather than repeating the `#if canImport` dance.
+@MainActor
+func copyToPasteboard(_ string: String) {
+    #if canImport(UIKit)
+    UIPasteboard.general.string = string
+    #elseif canImport(AppKit)
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(string, forType: .string)
+    #endif
+}

--- a/apple/Cabalmail/Views/AddressListView.swift
+++ b/apple/Cabalmail/Views/AddressListView.swift
@@ -104,6 +104,12 @@ struct AddressListView: View {
             }
             .contextMenu {
                 Button {
+                    copyToPasteboard(address.address)
+                    appState.showToast(.addressCopied(address.address), duration: 7)
+                } label: {
+                    Label("Copy Address", systemImage: "doc.on.doc")
+                }
+                Button {
                     Task { await model.toggleFavorite(address) }
                 } label: {
                     Label(

--- a/apple/Cabalmail/Views/AddressesView.swift
+++ b/apple/Cabalmail/Views/AddressesView.swift
@@ -19,6 +19,10 @@ struct AddressesView: View {
     @State private var pendingRevoke: Address?
     @State private var filterQuery: String = ""
     @State private var isRefreshing = false
+    /// Local banner. On iPad-regular this view lives in the settings sheet
+    /// and on macOS in the settings window, so the root `AppState.toast`
+    /// overlay can't reach it — host copy / creation banners here.
+    @State private var toast: Toast?
 
     var body: some View {
         #if os(macOS)
@@ -45,6 +49,7 @@ struct AddressesView: View {
                 actions: revokeDialogActions,
                 message: revokeDialogMessage
             )
+            .toastOverlay($toast)
         #else
         NavigationStack {
             content
@@ -61,6 +66,7 @@ struct AddressesView: View {
                     actions: revokeDialogActions,
                     message: revokeDialogMessage
                 )
+                .toastOverlay($toast)
         }
         #endif
     }
@@ -204,6 +210,12 @@ struct AddressesView: View {
         }
         .contextMenu {
             Button {
+                copyToPasteboard(address.address)
+                toast = .addressCopied(address.address)
+            } label: {
+                Label("Copy Address", systemImage: "doc.on.doc")
+            }
+            Button {
                 Task { await model.toggleFavorite(address) }
             } label: {
                 Label(
@@ -244,7 +256,10 @@ struct AddressesView: View {
     private var newAddressSheet: some View {
         NewAddressSheet(
             domains: appState.client?.configuration.domains ?? [],
-            onCreate: { _ in await model?.onAddressCreated() }
+            onCreate: { address in
+                await model?.onAddressCreated()
+                toast = .addressCreated(address)
+            }
         )
         .environment(appState)
     }
@@ -283,9 +298,11 @@ struct AddressesView: View {
     private func revokeDialogMessage(for address: Address) -> some View {
         Text("Mail sent to \(address.address) will be rejected. This can't be undone.")
     }
+}
 
-    // MARK: - Lifecycle
+// MARK: - Lifecycle
 
+extension AddressesView {
     private func ensureModel() async {
         if model == nil, let client = appState.client {
             model = AddressesViewModel(client: client)

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -45,6 +45,11 @@ struct ComposeView: View {
     @State private var photoSelection: [PhotosPickerItem] = []
     #endif
     @State private var showFileImporter = false
+    /// Compose-scoped banner. The compose surface is a separate window
+    /// (macOS / iPad regular) or a sheet (iPhone), so the root
+    /// `AppState.toast` overlay can't reach it — host the post-creation
+    /// "Created … / Copy" banner here instead.
+    @State private var composeToast: Toast?
     #if os(macOS)
     /// Intercepts the macOS window's red close button (and Cmd+W) so it
     /// routes through the same "Discard draft?" dialog as the toolbar
@@ -105,6 +110,7 @@ struct ComposeView: View {
                     domains: appState.client?.configuration.domains ?? [],
                     onCreate: { address in
                         await model.onAddressCreated(address)
+                        composeToast = .addressCreated(address)
                     }
                 )
                 .environment(appState)
@@ -160,6 +166,7 @@ struct ComposeView: View {
             } message: {
                 Text("Keep a copy of the draft for later, or discard it now.")
             }
+            .toastOverlay($composeToast)
         }
     }
 

--- a/apple/Cabalmail/Views/SignedInRootView.swift
+++ b/apple/Cabalmail/Views/SignedInRootView.swift
@@ -99,33 +99,23 @@ struct SignedInRootView: View {
                 )
             }
             if let toast = appState.toast {
-                BannerView(
-                    icon: icon(for: toast.kind),
-                    text: toast.message,
-                    tint: tint(for: toast.kind)
-                )
-                .transition(.move(edge: .top).combined(with: .opacity))
+                ToastBanner(toast: toast, onCopy: copyHandler(for: toast))
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
         .padding(.top, 6)
         .padding(.horizontal, 12)
     }
 
-    private func icon(for kind: Toast.Kind) -> String {
-        switch kind {
-        case .success: return "checkmark.circle.fill"
-        case .info:    return "info.circle.fill"
-        case .warning: return "tray.and.arrow.up.fill"
-        case .error:   return "exclamationmark.triangle.fill"
-        }
-    }
-
-    private func tint(for kind: Toast.Kind) -> Color {
-        switch kind {
-        case .success: return .green
-        case .info:    return .blue
-        case .warning: return .orange
-        case .error:   return .red
+    /// Builds the banner's Copy action when the toast carries an address.
+    /// Tapping it copies the address and replaces the banner with the shared
+    /// "successfully copied" confirmation, so the post-creation Copy button
+    /// and a list's copy action give identical feedback.
+    private func copyHandler(for toast: Toast) -> (() -> Void)? {
+        guard let address = toast.copyAddress else { return nil }
+        return {
+            copyToPasteboard(address)
+            appState.showToast(.addressCopied(address), duration: 7)
         }
     }
 
@@ -140,29 +130,5 @@ struct SignedInRootView: View {
             isOffline = !reachable
         }
         #endif
-    }
-}
-
-private struct BannerView: View {
-    let icon: String
-    let text: String
-    let tint: Color
-
-    var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: icon)
-                .foregroundStyle(tint)
-            Text(text)
-                .font(.footnote)
-                .foregroundStyle(.primary)
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(.ultraThinMaterial, in: Capsule(style: .continuous))
-        .overlay(
-            Capsule(style: .continuous)
-                .stroke(tint.opacity(0.3), lineWidth: 1)
-        )
     }
 }

--- a/apple/Cabalmail/Views/ToastBanner.swift
+++ b/apple/Cabalmail/Views/ToastBanner.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+/// The capsule banner primitive shared by the root status overlay
+/// (`SignedInRootView`) and the local `toastOverlay` hosts. Dumb on purpose:
+/// callers supply the icon / text / tint, and an optional Copy action that,
+/// when present, renders a trailing button.
+struct BannerView: View {
+    let icon: String
+    let text: String
+    let tint: Color
+    /// When non-nil the banner shows a trailing "Copy" button (the
+    /// post-creation address banner); nil for plain status banners.
+    var onCopy: (() -> Void)?
+
+    init(icon: String, text: String, tint: Color, onCopy: (() -> Void)? = nil) {
+        self.icon = icon
+        self.text = text
+        self.tint = tint
+        self.onCopy = onCopy
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(.primary)
+            Spacer(minLength: 0)
+            if let onCopy {
+                Button(action: onCopy) {
+                    Label("Copy", systemImage: "doc.on.doc")
+                        .font(.footnote.weight(.semibold))
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.borderless)
+                .tint(tint)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial, in: Capsule(style: .continuous))
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(tint.opacity(0.3), lineWidth: 1)
+        )
+    }
+}
+
+/// Renders a `Toast` value as a `BannerView`, mapping `kind` to the standard
+/// icon and tint. `onCopy` is wired by the host when the toast carries a
+/// `copyAddress`.
+struct ToastBanner: View {
+    let toast: Toast
+    var onCopy: (() -> Void)?
+
+    var body: some View {
+        BannerView(icon: icon, text: toast.message, tint: tint, onCopy: onCopy)
+    }
+
+    private var icon: String {
+        switch toast.kind {
+        case .success: return "checkmark.circle.fill"
+        case .info:    return "info.circle.fill"
+        case .warning: return "tray.and.arrow.up.fill"
+        case .error:   return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch toast.kind {
+        case .success: return .green
+        case .info:    return .blue
+        case .warning: return .orange
+        case .error:   return .red
+        }
+    }
+}
+
+extension View {
+    /// Hosts a transient, auto-dismissing toast anchored to the top of this
+    /// view. Use on surfaces presented modally — compose windows / sheets and
+    /// the settings sheet — where the root `AppState.toast` overlay would be
+    /// hidden behind the presented content. A toast carrying a `copyAddress`
+    /// renders a Copy button that copies the address and swaps in the shared
+    /// "successfully copied" confirmation.
+    func toastOverlay(
+        _ toast: Binding<Toast?>,
+        duration: TimeInterval = 7
+    ) -> some View {
+        modifier(ToastOverlayModifier(toast: toast, duration: duration))
+    }
+}
+
+private struct ToastOverlayModifier: ViewModifier {
+    @Binding var toast: Toast?
+    let duration: TimeInterval
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .top) {
+                if let toast {
+                    ToastBanner(toast: toast, onCopy: copyHandler(for: toast))
+                        .padding(.top, 6)
+                        .padding(.horizontal, 12)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                }
+            }
+            .animation(.default, value: toast)
+            // `task(id:)` restarts whenever the toast value changes: a new
+            // toast cancels the prior timer (the catch returns without
+            // clearing the replacement), and after `duration` the current
+            // toast clears itself.
+            .task(id: toast) {
+                guard toast != nil else { return }
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+                } catch {
+                    return
+                }
+                toast = nil
+            }
+    }
+
+    private func copyHandler(for toast: Toast) -> (() -> Void)? {
+        guard let address = toast.copyAddress else { return nil }
+        return {
+            copyToPasteboard(address)
+            self.toast = .addressCopied(address)
+        }
+    }
+}

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -168,6 +168,7 @@ targets:
       - path: Cabalmail/ContentView.swift
       - path: Cabalmail/AppState.swift
       - path: Cabalmail/AppStateSignals.swift
+      - path: Cabalmail/Pasteboard.swift
       - path: Cabalmail/Views
       - path: Cabalmail/ViewModels
     dependencies:

--- a/changelog.d/apple-copy-address.added.md
+++ b/changelog.d/apple-copy-address.added.md
@@ -1,0 +1,6 @@
+- The Apple clients can now copy an address to the clipboard. Long-press
+  (iOS) or right-click (macOS) any row in the address filter sidebar or the
+  management list for a **Copy Address** action, and the banner shown after
+  minting a new address — from the compose From picker or the management
+  list — carries a one-tap **Copy** button. Each copy confirms with an
+  unobtrusive, self-dismissing banner.


### PR DESCRIPTION
## What

Adds copy-address-to-clipboard affordances to the Apple clients (iOS + macOS), reaching parity with the React rail's copy action.

### Lists — long-press / right-click → **Copy Address**
- **Filter sidebar** (`AddressListView`) — new context-menu item.
- **Management list** (`AddressesView`) — new context-menu item (alongside Favorite / Revoke).

`.contextMenu` covers both long-press on iOS and right-click on macOS.

### After creating an address → one-tap **Copy**
Both creation flows now show a banner offering Copy, modeled on the existing "Message sent." banner — non-modal, self-dismissing after 7s:
- **Compose** From-picker (`NewAddressSheet` via `ComposeView`).
- **Management list** (`NewAddressSheet` via `AddressesView`).

Tapping **Copy** copies the address and swaps in the shared "Address `<address>` successfully copied" confirmation, the same confirmation a list copy shows.

## How
- `Toast` gains an optional `copyAddress` (modeled as data, not a closure, so it stays `Equatable`/`Sendable`) plus `addressCreated` / `addressCopied` factories.
- The capsule banner is extracted to `ToastBanner.swift` and gains an optional trailing Copy button.
- A reusable `toastOverlay(_:)` view modifier hosts a **local**, auto-dismissing banner. This is needed because the compose surface is a separate `WindowGroup` (macOS / iPad-regular) or a `.sheet` (iPhone), and the management list lives in the settings sheet/window — the root `AppState.toast` overlay can't reach either. The filter sidebar lives at root and keeps using the root overlay.
- Pasteboard access (the `UIPasteboard` / `NSPasteboard` split that was inlined in `MessageSourceSheet`) is centralized in `Pasteboard.swift`, added to both app targets in `project.yml`.

## Notes
- **Wording:** per request the confirmation reads `Address <address> successfully copied`. React's existing rail copy says `Address copied to clipboard.` — I left React untouched; flag if you'd like them unified later.
- **Scope:** copy lives on the context menu only (matching the long-press / right-click ask), not on swipe actions.

## Testing
- `swiftlint lint --strict` — clean.
- `xcodebuild` build (no signing) succeeds for both the **iOS** (`Cabalmail`) and **macOS** (`CabalmailMac`) schemes.
- No automated test coverage on the app target (CabalmailKit untouched); ready for your UAT on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)