### PR TITLE
Lift MailRootView sidebar chrome into an extension

### DIFF
--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -280,7 +280,14 @@ struct MailRootView: View {
         .disabled(true)
     }
     #endif
+}
 
+// MARK: - Sidebar chrome
+
+// Lifted into a same-file extension so the primary struct body stays under
+// SwiftLint's `type_body_length` cap, matching the pattern used by
+// `MessageListView` and its `+Filter` / `+Search` siblings.
+extension MailRootView {
     /// Sidebar search field — the wide-layout entry to global search. Engaging
     /// it (focus, a query, or an active search) swaps the content column to
     /// cross-folder results; clearing and unfocusing it returns to the folder.


### PR DESCRIPTION
The global-search and per-context-filter additions pushed the MailRootView struct body to 266 lines, over SwiftLint's 250-line type_body_length cap (a hard failure under CI's strict lint). Move the three sidebar view builders (searchField, sidebar, sidebarFilterField) into a same-file extension — same pattern MessageListView uses — bringing the body back under the cap. No behavior change.