### PR TITLE
Fix iPad message-list leading swipe; relocate sidebar New/Reload buttons

### DIFF
--- a/apple/Cabalmail/Views/AddressListView.swift
+++ b/apple/Cabalmail/Views/AddressListView.swift
@@ -30,6 +30,27 @@ struct AddressListView: View {
     private var activeFilterText: String { externalFilter?.wrappedValue ?? filterQuery }
 
     var body: some View {
+        VStack(spacing: 0) {
+            // Wide sidebar (iPad-regular / macOS): New / Reload flank the filter
+            // below the Folders/Addresses tabs. Compact keeps them in the toolbar.
+            if let externalFilter {
+                SidebarListHeaderRow(
+                    newAction: { showNewAddressSheet = true },
+                    newDisabled: false,
+                    newAccessibilityLabel: "Request new address",
+                    filterText: externalFilter,
+                    filterPrompt: "Filter addresses",
+                    isRefreshing: isRefreshing,
+                    refreshDisabled: isRefreshing || model == nil,
+                    refreshAccessibilityLabel: "Refresh addresses",
+                    refreshAction: { Task { await manualRefresh() } }
+                )
+            }
+            addressList
+        }
+    }
+
+    private var addressList: some View {
         List(selection: $selection) {
             if let model {
                 if model.isLoading && model.addresses.isEmpty {
@@ -62,22 +83,27 @@ struct AddressListView: View {
         .navigationTitle("Addresses")
         .sidebarFilterSearchable(text: $filterQuery, enabled: externalFilter == nil, prompt: "Filter addresses")
         .toolbar {
-            ToolbarItem {
-                Button {
-                    showNewAddressSheet = true
-                } label: {
-                    Image(systemName: "plus")
-                        .accessibilityLabel("Request new address")
+            // Compact keeps New / Reload in the toolbar; the wide sidebar moves
+            // them into SidebarListHeaderRow beside the filter (externalFilter is
+            // non-nil only on the wide layout).
+            if externalFilter == nil {
+                ToolbarItem {
+                    Button {
+                        showNewAddressSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .accessibilityLabel("Request new address")
+                    }
                 }
-            }
-            ToolbarItem {
-                Button {
-                    Task { await manualRefresh() }
-                } label: {
-                    RefreshActivityIcon(isLoading: isRefreshing)
-                        .accessibilityLabel("Refresh addresses")
+                ToolbarItem {
+                    Button {
+                        Task { await manualRefresh() }
+                    } label: {
+                        RefreshActivityIcon(isLoading: isRefreshing)
+                            .accessibilityLabel("Refresh addresses")
+                    }
+                    .disabled(isRefreshing || model == nil)
                 }
-                .disabled(isRefreshing || model == nil)
             }
         }
         .refreshable {

--- a/apple/Cabalmail/Views/FolderListView+Helpers.swift
+++ b/apple/Cabalmail/Views/FolderListView+Helpers.swift
@@ -14,6 +14,23 @@ extension FolderListView {
         await model.refresh()
     }
 
+    /// Wide-sidebar header row (New / filter / Reload), shown below the
+    /// Folders/Addresses tabs on iPad-regular and macOS. Lifted here so the
+    /// main `FolderListView` body stays under the type-body-length cap.
+    func wideSidebarHeader(filter: Binding<String>) -> some View {
+        SidebarListHeaderRow(
+            newAction: { showNewFolderSheet = true },
+            newDisabled: model == nil,
+            newAccessibilityLabel: "New folder",
+            filterText: filter,
+            filterPrompt: "Filter folders",
+            isRefreshing: isRefreshing,
+            refreshDisabled: isRefreshing || model == nil,
+            refreshAccessibilityLabel: "Refresh folders",
+            refreshAction: { Task { await manualRefresh() } }
+        )
+    }
+
     func filteredFolders(_ folders: [Folder]) -> [Folder] {
         let needle = activeFilterText.trimmingCharacters(in: .whitespaces).lowercased()
         guard !needle.isEmpty else { return folders }

--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -64,8 +64,9 @@ struct FolderListView: View {
     // context-menu item. Non-private so `folderContextMenu` in the `+Helpers`
     // extension (another file) can stage it.
     @State var emptyTrashConfirmPresented = false
-    // Drives the "New folder" sheet from the toolbar `+` button.
-    @State private var showNewFolderSheet = false
+    // Drives the "New folder" sheet from the `+` button. Non-private so the
+    // `+Helpers` extension's `wideSidebarHeader` can raise it too.
+    @State var showNewFolderSheet = false
     // Folder staged for deletion by a row's swipe / context menu, presented
     // as a confirmation dialog. Non-private so the delete-dialog plumbing in
     // `FolderListView+Helpers.swift` can reach it (same discipline as
@@ -73,8 +74,20 @@ struct FolderListView: View {
     @State var pendingDelete: Folder?
 
     var body: some View {
+        VStack(spacing: 0) {
+            // Wide sidebar (iPad-regular / macOS): the New / Reload buttons live
+            // here, flanking the filter, below the Folders/Addresses tabs.
+            // Compact keeps them in the toolbar (no filter row exists there).
+            if let externalFilter {
+                wideSidebarHeader(filter: externalFilter)
+            }
+            folderList
+        }
+    }
+
+    private var folderList: some View {
         let collapsedSet = decodeCollapsed()
-        List(selection: $selection) {
+        return List(selection: $selection) {
             if let model {
                 if model.isLoading && model.folders.isEmpty {
                     ProgressView("Loading folders…")
@@ -143,25 +156,30 @@ struct FolderListView: View {
                 }
             }
             #endif
-            ToolbarItem {
-                Button {
-                    showNewFolderSheet = true
-                } label: {
-                    Image(systemName: "plus")
-                        .accessibilityLabel("New folder")
+            // Compact keeps New / Reload in the toolbar; the wide sidebar moves
+            // them into SidebarListHeaderRow beside the filter (externalFilter is
+            // non-nil only on the wide layout).
+            if externalFilter == nil {
+                ToolbarItem {
+                    Button {
+                        showNewFolderSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                            .accessibilityLabel("New folder")
+                    }
+                    // The parent picker is seeded from the loaded folder list, so
+                    // hold the button until the first list load lands.
+                    .disabled(model == nil)
                 }
-                // The parent picker is seeded from the loaded folder list, so
-                // hold the button until the first list load lands.
-                .disabled(model == nil)
-            }
-            ToolbarItem {
-                Button {
-                    Task { await manualRefresh() }
-                } label: {
-                    RefreshActivityIcon(isLoading: isRefreshing)
-                        .accessibilityLabel("Refresh folders")
+                ToolbarItem {
+                    Button {
+                        Task { await manualRefresh() }
+                    } label: {
+                        RefreshActivityIcon(isLoading: isRefreshing)
+                            .accessibilityLabel("Refresh folders")
+                    }
+                    .disabled(isRefreshing || model == nil)
                 }
-                .disabled(isRefreshing || model == nil)
             }
         }
         .refreshable {

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import CabalmailKit
+#if os(iOS)
+import UIKit
+#endif
 
 /// Root of the signed-in navigation.
 ///
@@ -46,6 +49,24 @@ struct MailRootView: View {
     /// message shows `.detail`, a selected folder `.content`, and navigating
     /// back drops the selection. Ignored on regular-width layouts.
     @State private var compactColumn: NavigationSplitViewColumn = .sidebar
+    /// Wide-layout (iPad-regular) sidebar visibility. Defaults to `.doubleColumn`
+    /// — the folder/address sidebar starts COLLAPSED — so the message list is the
+    /// leftmost tile of the split. That is the only configuration in which the
+    /// list rows' leading swipe (read/unread) reveals at a normal drag distance:
+    /// when the sidebar is tiled to the list's left (`twoBesideSecondary`), the
+    /// split view's interactive column gesture out-arbitrates the row's leading
+    /// swipe, so the blue action only appears after an unreasonably long drag.
+    /// Collapsing the sidebar and revealing it on demand as an overlay (see
+    /// `SplitOverlayConfigurator`) keeps both swipes live in the reading state.
+    /// macOS keeps the sidebar visible (`.all`): a NavigationSplitView there is
+    /// AppKit-backed with no UISplitViewController gesture conflict, and it's a
+    /// desktop multi-pane window. Ignored on compact iPhone (navigates via
+    /// `compactColumn`).
+    #if os(macOS)
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    #else
+    @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
+    #endif
     @AppStorage("cabalmail.sidebar.tab") private var sidebarTabRaw: String = SidebarTab.folders.rawValue
     @Environment(AppState.self) private var appState
     @Environment(Preferences.self) private var preferences
@@ -121,7 +142,7 @@ struct MailRootView: View {
     }
 
     var body: some View {
-        NavigationSplitView(preferredCompactColumn: $compactColumn) {
+        NavigationSplitView(columnVisibility: $columnVisibility, preferredCompactColumn: $compactColumn) {
             sidebar
         } content: {
             if isSearching, let searchModel {
@@ -197,6 +218,13 @@ struct MailRootView: View {
                 #endif
             }
         }
+        // Force the iPad split view to OVERLAY the sidebar rather than tile it,
+        // so revealing folders floats over the message list instead of pushing
+        // the list off the leading edge (which would re-break the leading swipe).
+        // Best-effort and harmless if the split controller isn't found.
+        #if os(iOS)
+        .background(SplitOverlayConfigurator())
+        #endif
         // Clearing the envelope selection AND any active address filter when
         // the folder changes keeps the detail column from briefly rendering
         // an old message against the new mailbox, and matches the plan's
@@ -209,6 +237,13 @@ struct MailRootView: View {
             // Picking a folder shows its list on compact (it's pushed natively
             // from the sidebar List, but keep the binding in step).
             compactColumn = folder == nil ? .sidebar : .content
+            #if !os(macOS)
+            // On iPad-regular, re-collapse the overlaid sidebar after a folder
+            // pick so the message list is the leftmost tile again and its
+            // leading swipe stays live. No-op on compact (visibility ignored)
+            // and already-collapsed launches (INBOX auto-select).
+            if folder != nil { columnVisibility = .doubleColumn }
+            #endif
         }
         // Compact navigation: a selected message pushes the reader; navigating
         // back out (the binding falls off `.detail`) clears the selection so
@@ -348,13 +383,10 @@ extension MailRootView {
             .padding(.top, 8)
             .padding(.bottom, 4)
 
-            // Wide layout renders the per-context filter here — below the tabs,
-            // above the list — so the order reads search → tabs → filter → list.
-            // Compact lets each list keep its own top-of-sidebar `.searchable`.
-            if isWideSidebar {
-                sidebarFilterField
-            }
-
+            // The wide layout's per-context filter — and the New / Reload buttons
+            // that flank it — render inside the active list view's own header
+            // (`SidebarListHeaderRow`), below these tabs. Compact lets each list
+            // keep its own top-of-sidebar `.searchable` and toolbar buttons.
             switch effectiveSidebarTab {
             case .folders:
                 FolderListView(
@@ -381,37 +413,42 @@ extension MailRootView {
         }
     }
 
-    /// Per-context list filter for the wide sidebar — the "Filter folders" /
-    /// "Filter addresses" field shown below the section tabs. A plain styled
-    /// field (not `.searchable`, which would hoist above the global search);
-    /// the bound text drives the active list view's `externalFilter`.
-    @ViewBuilder
-    private var sidebarFilterField: some View {
-        let isFolders = effectiveSidebarTab == .folders
-        let text = isFolders ? $folderListFilter : $addressListFilter
-        HStack(spacing: 6) {
-            Image(systemName: "line.3.horizontal.decrease")
-                .foregroundStyle(.secondary)
-            TextField(isFolders ? "Filter folders" : "Filter addresses", text: text)
-                .textFieldStyle(.plain)
-            if !text.wrappedValue.isEmpty {
-                Button {
-                    text.wrappedValue = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
+}
+
+#if os(iOS)
+// MARK: - Split overlay behavior
+
+/// Forces the enclosing `UISplitViewController` to OVERLAY its sidebar instead
+/// of tiling it. SwiftUI's `NavigationSplitView` exposes no native knob for
+/// split behavior, and on a wide iPad it tiles by default — which, when the
+/// folder sidebar is revealed, pushes the message list off the leading edge and
+/// re-breaks the list's leading swipe. Overlaying floats the sidebar above the
+/// list, so revealing folders never disturbs the list's swipe geometry.
+///
+/// Best-effort: it walks the parent controller chain for the split controller
+/// and no-ops if none is found (the sidebar then re-tiles on reveal, which is
+/// still functional). Re-applied on every `updateUIViewController` so it
+/// survives the layout passes that can reset `preferredSplitBehavior`.
+private struct SplitOverlayConfigurator: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> Proxy { Proxy() }
+    func updateUIViewController(_ proxy: Proxy, context: Context) { proxy.applyOverlayBehavior() }
+
+    final class Proxy: UIViewController {
+        override func didMove(toParent parent: UIViewController?) {
+            super.didMove(toParent: parent)
+            applyOverlayBehavior()
+        }
+
+        func applyOverlayBehavior() {
+            var ancestor: UIViewController? = parent
+            while let current = ancestor {
+                if let split = current as? UISplitViewController {
+                    split.preferredSplitBehavior = .overlay
+                    return
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Clear filter")
+                ancestor = current.parent
             }
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 5)
-        .background(
-            RoundedRectangle(cornerRadius: 7)
-                .fill(Color.secondary.opacity(0.12))
-        )
-        .padding(.horizontal)
-        .padding(.bottom, 4)
     }
 }
+#endif

--- a/apple/Cabalmail/Views/SidebarListHeaderRow.swift
+++ b/apple/Cabalmail/Views/SidebarListHeaderRow.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Wide-sidebar (iPad-regular / macOS) header row for the folder and address
+/// lists: the per-context filter field flanked by the list's New (`+`) button on
+/// the leading edge and its Reload button on the trailing edge. Pulls those two
+/// actions out of the sidebar column's navigation toolbar and down beneath the
+/// Folders/Addresses tabs, next to the filter they act on.
+///
+/// Rendered by `FolderListView` / `AddressListView` only when their
+/// `externalFilter` binding is present (the wide layout); compact keeps the
+/// buttons in the toolbar and the filter in a `.searchable`. The filter field's
+/// styling matches the search field above the tabs in `MailRootView`.
+struct SidebarListHeaderRow: View {
+    let newAction: () -> Void
+    let newDisabled: Bool
+    let newAccessibilityLabel: String
+    @Binding var filterText: String
+    let filterPrompt: String
+    let isRefreshing: Bool
+    let refreshDisabled: Bool
+    let refreshAccessibilityLabel: String
+    let refreshAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: newAction) {
+                Image(systemName: "plus")
+                    .accessibilityLabel(newAccessibilityLabel)
+            }
+            .buttonStyle(.borderless)
+            .disabled(newDisabled)
+
+            filterField
+
+            Button(action: refreshAction) {
+                RefreshActivityIcon(isLoading: isRefreshing)
+                    .accessibilityLabel(refreshAccessibilityLabel)
+            }
+            .buttonStyle(.borderless)
+            .disabled(refreshDisabled)
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 4)
+    }
+
+    private var filterField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "line.3.horizontal.decrease")
+                .foregroundStyle(.secondary)
+            TextField(filterPrompt, text: $filterText)
+                .textFieldStyle(.plain)
+            if !filterText.isEmpty {
+                Button {
+                    filterText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear filter")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(Color.secondary.opacity(0.12))
+        )
+    }
+}

--- a/changelog.d/apple-ipad-list-leading-swipe.fixed.md
+++ b/changelog.d/apple-ipad-list-leading-swipe.fixed.md
@@ -1,0 +1,5 @@
+- Fixed the iPad message list's read/unread (leading) swipe needing an
+  unreasonably long drag before the action appeared. The folder/address
+  sidebar now starts collapsed on iPad and overlays the list when revealed,
+  so the message list is the leading column and its swipe actions reveal at a
+  normal distance. macOS keeps its sidebar visible.

--- a/changelog.d/apple-sidebar-new-reload-below-tabs.changed.md
+++ b/changelog.d/apple-sidebar-new-reload-below-tabs.changed.md
@@ -1,0 +1,4 @@
+- Moved the New and Reload buttons for the Folders and Addresses lists out of
+  the wide sidebar's toolbar and down beside the filter field (New to its left,
+  Reload to its right), below the Folders/Addresses tabs, on iPad and macOS.
+  Compact iPhone keeps them in the toolbar.


### PR DESCRIPTION
## Summary

Two related iPad/macOS sidebar changes.

### 1. iPad leading swipe (read/unread) fix — "Option A"

The message list's leading swipe required an unreasonably long drag before the blue action appeared on iPad. We dug into this before and shelved it as "structural, won't-fix." A fresh look (prompted by the observation that **hiding the sidebar makes the swipe behave**) overturned that:

- Root cause is the split view's **display mode**, not the embedded-`List` structure and not a beatable gesture. In the 3-column tiled mode (`twoBesideSecondary`) an interactive column gesture on the content column's leading edge out-arbitrates the row swipe. Disabling recognizers does **not** help (proven in a reduction harness — the gesture inventories for sidebar-shown vs sidebar-hidden are identical; only `displayMode` differs).
- The row swipe wins **only when the message list is the leftmost tile**.

Fix: default the wide-layout sidebar to **collapsed** (`.doubleColumn`) so the list is the leading column, and force the split view to **overlay** (not tile) the sidebar on reveal (`preferredSplitBehavior = .overlay`, via a small best-effort `SplitOverlayConfigurator`) so the native sidebar chrome floats over the list instead of pushing it off the leading edge.

- **macOS**: keeps its sidebar visible (`.all`) — AppKit-backed, no `UISplitViewController` gesture conflict.
- **Compact iPhone**: unaffected (navigates via `preferredCompactColumn`).

Validated in a standalone XCUITest reduction harness: with the list as the leftmost tile, the leading swipe reveals at the shortest drag distance (120 pt) from any start position; trailing stays working.

### 2. Relocate Folders/Addresses New + Reload buttons

Moved the New (`+`) and Reload buttons out of the wide sidebar's toolbar into a header row beside the filter field — **New to its left, Reload to its right**, below the Folders/Addresses tabs — on **iPad and macOS** (shared `SidebarListHeaderRow`). Compact iPhone keeps them in the toolbar (no filter row there). The settings gear is untouched.

## Testing

- `xcodebuild ... -destination 'generic/platform=iOS' build` — succeeds.
- `swiftlint lint` — clean (no warnings/errors; CI-strict).
- ⚠️ **Needs on-device/simulator confirmation**: the `.overlay` reveal relies on light UIKit introspection of `UISplitViewController` (no native SwiftUI knob exists). It's best-effort and falls back to a native re-tile-on-reveal if the controller isn't found — the swipe fix itself does not depend on it. Worth a look that (a) the collapsed sidebar still auto-selects INBOX on launch and (b) the sidebar reveals as an overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)