### PR TITLE
Remember in-message scroll position (nav cursor)

### DIFF
--- a/apple/Cabalmail/NavStateCoordinator.swift
+++ b/apple/Cabalmail/NavStateCoordinator.swift
@@ -45,6 +45,24 @@ final class NavStateCoordinator {
     /// the matching `MessageListView`.
     private(set) var pendingRestore: PendingRestore?
 
+    /// An in-message scroll position to reapply once the reader opens the
+    /// restored message. Consumed by `MessageDetailView` (which owns the body
+    /// renderer), keyed by folder + message so it only lands on the intended
+    /// message. `offset` restores a plain-text body; `anchor` restores an HTML
+    /// body — a message renders as one or the other, so the reader applies
+    /// whichever matches.
+    struct PendingScrollRestore: Equatable, Sendable {
+        let folderPath: String
+        let messageID: String?
+        let uid: UInt32?
+        let offset: Int?
+        let anchor: String?
+    }
+
+    /// Set alongside `pendingRestore` when the restored cursor carried a scroll
+    /// position; consumed by the reader after the message loads.
+    private(set) var pendingScrollRestore: PendingScrollRestore?
+
     /// Set by the resume toast's action; observed by `MailRootView`, which
     /// selects the folder and schedules the message restore, then clears it.
     var navigateRequest: NavState?
@@ -63,6 +81,8 @@ final class NavStateCoordinator {
     private var uid: UInt32?
     private var uidValidity: UInt32?
     private var listScroll: Int?
+    private var messageScroll: Int?
+    private var messageAnchor: String?
 
     private var saveTask: Task<Void, Never>?
     /// The last body actually written, to skip redundant network writes.
@@ -168,6 +188,8 @@ final class NavStateCoordinator {
         uid = cursor.uid
         uidValidity = cursor.uidValidity
         listScroll = cursor.listScroll
+        messageScroll = cursor.messageScroll
+        messageAnchor = cursor.messageAnchor
         restoreTick += 1
         pendingRestore = PendingRestore(
             folderPath: cursor.folder,
@@ -176,6 +198,20 @@ final class NavStateCoordinator {
             listScroll: cursor.listScroll,
             tick: restoreTick
         )
+        // Only publish a scroll restore when the cursor actually carried one, so
+        // the reader doesn't force a message that was saved at the top back to
+        // the top redundantly.
+        if cursor.messageScroll != nil || cursor.messageAnchor != nil {
+            pendingScrollRestore = PendingScrollRestore(
+                folderPath: cursor.folder,
+                messageID: cursor.messageID,
+                uid: cursor.uid,
+                offset: cursor.messageScroll,
+                anchor: cursor.messageAnchor
+            )
+        } else {
+            pendingScrollRestore = nil
+        }
     }
 
     /// Returns and clears the pending restore for `folderPath`, if it targets
@@ -183,6 +219,25 @@ final class NavStateCoordinator {
     func consumePendingRestore(for folderPath: String) -> PendingRestore? {
         guard let restore = pendingRestore, restore.folderPath == folderPath else { return nil }
         pendingRestore = nil
+        return restore
+    }
+
+    /// Returns and clears the pending scroll restore if it targets the message
+    /// `MessageDetailView` just opened — matched by folder plus Message-ID
+    /// (durable across a move) or UID. The reader calls this once the body has
+    /// loaded and applies `offset` (plain text) or `anchor` (HTML).
+    func consumeScrollRestore(folderPath: String, uid: UInt32?, messageID: String?) -> PendingScrollRestore? {
+        guard let restore = pendingScrollRestore, restore.folderPath == folderPath else { return nil }
+        let messageMatches: Bool
+        if let wanted = restore.messageID, let have = messageID {
+            messageMatches = wanted == have
+        } else if let wanted = restore.uid, let have = uid {
+            messageMatches = wanted == have
+        } else {
+            messageMatches = false
+        }
+        guard messageMatches else { return nil }
+        pendingScrollRestore = nil
         return restore
     }
 
@@ -207,6 +262,8 @@ final class NavStateCoordinator {
         uid = nil
         uidValidity = nil
         listScroll = nil
+        messageScroll = nil
+        messageAnchor = nil
         if suppressNextFolderRecord {
             suppressNextFolderRecord = false
             return
@@ -214,11 +271,26 @@ final class NavStateCoordinator {
         scheduleSave()
     }
 
-    /// Records that the user opened a message in `folderPath`.
+    /// Records that the user opened a message in `folderPath`. A freshly-opened
+    /// message starts at the top, so any prior in-message scroll is cleared —
+    /// `recordMessageScroll` re-populates it as the user reads.
     func recordMessage(folderPath: String, uid: UInt32, messageID: String?) {
         folder = folderPath
         self.uid = uid
         self.messageID = messageID
+        messageScroll = nil
+        messageAnchor = nil
+        scheduleSave()
+    }
+
+    /// Records the current in-message scroll position for the open message —
+    /// an exact `offset` for a plain-text body, a structural `anchor` for an
+    /// HTML body. Ignored unless the working cursor is still on that message,
+    /// so a late capture from a message the user already left can't mis-attach.
+    func recordMessageScroll(folderPath: String, uid: UInt32, offset: Int?, anchor: String?) {
+        guard folder == folderPath, self.uid == uid else { return }
+        messageScroll = offset
+        messageAnchor = anchor
         scheduleSave()
     }
 
@@ -229,6 +301,8 @@ final class NavStateCoordinator {
         guard folder == folderPath, uid != nil || messageID != nil else { return }
         uid = nil
         messageID = nil
+        messageScroll = nil
+        messageAnchor = nil
         scheduleSave()
     }
 
@@ -240,6 +314,8 @@ final class NavStateCoordinator {
             uid: uid,
             uidValidity: uidValidity,
             listScroll: listScroll,
+            messageScroll: messageScroll,
+            messageAnchor: messageAnchor,
             clientID: clientID
         )
         saveTask?.cancel()

--- a/apple/Cabalmail/Views/HTMLBodyView.swift
+++ b/apple/Cabalmail/Views/HTMLBodyView.swift
@@ -37,6 +37,32 @@ struct HTMLBodyView: View {
     /// advances, so a SwiftUI re-layout (which re-runs `update*View` with
     /// the same tick) doesn't re-trigger printing.
     var printRequestTick: Int = 0
+    /// In-message scroll anchor to reapply once the body finishes loading (a
+    /// child-index path + delta produced by a prior `onScrollCaptured`, resumed
+    /// from the nav cursor). Nil for a normal open. See `NavStateCoordinator`.
+    var restoreAnchor: String?
+    /// Reports the current scroll anchor while the message is on screen (polled
+    /// off the SwiftUI render loop). The reader relays it to the nav cursor so
+    /// the position survives across launches and devices.
+    var onScrollCaptured: ((String) -> Void)?
+
+    init(
+        html: String,
+        inlineImages: [String: URL],
+        allowRemote: Bool,
+        readerMode: Bool,
+        printRequestTick: Int = 0,
+        restoreAnchor: String? = nil,
+        onScrollCaptured: ((String) -> Void)? = nil
+    ) {
+        self.html = html
+        self.inlineImages = inlineImages
+        self.allowRemote = allowRemote
+        self.readerMode = readerMode
+        self.printRequestTick = printRequestTick
+        self.restoreAnchor = restoreAnchor
+        self.onScrollCaptured = onScrollCaptured
+    }
 
     var body: some View {
         #if os(macOS)
@@ -45,7 +71,9 @@ struct HTMLBodyView: View {
             inlineImages: inlineImages,
             allowRemote: allowRemote,
             readerMode: readerMode,
-            printRequestTick: printRequestTick
+            printRequestTick: printRequestTick,
+            restoreAnchor: restoreAnchor,
+            onScrollCaptured: onScrollCaptured
         )
         #else
         MobileHTMLView(
@@ -53,7 +81,9 @@ struct HTMLBodyView: View {
             inlineImages: inlineImages,
             allowRemote: allowRemote,
             readerMode: readerMode,
-            printRequestTick: printRequestTick
+            printRequestTick: printRequestTick,
+            restoreAnchor: restoreAnchor,
+            onScrollCaptured: onScrollCaptured
         )
         #endif
     }
@@ -68,6 +98,8 @@ private struct MobileHTMLView: UIViewRepresentable {
     let allowRemote: Bool
     let readerMode: Bool
     let printRequestTick: Int
+    let restoreAnchor: String?
+    let onScrollCaptured: ((String) -> Void)?
 
     func makeCoordinator() -> HTMLBodyCoordinator {
         HTMLBodyCoordinator(allowRemote: allowRemote)
@@ -93,6 +125,7 @@ private struct MobileHTMLView: UIViewRepresentable {
         // dark inherited palette.
         uiView.overrideUserInterfaceStyle = readerMode ? .unspecified : .light
         uiView.backgroundColor = readerMode ? nil : .white
+        context.coordinator.onScrollCaptured = onScrollCaptured
         context.coordinator.render(
             html: html,
             inlineImages: inlineImages,
@@ -101,6 +134,7 @@ private struct MobileHTMLView: UIViewRepresentable {
             on: uiView
         )
         context.coordinator.handlePrintTick(printRequestTick, for: uiView)
+        context.coordinator.updateRestoreAnchor(restoreAnchor, on: uiView)
     }
 }
 #endif
@@ -114,6 +148,8 @@ private struct MacHTMLView: NSViewRepresentable {
     let allowRemote: Bool
     let readerMode: Bool
     let printRequestTick: Int
+    let restoreAnchor: String?
+    let onScrollCaptured: ((String) -> Void)?
 
     func makeCoordinator() -> HTMLBodyCoordinator {
         HTMLBodyCoordinator(allowRemote: allowRemote)
@@ -135,6 +171,7 @@ private struct MacHTMLView: NSViewRepresentable {
         // CSS assumes a white page. Reader mode owns the palette via its
         // `prefers-color-scheme` stylesheet, so it tracks the system.
         nsView.appearance = readerMode ? nil : NSAppearance(named: .aqua)
+        context.coordinator.onScrollCaptured = onScrollCaptured
         context.coordinator.render(
             html: html,
             inlineImages: inlineImages,
@@ -143,6 +180,7 @@ private struct MacHTMLView: NSViewRepresentable {
             on: nsView
         )
         context.coordinator.handlePrintTick(printRequestTick, for: nsView)
+        context.coordinator.updateRestoreAnchor(restoreAnchor, on: nsView)
     }
 }
 #endif
@@ -171,9 +209,26 @@ final class HTMLBodyCoordinator: NSObject, WKNavigationDelegate {
     /// SwiftUI re-layout; comparing against this value ensures the system
     /// print sheet only opens when the parent's counter actually advances.
     private var lastPrintTick: Int = 0
+    /// Reports the current in-message scroll anchor to the reader. Set from
+    /// `update*View`; invoked by the capture poll.
+    var onScrollCaptured: ((String) -> Void)?
+    /// Scroll anchor to reapply once the page has loaded, or nil for a normal
+    /// open. Applied exactly once (`didApplyRestore`).
+    private var restoreAnchor: String?
+    private var didApplyRestore = false
+    private var didFinishLoad = false
+    /// Polls the page for its scroll anchor while it's on screen. Scoped to the
+    /// web view's lifetime (cancelled on deinit) so it never touches the
+    /// SwiftUI render loop. Started after the first load so it can't capture the
+    /// pre-restore top-of-page position.
+    private var pollTask: Task<Void, Never>?
 
     init(allowRemote: Bool) {
         self.allowRemote = allowRemote
+    }
+
+    deinit {
+        pollTask?.cancel()
     }
 
     /// Called from `update*View` with the current tick. Triggers the
@@ -226,6 +281,138 @@ final class HTMLBodyCoordinator: NSObject, WKNavigationDelegate {
             return .allow
         }
         return allowRemote ? .allow : .cancel
+    }
+
+    // MARK: - In-message scroll capture / restore
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        didFinishLoad = true
+        applyRestoreIfNeeded(on: webView)
+        startPollingIfNeeded(on: webView)
+    }
+
+    /// Records the target anchor and, if the page has already finished loading
+    /// (the anchor can arrive after `didFinish` when the reader consumes it just
+    /// after the body appears), applies it immediately. A no-op once applied.
+    func updateRestoreAnchor(_ anchor: String?, on webView: WKWebView) {
+        restoreAnchor = anchor
+        if didFinishLoad {
+            applyRestoreIfNeeded(on: webView)
+        }
+    }
+
+    /// Runs our restore script once: it walks the child-index path to the
+    /// anchored element and `scrollIntoView`s it, then nudges by the saved
+    /// delta. Re-run once after a short delay because inline images decoding
+    /// after `didFinish` can still shift layout. `nil`/empty anchors no-op.
+    private func applyRestoreIfNeeded(on webView: WKWebView) {
+        guard !didApplyRestore, let anchor = restoreAnchor, !anchor.isEmpty else { return }
+        didApplyRestore = true
+        let script = Self.restoreScript(anchor: anchor)
+        webView.evaluateJavaScript(script, completionHandler: nil)
+        Task { [weak webView] in
+            try? await Task.sleep(for: .milliseconds(400))
+            webView?.evaluateJavaScript(script, completionHandler: nil)
+        }
+    }
+
+    private func startPollingIfNeeded(on webView: WKWebView) {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self, weak webView] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled, let self, let webView else { return }
+                await self.captureAndReport(from: webView)
+            }
+        }
+    }
+
+    private func captureAndReport(from webView: WKWebView) async {
+        let result = try? await webView.evaluateJavaScript(Self.captureScript)
+        guard let anchor = result as? String, !anchor.isEmpty else { return }
+        onScrollCaptured?(anchor)
+    }
+
+    /// Reads the top-most visible element and returns a compact anchor:
+    /// `"i<child.index.path>|<delta>"`, or a `"f<fraction>"` fallback when the
+    /// top of the viewport isn't over a concrete element. App-initiated (runs
+    /// even though page-content JS is disabled); reads geometry only.
+    private static let captureScript = """
+    (function(){
+      var se=document.scrollingElement||document.documentElement;
+      if(!se){return "";}
+      var el=document.elementFromPoint(4,4);
+      if(!el||el===document.documentElement||el===document.body){
+        var h=se.scrollHeight-se.clientHeight;
+        return "f"+(h>0?(se.scrollTop/h).toFixed(4):"0");
+      }
+      var top=Math.round(el.getBoundingClientRect().top);
+      var path=[];
+      var n=el;
+      while(n&&n.parentElement&&n!==document.body){
+        var p=n.parentElement;
+        path.unshift(Array.prototype.indexOf.call(p.children,n));
+        n=p;
+      }
+      return "i"+path.join(".")+"|"+top;
+    })();
+    """
+
+    /// Escapes an arbitrary string into a safe JS double-quoted string literal.
+    /// The anchor normally comes from our own `captureScript`, but a cursor row
+    /// written by another client is only length/control-char validated
+    /// server-side, so escape defensively rather than interpolate raw.
+    private static func jsStringLiteral(_ value: String) -> String {
+        var out = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"": out += "\\\""
+            case "\\": out += "\\\\"
+            case "\n": out += "\\n"
+            case "\r": out += "\\r"
+            default:
+                if scalar.value < 0x20 {
+                    out += String(format: "\\u%04x", scalar.value)
+                } else {
+                    out.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return out + "\""
+    }
+
+    /// Restore counterpart to `captureScript`. The anchor is passed as an
+    /// escaped string literal (never interpolated into code), and the index
+    /// path is walked as numbers, so no untrusted content ever enters the
+    /// evaluated program.
+    private static func restoreScript(anchor: String) -> String {
+        let literal = jsStringLiteral(anchor)
+        return """
+        (function(a){
+          var se=document.scrollingElement||document.documentElement;
+          if(!a||!se){return;}
+          if(a.charAt(0)==="f"){
+            var frac=parseFloat(a.slice(1))||0;
+            var h=se.scrollHeight-se.clientHeight;
+            window.scrollTo(0,frac*(h>0?h:0));
+            return;
+          }
+          if(a.charAt(0)!=="i"){return;}
+          var rest=a.slice(1);
+          var bar=rest.indexOf("|");
+          var idxPart=bar>=0?rest.slice(0,bar):rest;
+          var delta=bar>=0?(parseInt(rest.slice(bar+1),10)||0):0;
+          var idxs=idxPart.length?idxPart.split(".").map(Number):[];
+          var node=document.body;
+          for(var k=0;k<idxs.length;k++){
+            if(!node||!node.children||idxs[k]>=node.children.length){node=null;break;}
+            node=node.children[idxs[k]];
+          }
+          if(!node){return;}
+          node.scrollIntoView(true);
+          window.scrollBy(0,-delta);
+        })(\(literal));
+        """
     }
 
     /// Renders `html` into `webView`, putting the remote-content blocker into

--- a/apple/Cabalmail/Views/MessageDetailView+Scroll.swift
+++ b/apple/Cabalmail/Views/MessageDetailView+Scroll.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import CabalmailKit
+
+// In-message scroll capture and restore, split out of `MessageDetailView` to
+// keep that file under SwiftLint's file-length cap (matching the `+Toolbar` /
+// `+Compose` sibling pattern). The nav cursor carries an exact content offset
+// for plain-text bodies (`messageScroll`) and a reflow-robust DOM anchor for
+// HTML bodies (`messageAnchor`); the reader consumes whichever matches the body
+// it rendered, and streams the live position back as the user reads.
+extension MessageDetailView {
+    /// The body region: spinner, HTML/plain renderer, or error/empty state.
+    /// Lives here (not in the main struct) so `MessageDetailView` stays under
+    /// SwiftLint's type-body cap after the scroll wiring.
+    @ViewBuilder
+    func body(for model: MessageDetailViewModel) -> some View {
+        // Spinner wins over the error/retry screen whenever a load is in
+        // flight, and whenever the view hasn't completed an attempt yet. A
+        // fast-failing fetch used to paint the red banner before the user
+        // saw any indication of work — issue #403.
+        if model.isLoading || !model.hasAttemptedLoad {
+            ProgressView("Fetching message…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let html = model.htmlBody, !model.forcePlainText {
+            htmlBodyView(html: html, model: model)
+        } else if let plain = model.plainText {
+            plainBodyView(plain)
+        } else if let errorMessage = model.errorMessage {
+            VStack(spacing: 12) {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                Button {
+                    Task { await model.load() }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .disabled(model.isLoading)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            Text("No renderable body.")
+                .foregroundStyle(.secondary)
+                .padding()
+        }
+    }
+
+    /// HTML body. WKWebView manages its own scrolling; `restoreAnchor` reapplies
+    /// a resumed scroll position once the body loads, and `onScrollCaptured`
+    /// streams the live position back to the cursor.
+    @ViewBuilder
+    private func htmlBodyView(html: String, model: MessageDetailViewModel) -> some View {
+        HTMLBodyView(
+            html: html,
+            inlineImages: model.inlineImages,
+            allowRemote: model.remoteContentAllowed,
+            readerMode: model.readerMode,
+            printRequestTick: model.printRequestTick,
+            restoreAnchor: restoreScrollAnchor,
+            onScrollCaptured: { anchor in reportMessageScroll(offset: nil, anchor: anchor) }
+        )
+    }
+
+    /// Plain-text body. It doesn't reflow, so an exact content offset
+    /// round-trips: bind the scroll position for restore, capture reads back.
+    @ViewBuilder
+    private func plainBodyView(_ plain: String) -> some View {
+        ScrollView {
+            Text(plain)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .scrollPosition($plainScrollPosition)
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentOffset.y
+        } action: { _, offset in
+            reportPlainScroll(offset)
+        }
+        .onChange(of: restoreScrollOffset) { _, offset in
+            if let offset { plainScrollPosition.scrollTo(y: CGFloat(offset)) }
+        }
+        .onAppear {
+            if let offset = restoreScrollOffset {
+                plainScrollPosition.scrollTo(y: CGFloat(offset))
+            }
+        }
+    }
+
+    /// Pulls a pending scroll restore off the nav coordinator once the body is
+    /// available, matched to this exact message. Runs at most once per message
+    /// (`didConsumeScrollRestore`); a normal open finds nothing pending and
+    /// leaves the reader at the top.
+    func consumeScrollRestoreIfReady() {
+        guard !didConsumeScrollRestore, let model else { return }
+        guard model.htmlBody != nil || model.plainText != nil else { return }
+        didConsumeScrollRestore = true
+        guard let restore = appState.navCoordinator?.consumeScrollRestore(
+            folderPath: folder.path,
+            uid: envelope.uid,
+            messageID: envelope.messageId
+        ) else { return }
+        restoreScrollAnchor = restore.anchor
+        restoreScrollOffset = restore.offset
+    }
+
+    /// Relays the current in-message scroll position to the nav cursor. `offset`
+    /// is set for plain text, `anchor` for HTML; the coordinator debounces and
+    /// only writes on change, and ignores it unless the cursor is still on this
+    /// message.
+    func reportMessageScroll(offset: Int?, anchor: String?) {
+        appState.navCoordinator?.recordMessageScroll(
+            folderPath: folder.path,
+            uid: envelope.uid,
+            offset: offset,
+            anchor: anchor
+        )
+    }
+
+    /// Throttled plain-text scroll reporter: `onScrollGeometryChange` fires
+    /// densely during a drag, so skip sub-8pt deltas to avoid churning the save
+    /// debounce.
+    func reportPlainScroll(_ offsetY: CGFloat) {
+        let offset = max(0, Int(offsetY))
+        if abs(offset - lastReportedPlainOffset) < 8 { return }
+        lastReportedPlainOffset = offset
+        reportMessageScroll(offset: offset, anchor: nil)
+    }
+}

--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -42,6 +42,16 @@ struct MessageDetailView: View {
     #if os(iOS) || os(visionOS)
     @State var contactEditorRequest: ContactEditorRequest?
     #endif
+    // In-message scroll restore/capture. Consumed once from the nav cursor
+    // after the body loads: `restoreScrollAnchor` feeds the HTML web view,
+    // `restoreScrollOffset` positions the plain-text scroll view. The reader
+    // reports the live position back so it survives across launches/devices.
+    // Helpers live in `MessageDetailView+Scroll.swift`; see there.
+    @State var restoreScrollAnchor: String?
+    @State var restoreScrollOffset: Int?
+    @State var didConsumeScrollRestore = false
+    @State var plainScrollPosition = ScrollPosition(edge: .top)
+    @State var lastReportedPlainOffset = Int.min
 
     var body: some View {
         GeometryReader { proxy in
@@ -113,6 +123,11 @@ struct MessageDetailView: View {
         .onChange(of: appState.replyRequestTick) { _, _ in beginCompose(.reply) }
         .onChange(of: appState.replyAllRequestTick) { _, _ in beginCompose(.replyAll) }
         .onChange(of: appState.forwardRequestTick) { _, _ in beginCompose(.forward) }
+        // Once a body is available, consume a pending scroll restore from the
+        // nav cursor (a no-op on a normal open). Both branches guard against
+        // re-consuming, so whichever body type lands first wins.
+        .onChange(of: model?.htmlBody) { _, _ in consumeScrollRestoreIfReady() }
+        .onChange(of: model?.plainText) { _, _ in consumeScrollRestoreIfReady() }
         .onAppear {
             BodyFetchLog.appear(uid: envelope.uid, modelExists: model != nil)
             // Drive the body fetch from `.onAppear` rather than SwiftUI's
@@ -229,57 +244,6 @@ struct MessageDetailView: View {
                 }
                 Spacer(minLength: 0)
             }
-        }
-    }
-
-    @ViewBuilder
-    private func body(for model: MessageDetailViewModel) -> some View {
-        // Spinner wins over the error/retry screen whenever a load is in
-        // flight, and whenever the view hasn't completed an attempt yet. A
-        // fast-failing fetch used to paint the red banner before the user
-        // saw any indication of work — issue #403.
-        if model.isLoading || !model.hasAttemptedLoad {
-            ProgressView("Fetching message…")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let html = model.htmlBody, !model.forcePlainText {
-            // WKWebView manages its own scrolling; fill the available space
-            // and let it page through tall messages internally.
-            HTMLBodyView(
-                html: html,
-                inlineImages: model.inlineImages,
-                allowRemote: model.remoteContentAllowed,
-                readerMode: model.readerMode,
-                printRequestTick: model.printRequestTick
-            )
-        } else if let plain = model.plainText {
-            // `.primary` foreground adapts to light/dark mode and gives
-            // message text the same contrast as the surrounding chrome.
-            ScrollView {
-                Text(plain)
-                    .font(.body)
-                    .foregroundStyle(.primary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding()
-            }
-        } else if let errorMessage = model.errorMessage {
-            VStack(spacing: 12) {
-                Label(errorMessage, systemImage: "exclamationmark.triangle")
-                    .foregroundStyle(.red)
-                Button {
-                    Task { await model.load() }
-                } label: {
-                    Label("Retry", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.bordered)
-                .disabled(model.isLoading)
-            }
-            .padding()
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            Text("No renderable body.")
-                .foregroundStyle(.secondary)
-                .padding()
         }
     }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/NavState.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/NavState.swift
@@ -20,7 +20,14 @@ public struct NavState: Sendable, Equatable {
     public var uid: UInt32?
     public var uidValidity: UInt32?
     public var listScroll: Int?
+    /// In-message scroll for a plain-text body — an exact content offset (no
+    /// reflow, so a pixel value round-trips faithfully). HTML bodies use
+    /// `messageAnchor` instead, which survives WebKit's post-load reflow.
     public var messageScroll: Int?
+    /// In-message scroll for an HTML body: a compact structural anchor the
+    /// Apple client resolves with `scrollIntoView` (a child-index path to the
+    /// top-most visible element plus a small pixel delta). Opaque end to end.
+    public var messageAnchor: String?
     /// Identifies the install that wrote this cursor. Set by the client on
     /// save; echoed back on load. See `InstallIdentity`.
     public var clientID: String
@@ -36,6 +43,7 @@ public struct NavState: Sendable, Equatable {
         uidValidity: UInt32? = nil,
         listScroll: Int? = nil,
         messageScroll: Int? = nil,
+        messageAnchor: String? = nil,
         clientID: String,
         updatedAt: Int64? = nil
     ) {
@@ -45,6 +53,7 @@ public struct NavState: Sendable, Equatable {
         self.uidValidity = uidValidity
         self.listScroll = listScroll
         self.messageScroll = messageScroll
+        self.messageAnchor = messageAnchor
         self.clientID = clientID
         self.updatedAt = updatedAt
     }
@@ -58,6 +67,7 @@ extension NavState: Decodable {
         case uidValidity = "uid_validity"
         case listScroll = "list_scroll"
         case messageScroll = "msg_scroll"
+        case messageAnchor = "msg_anchor"
         case clientID = "client_id"
         case updatedAt = "updated_at"
     }
@@ -73,6 +83,7 @@ extension NavState: Decodable {
         self.uidValidity = try container.decodeIfPresent(UInt32.self, forKey: .uidValidity)
         self.listScroll = try container.decodeIfPresent(Int.self, forKey: .listScroll)
         self.messageScroll = try container.decodeIfPresent(Int.self, forKey: .messageScroll)
+        self.messageAnchor = try container.decodeIfPresent(String.self, forKey: .messageAnchor)
         // Older rows (or a hand-written one) might omit client_id; treat it as
         // "unknown origin" rather than failing the whole decode.
         self.clientID = try container.decodeIfPresent(String.self, forKey: .clientID) ?? ""
@@ -92,6 +103,7 @@ extension NavState {
         if let uidValidity { body["uid_validity"] = Int(uidValidity) }
         if let listScroll { body["list_scroll"] = listScroll }
         if let messageScroll { body["msg_scroll"] = messageScroll }
+        if let messageAnchor { body["msg_anchor"] = messageAnchor }
         return body
     }
 

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientNavStateTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientNavStateTests.swift
@@ -28,6 +28,7 @@ final class ApiClientNavStateTests: XCTestCase {
         let body = """
         {"folder":"Lists.Cabal","message_id":"<abc@x>","uid":4123,\
         "uid_validity":1690000000,"list_scroll":320,"msg_scroll":0,\
+        "msg_anchor":"i2.0.5|-12",\
         "client_id":"other-install","updated_at":1719600000000}
         """
         let http = RecordingHTTPTransport(responses: [(Data(body.utf8), 200)])
@@ -38,6 +39,7 @@ final class ApiClientNavStateTests: XCTestCase {
         XCTAssertEqual(cursor?.uidValidity, 1_690_000_000)
         XCTAssertEqual(cursor?.listScroll, 320)
         XCTAssertEqual(cursor?.messageScroll, 0)
+        XCTAssertEqual(cursor?.messageAnchor, "i2.0.5|-12")
         XCTAssertEqual(cursor?.clientID, "other-install")
         XCTAssertEqual(cursor?.updatedAt, 1_719_600_000_000)
 
@@ -64,6 +66,7 @@ final class ApiClientNavStateTests: XCTestCase {
             messageID: "<m@x>",
             uid: 99,
             listScroll: 12,
+            messageAnchor: "i3.1|40",
             clientID: "this-install",
             updatedAt: 1   // must be dropped from the body; server stamps it
         )
@@ -80,6 +83,7 @@ final class ApiClientNavStateTests: XCTestCase {
         XCTAssertEqual(payload?["message_id"] as? String, "<m@x>")
         XCTAssertEqual(payload?["uid"] as? Int, 99)
         XCTAssertEqual(payload?["list_scroll"] as? Int, 12)
+        XCTAssertEqual(payload?["msg_anchor"] as? String, "i3.1|40")
         XCTAssertEqual(payload?["client_id"] as? String, "this-install")
         // The client never sends recency; the server owns updated_at.
         XCTAssertNil(payload?["updated_at"])

--- a/changelog.d/apple-nav-state.added.md
+++ b/changelog.d/apple-nav-state.added.md
@@ -1,8 +1,8 @@
 - The Apple clients now remember where you were between launches — the folder
-  you were last in and the message you were reading. On relaunch they open to
-  your Inbox and, when that saved folder and message are still reachable, show
-  a banner offering to pick up where you left off; tap it to jump there. The
+  you were last in, the message you were reading, and roughly where you were
+  scrolled within it. On relaunch they open to your Inbox and, when that saved
+  folder and message are still reachable, show a banner offering to pick up
+  where you left off; tap it to jump back there, scroll position and all. The
   position syncs across your devices, so the same banner appears when another
   client has moved on. Everything degrades gracefully when a remembered folder
-  or message has since been deleted or moved (no banner). (Scroll position is
-  not yet remembered.)
+  or message has since been deleted or moved (no banner).

--- a/lambda/api/set_nav_state/function.py
+++ b/lambda/api/set_nav_state/function.py
@@ -23,6 +23,10 @@ table = ddb.Table(TABLE_NAME)
 MAX_FOLDER_LENGTH = 1024
 MAX_MESSAGE_ID_LENGTH = 998   # RFC 5322 line-length ceiling for a Message-ID
 MAX_CLIENT_ID_LENGTH = 64
+# In-message scroll anchor: a compact structural pointer the Apple client
+# builds for HTML bodies (a child-index path plus a small pixel delta, e.g.
+# "i2.0.5|-12"). Opaque to the server; the cap just stops an unbounded blob.
+MAX_ANCHOR_LENGTH = 512
 # Whole-number ceiling shared by uid/uid_validity/scroll offsets - large enough
 # for any real IMAP UID or pixel offset, small enough to reject garbage.
 MAX_NUMBER = 2 ** 53
@@ -96,6 +100,16 @@ def handler(event, _context):  # pylint: disable=too-many-return-statements
                 'body': json.dumps({'Error': 'Invalid value for message_id.'})
             }
         nav_state['message_id'] = message_id
+
+    # Optional string field: the in-message scroll anchor (HTML bodies).
+    if body.get('msg_anchor') is not None:
+        msg_anchor = _clean_str(body.get('msg_anchor'), MAX_ANCHOR_LENGTH)
+        if msg_anchor is None:
+            return {
+                'statusCode': 400,
+                'body': json.dumps({'Error': 'Invalid value for msg_anchor.'})
+            }
+        nav_state['msg_anchor'] = msg_anchor
 
     # Optional whole-number fields: IMAP coordinates and scroll offsets.
     for key in ('uid', 'uid_validity', 'list_scroll', 'msg_scroll'):


### PR DESCRIPTION
Adds the third nav-cursor priority — the scroll position *within* a message — restored on resume. Follows #568 (launch-resume toast), now merged to stage.

## Approach

- **HTML mail (WKWebView) — DOM anchor (your suggestion).** App-injected JS records a **child-index path to the top-most visible element + a pixel delta**, and restores with `scrollIntoView`. Robust to WebKit's post-load reflow in a way a fixed offset isn't. Page-content JS stays disabled; our helper runs via `evaluateJavaScript`, reads geometry only, and the anchor is passed as an **escaped string literal** (never interpolated into code) and walked as **numbers**, so untrusted content can't enter the evaluated program. Captured by a poll scoped to the web view's lifetime (off the SwiftUI render loop).
- **Plain-text mail — exact offset.** No reflow, so a content offset round-trips precisely via `onScrollGeometryChange` / `ScrollPosition` (iOS 18 / macOS 15).

## Storage

- `set_nav_state`: one new optional bounded string `msg_anchor` (mirrors `message_id`); `get_nav_state` returns the whole map, unchanged. Both scroll fields were previously unwritten, so no migration.
- `NavState`: `messageScroll` (plain) / `messageAnchor` (HTML). The coordinator clears scroll when the message changes, only attaches captures to the open message, and the reader consumes a pending scroll restore **once**, matched by folder + Message-ID (durable across moves) or UID.

## Best-effort limits (as flagged)

- Capture is polled ~2s, so a scroll in the last instant before a hard background may not persist.
- HTML restore resolves within the loaded window and can drift slightly on content that reflows well after load (largely mitigated here since remote content is blocked by default).
- Needs on-device confirmation that `evaluateJavaScript` runs with `allowsContentJavaScript = false` (it should); if it ever doesn't, capture/restore simply no-op — non-breaking.

Built iOS + macOS, 289 Kit tests pass (incl. updated `NavState` round-trip), SwiftLint `--strict` clean, pylint 10/10. Ships in the next TestFlight build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)