### PR TITLE
Render inline cid: images as data URIs so they actually load

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageDetailViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageDetailViewModel.swift
@@ -416,15 +416,19 @@ private extension MessageDetailViewModel {
         var attachmentList: [Attachment] = []
         var inlineMap: [String: URL] = [:]
         for leaf in root.leafParts where isAttachmentLike(leaf) {
+            // Inline `cid:` images are embedded as `data:` URIs, not temp
+            // files: the body web view loads with an opaque origin and can't
+            // fetch `file://` subresources, so a file URL would silently fail
+            // to render. See `MimePart.inlineImageDataURL`.
+            if let contentID = leaf.contentID,
+               let dataURL = leaf.inlineImageDataURL {
+                inlineMap[contentID] = dataURL
+                continue
+            }
             let filename = leaf.contentDisposition?.filename
                 ?? leaf.contentType.name
                 ?? "attachment-\(UUID().uuidString).bin"
             let url = try writeToTmp(data: leaf.decodedBody, filename: filename)
-            if let contentID = leaf.contentID,
-               leaf.contentType.type == "image" {
-                inlineMap[contentID] = url
-                continue
-            }
             attachmentList.append(Attachment(
                 id: leaf.contentID ?? url.lastPathComponent,
                 filename: filename,

--- a/apple/Cabalmail/Views/HTMLBodyView.swift
+++ b/apple/Cabalmail/Views/HTMLBodyView.swift
@@ -17,8 +17,11 @@ import AppKit
 ///   level and subframe navigations; subresource loads bypass it entirely,
 ///   which is why the earlier "deny non-file URLs in `decidePolicyFor`"
 ///   approach silently loaded tracker pixels despite the preference.
-/// - `cid:` inline image URLs are rewritten to local `file://` URLs from
-///   `inlineImages` before the HTML is handed to the web view.
+/// - `cid:` inline image URLs are rewritten to `data:` URIs from
+///   `inlineImages` before the HTML is handed to the web view. (A temp
+///   `file://` URL can't be used: the document's opaque origin — a side
+///   effect of `loadHTMLString(_:baseURL: nil)` — forbids `file://`
+///   subresource loads.)
 struct HTMLBodyView: View {
     let html: String
     let inlineImages: [String: URL]
@@ -359,8 +362,8 @@ final class HTMLBodyCoordinator: NSObject, WKNavigationDelegate {
     }
 }
 
-/// Walks the HTML and rewrites `cid:` URLs (case-insensitive) to local
-/// `file://` URLs pulled from the inline-image map. Purely string-level so
+/// Walks the HTML and rewrites `cid:` URLs (case-insensitive) to the
+/// `data:` URIs pulled from the inline-image map. Purely string-level so
 /// we never need to run a JS context. In `readerMode`, prepends a reset +
 /// typography stylesheet that overrides author CSS for a Safari Reader-
 /// style presentation.

--- a/apple/CabalmailKit/Sources/CabalmailKit/MIME/MimeTypes.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/MIME/MimeTypes.swift
@@ -119,6 +119,24 @@ public struct MimePart: Sendable, Hashable {
         return [self]
     }
 
+    /// For an inline image part — an `image/*` leaf carrying a `Content-ID` —
+    /// the `data:` URL that embeds its bytes for direct rendering. Nil for any
+    /// other part.
+    ///
+    /// Inline `cid:` images must be embedded as `data:` URIs rather than
+    /// rewritten to a temp `file://` URL: the message body is shown in a
+    /// `WKWebView` loaded via `loadHTMLString(_:baseURL: nil)`, which gives the
+    /// document an opaque origin that WebKit forbids from fetching `file://`
+    /// subresources. A `data:` URI carries no origin requirement and is left
+    /// alone by the remote-content blocker (which only matches `http(s)://`).
+    public var inlineImageDataURL: URL? {
+        guard let contentID, !contentID.isEmpty, contentType.type == "image" else {
+            return nil
+        }
+        let base64 = decodedBody.base64EncodedString()
+        return URL(string: "data:\(contentType.mimeType);base64,\(base64)")
+    }
+
     /// Returns `decodedBody` as a `String` using the charset declared in
     /// Content-Type, falling back to UTF-8 and then ISO-8859-1. Returns nil
     /// for non-text parts.

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/MimeParserTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/MimeParserTests.swift
@@ -157,6 +157,84 @@ final class MimeParserTests: XCTestCase {
         XCTAssertEqual(attachment?.contentDisposition?.filename, "report.xml.gz")
     }
 
+    func testCidInlineImageInNestedRelatedIsExtractable() {
+        // Mirrors a USPS Informed Delivery digest: multipart/alternative whose
+        // HTML alternative is itself a multipart/related carrying the inline
+        // mailpiece images by Content-ID. The HTML references them as
+        // `cid:1005412273-018.jpg` (quoted-printable encoded on the wire).
+        let outer = "OUTER"
+        let related = "INNER"
+        let jpeg = Data([0xFF, 0xD8, 0xFF, 0xE0]).base64EncodedString()  // JPEG magic
+        let message = """
+        Content-Type: multipart/alternative; boundary="\(outer)"\r
+        \r
+        --\(outer)\r
+        Content-Type: text/plain; charset="UTF-8"\r
+        \r
+        Plain digest\r
+        --\(outer)\r
+        Content-Type: multipart/related; boundary="\(related)"\r
+        \r
+        --\(related)\r
+        Content-Type: text/html; charset="UTF-8"\r
+        Content-Transfer-Encoding: quoted-printable\r
+        \r
+        <img src=3D"cid:1005412273-018.jpg" alt=3D"Mailpiece Image">\r
+        --\(related)\r
+        Content-Type: image/jpeg\r
+        Content-Transfer-Encoding: base64\r
+        Content-ID: <1005412273-018.jpg>\r
+        Content-Disposition: inline; filename="1005412273-018.jpg"\r
+        \r
+        \(jpeg)\r
+        --\(related)--\r
+        --\(outer)--
+        """
+        let part = MimeParser.parse(Data(message.utf8))
+
+        // The HTML, once transfer-decoded, references the cid.
+        let html = part.firstPart { $0.contentType.mimeType == "text/html" }
+        XCTAssertEqual(
+            html?.textContent(),
+            #"<img src="cid:1005412273-018.jpg" alt="Mailpiece Image">"#
+        )
+
+        // The image leaf must surface with its angle-bracket-stripped
+        // Content-ID so the view's cid→data rewrite can match the `src`.
+        let image = part.leafParts.first { $0.contentType.type == "image" }
+        XCTAssertNotNil(image, "inline image part should be a leaf")
+        XCTAssertEqual(image?.contentID, "1005412273-018.jpg")
+        XCTAssertEqual(image?.decodedBody, Data([0xFF, 0xD8, 0xFF, 0xE0]))
+
+        // It exposes a `data:` URI (not a file URL) so the WKWebView, whose
+        // opaque origin can't load file:// subresources, can render it.
+        let expectedBase64 = Data([0xFF, 0xD8, 0xFF, 0xE0]).base64EncodedString()
+        XCTAssertEqual(
+            image?.inlineImageDataURL?.absoluteString,
+            "data:image/jpeg;base64,\(expectedBase64)"
+        )
+    }
+
+    func testInlineImageDataURLNilForNonImageOrMissingContentID() {
+        // A part with a Content-ID but a non-image type → not inline.
+        let textWithCID = MimeParser.parse(Data("""
+        Content-Type: text/calendar\r
+        Content-ID: <evt@x>\r
+        \r
+        BEGIN:VCALENDAR
+        """.utf8))
+        XCTAssertNil(textWithCID.inlineImageDataURL)
+
+        // An image with no Content-ID → a regular attachment, not inline.
+        let imageNoCID = MimeParser.parse(Data("""
+        Content-Type: image/png\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(Data([0x89, 0x50, 0x4E, 0x47]).base64EncodedString())
+        """.utf8))
+        XCTAssertNil(imageNoCID.inlineImageDataURL)
+    }
+
     func testFoldedHeadersUnfoldIntoSingleValue() {
         let message = """
         Subject: Hello\r

--- a/changelog.d/apple-html-reload-churn.fixed.md
+++ b/changelog.d/apple-html-reload-churn.fixed.md
@@ -1,0 +1,4 @@
+- Apple clients: the message body web view no longer reloads on every
+  SwiftUI update (flag changes, attachment loads, folder polling); it
+  reloads only when the content or remote-content policy actually changes.
+  The prior churn could cancel in-flight remote image requests mid-load.

--- a/changelog.d/apple-inline-cid-images.fixed.md
+++ b/changelog.d/apple-inline-cid-images.fixed.md
@@ -1,0 +1,4 @@
+- Apple clients: inline `cid:` images (e.g. USPS Informed Delivery
+  mailpiece scans) now render in the message body. They were rewritten to
+  temp `file://` URLs, which the body web view — loaded with an opaque
+  origin — is not allowed to fetch; they are now embedded as `data:` URIs.

--- a/changelog.d/apple-remote-image-reload.fixed.md
+++ b/changelog.d/apple-remote-image-reload.fixed.md
@@ -1,6 +1,0 @@
-- Apple clients: fixed remote images failing to load after tapping "Show
-  remote content" — the message web view reloaded on every SwiftUI update,
-  cancelling slower in-flight image requests (e.g. USPS Informed Delivery
-  mailpiece scans), so only the fastest one or two ever appeared. It now
-  reloads only when the message content or remote-content policy actually
-  changes.


### PR DESCRIPTION
The real cause of the missing USPS Informed Delivery mailpiece images: they are inline `cid:` parts, not remote content. The view rewrote each `cid:` reference to a temp `file://` URL, but the body `WKWebView` loads HTML via `loadHTMLString(_:baseURL: nil)`, giving the document an opaque origin that WebKit forbids from fetching `file://` subresources. So inline images silently failed while remote `https://` images (the logo) loaded once the blocker was lifted.

Inline images are now embedded as `data:` URIs (`MimePart .inlineImageDataURL`), which carry no origin requirement and are left alone by the remote-content blocker (it only matches `http(s)://`). Inline parts no longer touch the temp directory; only real attachments are written to disk.

Adds CabalmailKit coverage: a USPS-style nested multipart/related parses to an inline image leaf with the angle-bracket-stripped Content-ID and a `data:` URI, plus negative cases for non-image / missing-Content-ID parts.