### PR TITLE
Order wide sidebar: search → tabs → filter → list

### DIFF
--- a/apple/Cabalmail/Views/AddressListView.swift
+++ b/apple/Cabalmail/Views/AddressListView.swift
@@ -15,6 +15,14 @@ struct AddressListView: View {
     @State private var filterQuery: String = ""
     @State private var isRefreshing = false
     @Binding var selection: Address?
+    /// When set, the parent (the wide macOS / iPad-regular sidebar) owns the
+    /// filter field — rendered below the section tabs — and this view filters by
+    /// it instead of showing its own top-of-sidebar `.searchable`. Nil keeps the
+    /// self-contained searchable (compact, standalone).
+    var externalFilter: Binding<String>?
+    /// The filter text actually in effect: the parent's when injected, else the
+    /// view's own `.searchable` query.
+    private var activeFilterText: String { externalFilter?.wrappedValue ?? filterQuery }
 
     var body: some View {
         List(selection: $selection) {
@@ -47,7 +55,7 @@ struct AddressListView: View {
             }
         }
         .navigationTitle("Addresses")
-        .searchable(text: $filterQuery, placement: .sidebar, prompt: "Filter addresses")
+        .sidebarFilterSearchable(text: $filterQuery, enabled: externalFilter == nil, prompt: "Filter addresses")
         .toolbar {
             ToolbarItem {
                 Button {
@@ -79,7 +87,7 @@ struct AddressListView: View {
     }
 
     private func filteredAddresses(_ addresses: [Address]) -> [Address] {
-        let needle = filterQuery.trimmingCharacters(in: .whitespaces).lowercased()
+        let needle = activeFilterText.trimmingCharacters(in: .whitespaces).lowercased()
         guard !needle.isEmpty else { return addresses }
         return addresses.filter { address in
             address.address.lowercased().contains(needle)

--- a/apple/Cabalmail/Views/FolderListView+Helpers.swift
+++ b/apple/Cabalmail/Views/FolderListView+Helpers.swift
@@ -15,7 +15,7 @@ extension FolderListView {
     }
 
     func filteredFolders(_ folders: [Folder]) -> [Folder] {
-        let needle = filterQuery.trimmingCharacters(in: .whitespaces).lowercased()
+        let needle = activeFilterText.trimmingCharacters(in: .whitespaces).lowercased()
         guard !needle.isEmpty else { return folders }
         return folders.filter { folder in
             folder.path.lowercased().contains(needle)

--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -27,6 +27,14 @@ struct FolderListView: View {
     @State var filterQuery: String = ""
     @State var isRefreshing = false
     @Binding var selection: Folder?
+    /// When set, the parent (the wide macOS / iPad-regular sidebar) owns the
+    /// filter field — rendered below the section tabs — and this view filters by
+    /// it instead of showing its own top-of-sidebar `.searchable`. Nil keeps the
+    /// self-contained searchable (compact, standalone).
+    var externalFilter: Binding<String>?
+    /// The filter text actually in effect: the parent's when injected, else the
+    /// view's own `.searchable` query.
+    var activeFilterText: String { externalFilter?.wrappedValue ?? filterQuery }
     /// Called exactly once, the first time the folder list successfully
     /// loads. `MailRootView` uses it to seed a default `selection` so the
     /// signed-in user doesn't land on an empty "pick a mailbox" screen
@@ -107,7 +115,7 @@ struct FolderListView: View {
             }
         }
         .navigationTitle("Mailboxes")
-        .searchable(text: $filterQuery, placement: .sidebar, prompt: "Filter folders")
+        .sidebarFilterSearchable(text: $filterQuery, enabled: externalFilter == nil, prompt: "Filter folders")
         .toolbar {
             #if !os(macOS)
             // Settings / Addresses / Folders admin live behind this gear as a

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -59,6 +59,28 @@ struct MailRootView: View {
     /// the field is focused (or holds a query / active search) the content
     /// column shows results instead of the selected folder.
     @FocusState private var searchFieldFocused: Bool
+    /// Per-context list-filter text for the wide sidebar. On macOS / iPad-regular
+    /// this view renders the "Filter folders" / "Filter addresses" field itself
+    /// (below the section tabs) so it sits under the global search rather than
+    /// being hoisted above it by `.searchable(placement: .sidebar)`; the binding
+    /// is handed to the list view. Unused on compact, where the list keeps its
+    /// own searchable.
+    @State private var folderListFilter = ""
+    @State private var addressListFilter = ""
+    /// Whether this is the wide single-rail sidebar (macOS, iPad-regular) where
+    /// `.searchable(placement: .sidebar)` pins fields to the column top. Uses the
+    /// `showsSettingsGear` flag rather than `horizontalSizeClass` because the
+    /// sidebar column reports a compact size class even on a regular-width iPad.
+    #if !os(macOS)
+    @Environment(\.showsSettingsGear) private var showsSettingsGear
+    #endif
+    private var isWideSidebar: Bool {
+        #if os(macOS)
+        return true
+        #else
+        return showsSettingsGear
+        #endif
+    }
     /// Non-nil while a message drag temporarily overrides the visible sidebar
     /// tab. When the user starts dragging a message while viewing Addresses,
     /// this flips the sidebar to Folders so they have somewhere to drop;
@@ -319,10 +341,18 @@ struct MailRootView: View {
             .padding(.top, 8)
             .padding(.bottom, 4)
 
+            // Wide layout renders the per-context filter here — below the tabs,
+            // above the list — so the order reads search → tabs → filter → list.
+            // Compact lets each list keep its own top-of-sidebar `.searchable`.
+            if isWideSidebar {
+                sidebarFilterField
+            }
+
             switch effectiveSidebarTab {
             case .folders:
                 FolderListView(
                     selection: $selectedFolder,
+                    externalFilter: isWideSidebar ? $folderListFilter : nil,
                     onFoldersLoaded: { folders in
                         // Default-select INBOX the first time the list arrives.
                         // The Compose button lives on the message-list toolbar,
@@ -336,8 +366,45 @@ struct MailRootView: View {
                     }
                 )
             case .addresses:
-                AddressListView(selection: $selectedAddress)
+                AddressListView(
+                    selection: $selectedAddress,
+                    externalFilter: isWideSidebar ? $addressListFilter : nil
+                )
             }
         }
+    }
+
+    /// Per-context list filter for the wide sidebar — the "Filter folders" /
+    /// "Filter addresses" field shown below the section tabs. A plain styled
+    /// field (not `.searchable`, which would hoist above the global search);
+    /// the bound text drives the active list view's `externalFilter`.
+    @ViewBuilder
+    private var sidebarFilterField: some View {
+        let isFolders = effectiveSidebarTab == .folders
+        let text = isFolders ? $folderListFilter : $addressListFilter
+        HStack(spacing: 6) {
+            Image(systemName: "line.3.horizontal.decrease")
+                .foregroundStyle(.secondary)
+            TextField(isFolders ? "Filter folders" : "Filter addresses", text: text)
+                .textFieldStyle(.plain)
+            if !text.wrappedValue.isEmpty {
+                Button {
+                    text.wrappedValue = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear filter")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(Color.secondary.opacity(0.12))
+        )
+        .padding(.horizontal)
+        .padding(.bottom, 4)
     }
 }

--- a/apple/Cabalmail/Views/SidebarFilterSearchable.swift
+++ b/apple/Cabalmail/Views/SidebarFilterSearchable.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+extension View {
+    /// Applies the sidebar filter `.searchable` only when `enabled`.
+    ///
+    /// `.searchable(placement: .sidebar)` is hoisted by the system to the very
+    /// top of the sidebar column. On the wide (macOS / iPad-regular) layout the
+    /// global "Search all mail" field owns that top slot, and the per-context
+    /// folder/address filter is rendered as a plain field *below* the section
+    /// tabs instead — so the list view passes `enabled: false` to suppress its
+    /// own searchable and filters by the parent-owned binding. Compact passes
+    /// `enabled: true` to keep the self-contained sidebar searchable.
+    @ViewBuilder
+    func sidebarFilterSearchable(text: Binding<String>, enabled: Bool, prompt: String) -> some View {
+        if enabled {
+            searchable(text: text, placement: .sidebar, prompt: Text(prompt))
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
UAT on stage flagged that on macOS / iPad-regular the global "Search all mail" field rendered *below* the per-context "Filter folders/addresses" field, because the latter is a `.searchable(placement: .sidebar)` that the system pins to the top of the sidebar column.

On the wide single-rail sidebar, suppress the list's own `.searchable` (via a new `externalFilter` binding on FolderListView/AddressListView) and render the per-context filter as a plain field below the section tabs. With no sidebar-searchable left to hoist, the global field sits at the top, giving search → tabs → filter → list.

Compact (iPhone) is unchanged: the lists keep their self-contained top-of-sidebar `.searchable`. Detected via `showsSettingsGear` (true only on the wide layout) since the sidebar column reports a compact size class even on a regular-width iPad.

Note: a minor macOS side effect — Cmd-F no longer focuses the folder/address filter, since neither sidebar field is `.searchable` now.