### PR TITLE
Launch resume: land in Inbox, offer a toast instead of auto-restoring

### DIFF
--- a/apple/Cabalmail/NavStateCoordinator.swift
+++ b/apple/Cabalmail/NavStateCoordinator.swift
@@ -12,12 +12,16 @@ import CabalmailKit
 /// `.onChange` handlers and read by views.
 ///
 /// Cursor lifecycle:
-/// - **Launch** (`initialCursor`): fetch once, restore silently. No prompt —
-///   the user opened this client to use it.
+/// - **Launch** (`launchResumeCandidate`): fetch once and land on INBOX
+///   regardless — never restore silently. If the saved folder still exists and
+///   the recorded message is still in that folder's initial window, return the
+///   cursor so `MailRootView` can offer a "pick up where you left off" toast.
+///   Until the user taps it they stay in INBOX, and the default landing is held
+///   back from overwriting the saved cursor (`armProvisionalLanding`).
 /// - **Foreground** (`foreignCursorOnForeground`): fetch again; if the cursor
 ///   now carries a different `clientID` and a newer `updatedAt` than we last
-///   saw, surface it for the "pick up where you left off" toast. Our own
-///   writes never trip this (same `clientID`).
+///   saw, surface it for the same toast. Our own writes never trip this (same
+///   `clientID`).
 /// - **Recording** (`recordFolder`/`recordMessage`): update the working cursor
 ///   and debounce a save, so only the active client writes, and only on change.
 @Observable
