### PR TITLE
Apple: smooth iPad resize-handle drag (1:1 tracking)

### DIFF
--- a/apple/Cabalmail/Views/ColumnResizeHandle.swift
+++ b/apple/Cabalmail/Views/ColumnResizeHandle.swift
@@ -46,8 +46,15 @@ struct ColumnResizeHandle: View {
                     .frame(width: 4, height: 36)
             }
             .contentShape(Rectangle())
+            // Measure in GLOBAL space, not the handle's local space. The handle
+            // is pinned to the column's trailing edge, so resizing moves it —
+            // and a local-space translation would be measured against that
+            // moving origin, under-reporting by the amount the column just grew
+            // and feeding back on itself (the divider tracked the finger at
+            // roughly half speed and jittered between frames). Global space is
+            // fixed to the screen, so the translation is the true finger delta.
             .highPriorityGesture(
-                DragGesture(minimumDistance: 1)
+                DragGesture(minimumDistance: 1, coordinateSpace: .global)
                     .onChanged { value in
                         let anchor = dragAnchor ?? width
                         if dragAnchor == nil { dragAnchor = anchor }


### PR DESCRIPTION
Follow-up to #554/#555 (both merged). The list↔reader divider now resizes and persists across force-quit — but the drag jittered and tracked the finger at roughly half speed (a "bungee cord" feel).

## Root cause

The handle is pinned to the column's trailing edge, so resizing the column moves the handle. The `DragGesture` measured `translation` in the handle's **local** coordinate space — i.e. against an origin that moves as you drag. Each frame under-reported the movement by the amount the column had just grown, fed back on itself, settled near half travel, and oscillated frame-to-frame (the jitter).

## Fix

Measure the gesture in `.global` space (fixed to the screen), so `translation` is the true finger delta and the divider tracks 1:1, smoothly.

One line of real change:
```swift
DragGesture(minimumDistance: 1, coordinateSpace: .global)
```

## Testing

- swiftlint clean; iOS build succeeds (`scripts/build-apple.sh ios` → EXIT 0).
- Device check: drag should now follow the finger 1:1 with no jitter; persistence across force-quit is already confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)