### PR TITLE
Fix TestFlight notes: use top-level betaBuildLocalizations filter

### DIFF
--- a/.github/scripts/set-testflight-notes.py
+++ b/.github/scripts/set-testflight-notes.py
@@ -238,10 +238,15 @@ def wait_for_build(app_id, build_number, token_factory, timeout, interval):
 
 def set_notes(build_id, locale, notes, token_factory):
     """Create or update the betaBuildLocalizations whatsNew for the build."""
-    query = urllib.parse.urlencode({"filter[locale]": locale, "limit": 1})
+    # The top-level collection supports filter[build]+filter[locale]; the
+    # build relationship endpoint (/v1/builds/{id}/betaBuildLocalizations)
+    # rejects filter[locale] with PARAMETER_ERROR.ILLEGAL.
+    query = urllib.parse.urlencode(
+        {"filter[build]": build_id, "filter[locale]": locale, "limit": 1}
+    )
     existing = api_request(
         "GET",
-        f"/v1/builds/{build_id}/betaBuildLocalizations?{query}",
+        f"/v1/betaBuildLocalizations?{query}",
         token_factory,
     )
     data = existing.get("data") or []

--- a/changelog.d/testflight-notes-locale-filter.fixed.md
+++ b/changelog.d/testflight-notes-locale-filter.fixed.md
@@ -1,0 +1,4 @@
+- Fixed the prod TestFlight "What to Test" step failing to write notes with
+  `PARAMETER_ERROR.ILLEGAL` on `filter[locale]`. It now queries the top-level
+  `betaBuildLocalizations` collection, which accepts the locale filter, instead
+  of the build relationship endpoint, which does not.


### PR DESCRIPTION
## What

Follow-up to #533. In the first prod run the new "What to Test" step resolved the app, found the build, and waited out processing correctly, but failed at the final write:

```
App Store Connect API error 400: PARAMETER_ERROR.ILLEGAL
The parameter 'filter[locale]' can not be used with this request
  source.parameter: filter[locale]
```

The build *relationship* endpoint `GET /v1/builds/{id}/betaBuildLocalizations` does not accept `filter[locale]`. Switched to the top-level `GET /v1/betaBuildLocalizations` collection with `filter[build]` + `filter[locale]`, which does.

Because the step is best-effort, the failed run only warned — it did not break the release. The notes simply weren't set.

## Verification

- Python compiles.
- This is the only place that used the relationship-filter pattern; `find_build` already uses a supported top-level filter and worked in the live run.

Still unverified end-to-end against the live ASC write path; the next prod release after this merges is the real test (again, soft-fail if anything else needs adjusting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)