@@ -67,6 +71,10 @@ final class NavStateCoordinator {
     /// user dismissed isn't re-offered on every foreground.
     private var lastSeenUpdatedAt: Int64 = 0
     private var restoreTick = 0
+    /// Set by `armProvisionalLanding`: swallow the next `recordFolder` (the
+    /// launch INBOX landing) without persisting, so a still-valid saved cursor
+    /// isn't overwritten before the user acts on the resume toast.
+    private var suppressNextFolderRecord = false
     /// Debounce window for cursor saves. Long enough that a quick folder→
     /// message→scroll sequence collapses to one write.
     private let saveDebounce: Duration = .seconds(1)
@@ -78,15 +86,62 @@ final class NavStateCoordinator {
 
     // MARK: Launch restore
 
-    /// Fetches the saved cursor once. Returns it so `MailRootView` can select
-    /// the folder; subsequent calls return nil. Records the cursor's recency so
-    /// the same position isn't later offered back as a cross-client jump.
-    func initialCursor() async -> NavState? {
+    /// Envelopes the message list loads on first open
+    /// (`MessageListViewModel.pageSize`). Launch reachability is checked against
+    /// this same window, so a cursor we vouch for always resolves to a
+    /// selectable row when the user taps Resume.
+    private static let initialWindow: UInt32 = 50
+
+    /// Fetches the saved cursor once and returns it *only* if it's still a
+    /// usable resume target: the folder still exists and, when a message was
+    /// recorded, that message is still in the folder's initial window. Returns
+    /// nil otherwise (no cursor, folder deleted, message moved/expunged) so
+    /// `MailRootView` simply stays in INBOX with no prompt. Never restores — the
+    /// caller offers a toast. Records the cursor's recency so the same position
+    /// isn't later re-offered by the foreground cross-client path.
+    func launchResumeCandidate(folders: [Folder]) async -> NavState? {
         guard !hasLoadedInitial else { return nil }
         hasLoadedInitial = true
         guard let cursor = try? await client.navState() else { return nil }
         lastSeenUpdatedAt = max(lastSeenUpdatedAt, cursor.updatedAt ?? 0)
+        // The folder must still exist (another client may have deleted it).
+        guard folders.contains(where: { $0.path == cursor.folder }) else { return nil }
+        // A folder-only cursor has no message to verify; a message cursor must
+        // still be reachable in that folder.
+        if cursor.messageID != nil || cursor.uid != nil {
+            let reachable = await messageIsReachable(cursor)
+            if !reachable { return nil }
+        }
         return cursor
+    }
+
+    /// Whether `cursor`'s recorded message is present in its folder's initial
+    /// window — the same page (`status` + `topEnvelopes`) the list loads on
+    /// open — matched by Message-ID first then UID, exactly as the list's
+    /// restore does. Any probe failure returns false: we never offer a resume
+    /// we can't stand behind.
+    private func messageIsReachable(_ cursor: NavState) async -> Bool {
+        do {
+            try await client.imapClient.connectAndAuthenticate()
+            let status = try await client.imapClient.status(path: cursor.folder)
+            let total = UInt32(max(0, status.messages ?? 0))
+            guard total > 0 else { return false }
+            let window = try await client.imapClient.topEnvelopes(
+                folder: cursor.folder,
+                limit: Self.initialWindow,
+                totalMessages: total
+            )
+            if let messageID = cursor.messageID,
+               window.contains(where: { $0.messageId == messageID }) {
+                return true
+            }
+            if let uid = cursor.uid, window.contains(where: { $0.uid == uid }) {
+                return true
+            }
+            return false
+        } catch {
+            return false
+        }
     }
 
     // MARK: Foreground reconcile
@@ -133,14 +188,29 @@ final class NavStateCoordinator {
 
     // MARK: Recording
 
+    /// Arms suppression of the next folder record. `MailRootView` calls this
+    /// before it default-selects INBOX at launch while a resume may be pending,
+    /// so that landing doesn't clobber the saved cursor. Cleared by the first
+    /// `recordFolder` (the landing), or explicitly recorded once the probe
+    /// confirms there's nothing to resume.
+    func armProvisionalLanding() {
+        suppressNextFolderRecord = true
+    }
+
     /// Records that the user is now in `folderPath` (no message yet). Folder is
-    /// the highest-priority cursor field, so this always schedules a save.
+    /// the highest-priority cursor field, so this normally schedules a save —
+    /// except for the launch INBOX landing, which updates the working cursor
+    /// but must not persist over a still-valid saved position.
     func recordFolder(_ folderPath: String) {
         folder = folderPath
         messageID = nil
         uid = nil
         uidValidity = nil
         listScroll = nil
+        if suppressNextFolderRecord {
+            suppressNextFolderRecord = false
+            return
+        }
         scheduleSave()
     }
 

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -84,7 +84,8 @@ struct MailRootView: View {
     /// Drives the cross-client cursor reconcile: returning to the foreground
     /// re-reads the server cursor and, if another client moved it on, offers
     /// the "pick up where you left off" toast. The initial launch transition
-    /// doesn't fire `.onChange`, so a cold launch restores silently instead.
+    /// doesn't fire `.onChange`, so a cold launch offers its own resume toast
+    /// from the folder-load path (`landOnInboxAndOfferResume`) instead.
     @Environment(\.scenePhase) private var scenePhase
     /// Global-search model for the wide (iPad-regular / macOS) layout, owned
     /// here so the sidebar search field and the content column share one query
@@ -333,9 +334,9 @@ struct MailRootView: View {
         }
         // Returning to the foreground after the initial launch: if another
         // client moved the cursor on, offer the jump. `hasLoadedInitial` gates
-        // out the cold-launch path (which restores silently via the sidebar's
-        // onFoldersLoaded), and `old != .active` ignores in-app interruptions
-        // that didn't actually background us.
+        // out the cold-launch path (which offers its own resume toast via the
+        // sidebar's onFoldersLoaded), and `old != .active` ignores in-app
+        // interruptions that didn't actually background us.
         .onChange(of: scenePhase) { old, new in
             guard new == .active, old != .active,
                   let coordinator = appState.navCoordinator,
@@ -407,23 +408,34 @@ struct MailRootView: View {
 // SwiftLint's `type_body_length` cap, matching the pattern used by
 // `MessageListView` and its `+Filter` / `+Search` siblings.
 extension MailRootView {
-    /// First-load folder selection: restore the saved cross-client cursor's
-    /// folder if it still exists, otherwise default to INBOX. Graceful when the
-    /// remembered folder was deleted elsewhere — the lookup simply misses and
-    /// we fall back. The message restore (if any) rides along via the
-    /// coordinator's `pendingRestore`, which the folder's message list consumes
-    /// after it loads; a since-deleted message just leaves the list unselected.
-    private func restoreOrDefaultSelect(from folders: [Folder]) {
+    /// First-load folder selection: always land on INBOX, then — in the
+    /// background — check whether the saved cursor is still a usable resume
+    /// target (folder present, recorded message still in the folder's initial
+    /// window) and, if so, offer a "pick up where you left off" toast rather
+    /// than jumping there. Tapping it drives the same `navigateRequest` path as
+    /// the cross-client resume. The INBOX landing's own cursor write is held
+    /// back (`armProvisionalLanding`) so a still-valid saved position survives
+    /// until the user resumes or navigates on their own; if there's nothing to
+    /// resume, INBOX is recorded normally once the probe returns.
+    private func landOnInboxAndOfferResume(from folders: [Folder]) {
         let inbox = folders.first { folder in
             folder.path.caseInsensitiveCompare("INBOX") == .orderedSame
         } ?? folders.first
+        appState.navCoordinator?.armProvisionalLanding()
+        selectedFolder = inbox
         Task {
-            if let cursor = await appState.navCoordinator?.initialCursor(),
-               let target = folders.first(where: { $0.path == cursor.folder }) {
-                selectedFolder = target
-                appState.navCoordinator?.scheduleRestore(for: cursor)
-            } else {
-                selectedFolder = inbox
+            let candidate = await appState.navCoordinator?.launchResumeCandidate(folders: folders)
+            // If the user already navigated off INBOX while the probe ran, leave
+            // them be rather than surfacing a now-stale prompt.
+            guard selectedFolder?.path == inbox?.path else { return }
+            if let candidate {
+                appState.showToast(
+                    .resumeNavigation(folderName: Folder(path: candidate.folder).name, cursor: candidate),
+                    duration: 10
+                )
+            } else if let inbox {
+                // Nothing to resume: materialize the INBOX landing we suppressed.
+                appState.navCoordinator?.recordFolder(inbox.path)
             }
         }
     }
@@ -498,14 +510,15 @@ extension MailRootView {
                     selection: $selectedFolder,
                     externalFilter: isWideSidebar ? $folderListFilter : nil,
                     onFoldersLoaded: { folders in
-                        // First load: restore the saved cursor's folder if it
-                        // still exists, otherwise default-select INBOX. The
-                        // Compose button lives on the message-list toolbar, so a
-                        // nil-selection state would leave the user no way to
-                        // start a new message; INBOX is always present
+                        // First load: land on INBOX and, if a saved position is
+                        // still reachable, offer a resume toast (see
+                        // `landOnInboxAndOfferResume`). The Compose button lives
+                        // on the message-list toolbar, so a nil-selection state
+                        // would leave the user no way to start a new message;
+                        // INBOX is always present
                         // (`FolderListViewModel.sortForSidebar` pins it first).
                         guard selectedFolder == nil else { return }
-                        restoreOrDefaultSelect(from: folders)
+                        landOnInboxAndOfferResume(from: folders)
                     }
                 )
             case .addresses:

--- a/changelog.d/apple-nav-state.added.md
+++ b/changelog.d/apple-nav-state.added.md
@@ -1,6 +1,8 @@
 - The Apple clients now remember where you were between launches — the folder
-  you were last in and the message you were reading — and restore it on
-  relaunch, gracefully falling back when a remembered folder or message has
-  since been deleted or moved. The position syncs across your devices: when
-  another client has moved on, a banner offers to pick up where you left off
-  there. (Scroll position is not yet remembered.)
+  you were last in and the message you were reading. On relaunch they open to
+  your Inbox and, when that saved folder and message are still reachable, show
+  a banner offering to pick up where you left off; tap it to jump there. The
+  position syncs across your devices, so the same banner appears when another
+  client has moved on. Everything degrades gracefully when a remembered folder
+  or message has since been deleted or moved (no banner). (Scroll position is
+  not yet remembered.)


### PR DESCRIPTION
## What changed

Per request: on relaunch the Apple clients now **always land on INBOX** and offer an opt-in **"pick up where you left off"** toast, instead of silently jumping back to the saved folder/message. Tapping the toast resumes; ignoring it leaves you in INBOX.

The toast appears **only when the saved position is still reachable**: the folder still exists *and* — if a message was recorded — that message is still in the folder's initial (top-50) window. That's the same window the list loads and restores against, so a toast we show always resolves to a selectable message on tap. Folder deleted / message moved or expunged elsewhere ⇒ no toast, you just stay in INBOX.

## Why this also fixes the "I never saw the cross-client toast"

The old launch path restored the cursor silently on every cold launch, regardless of which device wrote it — so the cross-device resume happened *without a prompt*. The toast only ever fired on the foreground-after-a-remote-change path, which a normal relaunch doesn't hit. Routing launch through the same toast makes both same-device and cross-device resume visible.

## Notes

- **Saved position is preserved until you act.** `armProvisionalLanding()` holds back the INBOX landing's own cursor write so it doesn't overwrite a still-valid saved position before you resume or navigate somewhere yourself. If there's nothing to resume, INBOX records normally.
- **Folder-only cursors** (you were browsing a folder without opening a message) offer the toast on folder reachability alone — there's no message to verify.
- **Strict verification cost:** as agreed, this adds a background `status` + `topEnvelopes` probe of the saved folder at launch. It never blocks the INBOX render; it only decides whether the toast appears. A message buried below the top window reads as "not reachable" (same limitation as the list's own restore).
- **Toast wording unchanged:** reuses the existing "Pick up where you left off in <folder>?" banner with a **Resume** button (rather than a literal "OK"), so the launch and cross-client prompts stay identical. Trivial to switch to "OK" if you prefer.
- **Scroll** still deferred.

Built (macOS target) and SwiftLint `--strict` clean. Apple client code isn't deployed by stage — this ships in the next TestFlight build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)