### PR TITLE
Add changelog fragment for 2026-06-29 dependabot bumps

### DIFF
--- a/changelog.d/dependabot-2026-06-29.changed.md
+++ b/changelog.d/dependabot-2026-06-29.changed.md
@@ -1,0 +1,8 @@
+- Routine dependency bumps via Dependabot. The `mail-tier-base` group
+  advanced the `amazonlinux:2023` base-image digest across the imap,
+  sinkhole, smtp-in, and smtp-out images; the `monitoring-images` group
+  bumped `grafana/grafana` to 13.1.0, `binwiederhier/ntfy` to v2.25.0, and
+  the certbot-renewal Lambda's `lambda/python` base digest; and the
+  `github-actions` group bumped `aws-actions/configure-aws-credentials`,
+  `actions/cache`, `actions/setup-python`, `actions/setup-node`, and
+  `anthropics/claude-code-action` to their latest pinned versions.


### PR DESCRIPTION
Documents the three Dependabot groups merged into stage today (#559, #560, #561) with a single `changed` changelog fragment:

- **mail-tier-base** — `amazonlinux:2023` digest bump across imap, sinkhole, smtp-in, smtp-out
- **monitoring-images** — `grafana/grafana` 13.1.0, `binwiederhier/ntfy` v2.25.0, certbot-renewal `lambda/python` digest
- **github-actions** — `configure-aws-credentials`, `actions/cache`, `setup-python`, `setup-node`, `claude-code-action`

No code change; fragment only. The collator folds it into the next dated release section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)