### PR TITLE
Move iPad Settings gear to the message-list toolbar

### DIFF
--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -14,14 +14,6 @@ struct FolderListView: View {
     // extensions in this directory.
     @Environment(AppState.self) var appState
     @Environment(Preferences.self) var preferences
-    #if !os(macOS)
-    // Drives whether the settings gear shows: true only on the regular-width
-    // single-rail layout, where the section tab bar is gone. Compact keeps its
-    // Settings tab instead. An environment flag, not a `horizontalSizeClass`
-    // check - this sidebar is a narrow split-view column and reports compact
-    // even on a regular-width iPad.
-    @Environment(\.showsSettingsGear) private var showsSettingsGear
-    #endif
     @State var model: FolderListViewModel?
     @State private var didNotifyLoad = false
     @State var filterQuery: String = ""
@@ -138,24 +130,6 @@ struct FolderListView: View {
         .navigationTitle("Mailboxes")
         .sidebarFilterSearchable(text: $filterQuery, enabled: externalFilter == nil, prompt: "Filter folders")
         .toolbar {
-            #if !os(macOS)
-            // Settings / Addresses / Folders admin live behind this gear as a
-            // modal sheet (`SettingsSheet`), mirroring the macOS ⌘, window.
-            // The Mailboxes sidebar is the natural app-level home for it at
-            // regular width, where the old section switcher is gone; compact
-            // width keeps a Settings tab and macOS its Settings scene, so the
-            // gear is regular-width-only to avoid a redundant entry point.
-            if showsSettingsGear {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        appState.requestSettings()
-                    } label: {
-                        Image(systemName: "gearshape")
-                            .accessibilityLabel("Settings")
-                    }
-                }
-            }
-            #endif
             // Compact keeps New / Reload in the toolbar; the wide sidebar moves
             // them into SidebarListHeaderRow beside the filter (externalFilter is
             // non-nil only on the wide layout).

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -141,46 +141,73 @@ struct MailRootView: View {
         )
     }
 
+    /// Content column: global search results while the sidebar search field is
+    /// engaged, otherwise the selected folder's message list (or an empty-state
+    /// prompt). Extracted so `body` can hang the Settings gear on its toolbar.
+    @ViewBuilder
+    private var contentColumn: some View {
+        if isSearching, let searchModel {
+            // Global search owns the content column while the sidebar field
+            // is engaged. Stable `.id` so it isn't torn down per keystroke;
+            // the detail column still reads the selected message, against
+            // the result's true mailbox via `crossFolderDetail`.
+            MessageListView(
+                scope: .search,
+                injectedSearchModel: searchModel,
+                selection: $selectedEnvelope,
+                addressFilter: nil,
+                onClearAddressFilter: {},
+                onSearchResultSelected: { sourceFolderPath in
+                    crossFolderDetail = sourceFolderPath.map { Folder(path: $0) }
+                },
+                onSelectionCountChanged: { listSelectionCount = $0 }
+            )
+            .id("search")
+        } else if let selectedFolder {
+            MessageListView(
+                scope: .folder(selectedFolder),
+                selection: $selectedEnvelope,
+                addressFilter: selectedAddress?.address,
+                onClearAddressFilter: { selectedAddress = nil },
+                onSearchResultSelected: { sourceFolderPath in
+                    crossFolderDetail = sourceFolderPath.map { Folder(path: $0) }
+                },
+                onSelectionCountChanged: { listSelectionCount = $0 }
+            )
+            .id(selectedFolder.path)
+        } else {
+            ContentUnavailableView(
+                "Select a folder",
+                systemImage: "sidebar.left",
+                description: Text("Pick a mailbox from the sidebar to browse messages.")
+            )
+        }
+    }
+
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility, preferredCompactColumn: $compactColumn) {
             sidebar
         } content: {
-            if isSearching, let searchModel {
-                // Global search owns the content column while the sidebar field
-                // is engaged. Stable `.id` so it isn't torn down per keystroke;
-                // the detail column still reads the selected message, against
-                // the result's true mailbox via `crossFolderDetail`.
-                MessageListView(
-                    scope: .search,
-                    injectedSearchModel: searchModel,
-                    selection: $selectedEnvelope,
-                    addressFilter: nil,
-                    onClearAddressFilter: {},
-                    onSearchResultSelected: { sourceFolderPath in
-                        crossFolderDetail = sourceFolderPath.map { Folder(path: $0) }
-                    },
-                    onSelectionCountChanged: { listSelectionCount = $0 }
-                )
-                .id("search")
-            } else if let selectedFolder {
-                MessageListView(
-                    scope: .folder(selectedFolder),
-                    selection: $selectedEnvelope,
-                    addressFilter: selectedAddress?.address,
-                    onClearAddressFilter: { selectedAddress = nil },
-                    onSearchResultSelected: { sourceFolderPath in
-                        crossFolderDetail = sourceFolderPath.map { Folder(path: $0) }
-                    },
-                    onSelectionCountChanged: { listSelectionCount = $0 }
-                )
-                .id(selectedFolder.path)
-            } else {
-                ContentUnavailableView(
-                    "Select a folder",
-                    systemImage: "sidebar.left",
-                    description: Text("Pick a mailbox from the sidebar to browse messages.")
-                )
-            }
+            contentColumn
+                // App-level Settings gear, relocated next to the content column's
+                // sidebar toggle now that the sidebar — its former home — starts
+                // collapsed on iPad. Regular-width iPad only (compact keeps its
+                // Settings tab, macOS its Settings scene), matching where the gear
+                // appeared before.
+                #if !os(macOS)
+                .toolbar {
+                    if showsSettingsGear {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button {
+                                appState.requestSettings()
+                            } label: {
+                                Image(systemName: "gearshape")
+                                    .accessibilityLabel("Settings")
+                            }
+                        }
+                    }
+                }
+                #endif
         } detail: {
             if listSelectionCount >= 2 {
                 // Multi-selection: no single message to read, so mirror Mail's

--- a/changelog.d/apple-ipad-settings-gear-message-list.changed.md
+++ b/changelog.d/apple-ipad-settings-gear-message-list.changed.md
@@ -1,0 +1,3 @@
+- Moved the iPad Settings gear from the (now collapsed-by-default) sidebar to
+  the message list's toolbar, adjacent to the sidebar toggle, so it stays
+  reachable without first revealing the sidebar.


### PR DESCRIPTION
## Summary

Follow-up to #551. With the iPad sidebar now collapsed by default, the Settings gear — which lived in the sidebar's toolbar — was only reachable after revealing the sidebar. This relocates it to the **content column's toolbar at `.topBarLeading`, adjacent to the native sidebar toggle**, so it's reachable at all times.

- Extracted the content column into a `contentColumn` property so the gear toolbar hangs off every content state (folder list, search, empty).
- **Regular-width iPad only** — unchanged on compact iPhone (Settings tab) and macOS (Settings scene). Same visibility gate (`showsSettingsGear`) as before, just a new home; removed the now-unused gear + `showsSettingsGear` reference from `FolderListView`.

## Testing

- `xcodebuild ... -destination 'generic/platform=iOS' build` — succeeds.
- `swiftlint lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)