### PR TITLE
Fix get_nav_state Decimal crash breaking cursor restore

### DIFF
--- a/changelog.d/nav-state-restore-decimal.fixed.md
+++ b/changelog.d/nav-state-restore-decimal.fixed.md
@@ -1,0 +1,5 @@
+- Fixed navigation-cursor restore on the Apple clients: `get_nav_state`
+  crashed with a `Decimal is not JSON serializable` error on every read, so
+  clients silently fell back to INBOX on launch instead of restoring the last
+  folder/message. Positions were being saved all along; only the read was
+  broken.

--- a/lambda/api/get_nav_state/function.py
+++ b/lambda/api/get_nav_state/function.py
@@ -1,6 +1,7 @@
 '''Fetches the current user's navigation cursor (last folder/message/scroll).'''
 import json
 import os
+from decimal import Decimal
 import boto3  # pylint: disable=import-error
 
 ddb = boto3.resource('dynamodb')
@@ -14,9 +15,11 @@ def _to_plain(value):
         return [_to_plain(v) for v in value]
     if isinstance(value, dict):
         return {k: _to_plain(v) for k, v in value.items()}
-    # boto3 returns numbers as Decimal; the cursor only stores whole numbers.
-    if hasattr(value, 'is_integer'):
-        return int(value)
+    # boto3 returns numbers as Decimal. Decimal has no is_integer(), so match
+    # it explicitly (the previous duck-type check missed it, leaving Decimals
+    # that json.dumps could not serialize). The cursor stores whole numbers.
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
     return value
 
 


### PR DESCRIPTION
## Problem

Navigation-cursor restore (PR #563) never worked on the Apple clients. Verified on **stage**:

- `set_nav_state` (write): 11 invocations, **0 errors** — positions were being saved.
- `get_nav_state` (read): 7 invocations, **7 errors (100%)**.

The read crashed with:

```
[ERROR] TypeError: Object of type Decimal is not JSON serializable
  File "/var/task/function.py", line 37, in handler
    'body': json.dumps(nav_state)
```

DynamoDB returns numeric attributes (the `updated_at` timestamp) as `decimal.Decimal`. `_to_plain` tried to normalize them with `hasattr(value, 'is_integer')`, but `Decimal` has no `is_integer()` on the Lambda runtime, so the value fell through unconverted and `json.dumps` raised. `json.dumps(nav_state)` sits outside the try/except, so it surfaced as an unhandled 502. The Apple clients caught it via graceful degradation and landed on INBOX — making restore look dead.

## Fix

Match `Decimal` explicitly in `_to_plain` and coerce to `int` (or `float` when non-integral). Verified against the exact stage item shape plus nested/fractional cases; pylint 10/10.

No client changes needed — the existing TestFlight build will start restoring correctly once this deploys and the read stops 502-ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)