### PR TITLE
Apple: fix unresponsive iPad list/reader resize handle

### DIFF
--- a/apple/Cabalmail/Views/ColumnResizeHandle.swift
+++ b/apple/Cabalmail/Views/ColumnResizeHandle.swift
@@ -25,18 +25,28 @@ struct ColumnResizeHandle: View {
         // A wide, transparent strip straddling the system divider gives a
         // forgiving grab target; the faint capsule marks where to grab without
         // drawing a second visible rule beside the divider SwiftUI already paints.
-        Color.clear
-            .frame(width: 16)
+        //
+        // The strip stays FULLY INSIDE the column (no negative inset). The
+        // `UISplitViewController` owns the exact column boundary, and an overlay
+        // nudged past the column's bounds gets clipped out of hit-testing by
+        // UIKit — so the visible grip looked present but ignored every touch
+        // because the half a user aims at was the clipped, dead half. Keeping
+        // the whole strip (and the capsule centred on it) inside the column
+        // puts the grab target where the eye lands.
+        //
+        // A near-zero-opacity fill rather than `Color.clear` guarantees the
+        // strip is hit-testable, and `highPriorityGesture` lets the drag win
+        // over the message list's scroll/tap underneath.
+        Rectangle()
+            .fill(Color.primary.opacity(0.001))
+            .frame(width: 22)
             .overlay {
                 Capsule()
                     .fill(.secondary.opacity(0.35))
                     .frame(width: 4, height: 36)
             }
             .contentShape(Rectangle())
-            // Shift the strip outward so it centres on the column's edge rather
-            // than sitting fully inside the column.
-            .padding(.trailing, -8)
-            .gesture(
+            .highPriorityGesture(
                 DragGesture(minimumDistance: 1)
                     .onChanged { value in
                         let anchor = dragAnchor ?? width


### PR DESCRIPTION
Follow-up to #554 (already merged to stage). On-device the resize grip rendered but ignored **all** input — touch and trackpad alike.

## Root cause

`.padding(.trailing, -8)` pushed the handle strip *past* the column's trailing edge. UIKit clips a `NavigationSplitView` column's bounds for hit-testing, so the visible capsule — centred on the edge — sat in the clipped, dead half, and the only live region was an 8pt sliver to its left that nobody would aim at. The grip looked present but the part you naturally target wasn't hittable.

## Fix

- Keep the strip **fully inside** the column (no negative inset) so the grip and its hit area coincide where the eye lands.
- Near-zero-opacity fill instead of `Color.clear` to guarantee hit-testing.
- `highPriorityGesture` so the drag wins over the message list's scroll/tap underneath.
- Widen the grab strip to 22pt.

## Testing

- swiftlint clean; iOS build succeeds (`scripts/build-apple.sh ios` → EXIT 0).
- **Still device-only to confirm:** that grabbing the handle now actually *moves* the divider. The other open unknown is whether `.navigationSplitViewColumnWidth` steers the content↔detail divider on iPad at all — if the handle now responds to drag but the divider doesn't move (or snaps back), that's the next thing to chase, and we'd pivot to a custom two-pane layout. So when testing: please note specifically *(a)* does it grab now, and *(b)* does the divider move and stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)