### PR TITLE
Move address list to a hidden-by-default right sidebar

### DIFF
--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -15,15 +15,6 @@ import UIKit
 /// changes. Without it, the same view instance is reused with a new folder
 /// or envelope prop and its one-shot `.task` never re-fires — which is the
 /// bug that made "select a second folder" do nothing on the split layout.
-/// Which list the sidebar is showing — toggled by a segmented control
-/// pinned above the list itself. Persisted across launches via
-/// `@AppStorage` so the user lands on the tab they last used.
-enum SidebarTab: String, CaseIterable, Identifiable {
-    case folders
-    case addresses
-    var id: String { rawValue }
-}
-
 struct MailRootView: View {
     @State private var selectedFolder: Folder?
     @State private var selectedEnvelope: Envelope?
@@ -67,7 +58,11 @@ struct MailRootView: View {
     #else
     @State private var columnVisibility: NavigationSplitViewVisibility = .doubleColumn
     #endif
-    @AppStorage("cabalmail.sidebar.tab") private var sidebarTabRaw: String = SidebarTab.folders.rawValue
+    /// Whether the right-hand addresses inspector is showing. Hidden by default
+    /// (on every launch) — it's an occasional reference/management panel reached
+    /// from the toolbar, so it doesn't persist open. Wide layouts only; compact
+    /// iPhone reaches addresses through its own bottom tab, never this inspector.
+    @State private var addressInspectorPresented = false
     /// Persisted width of the message-list (content) column in the wide
     /// (regular-width iPad / visionOS) three-column layout. `NavigationSplitView`
     /// doesn't report where a user drags the native list-reader divider, so the
@@ -119,24 +114,6 @@ struct MailRootView: View {
         return showsSettingsGear
         #endif
     }
-    /// Non-nil while a message drag temporarily overrides the visible sidebar
-    /// tab. When the user starts dragging a message while viewing Addresses,
-    /// this flips the sidebar to Folders so they have somewhere to drop;
-    /// clearing it on drag end falls the display back to the persisted tab
-    /// (Addresses), satisfying "release flips back to addresses." Kept
-    /// separate from `sidebarTabRaw` so the override never persists.
-    @State private var sidebarDragOverride: SidebarTab?
-
-    private var sidebarTab: SidebarTab {
-        SidebarTab(rawValue: sidebarTabRaw) ?? .folders
-    }
-
-    /// The tab the sidebar actually shows: the drag override if one is
-    /// active, otherwise the user's persisted choice.
-    private var effectiveSidebarTab: SidebarTab {
-        sidebarDragOverride ?? sidebarTab
-    }
-
     /// Folder that drives `MessageDetailView`. Cross-folder search results
     /// override the sidebar selection; everything else uses it directly.
     private var detailFolder: Folder? {
@@ -309,19 +286,6 @@ struct MailRootView: View {
         .onChange(of: compactColumn) { _, column in
             if column != .detail, selectedEnvelope != nil { selectedEnvelope = nil }
         }
-        // Reveal Folders as drop targets the moment a message drag starts on
-        // the Addresses tab, and fall back to the persisted tab when it ends.
-        // The drag flag is flipped by the row's `.onDrag` (start) and by the
-        // folder-row / catch-all drop handlers (end).
-        .onChange(of: appState.messageDragInProgress) { _, dragging in
-            if dragging {
-                if effectiveSidebarTab == .addresses {
-                    sidebarDragOverride = .folders
-                }
-            } else {
-                sidebarDragOverride = nil
-            }
-        }
         // Catch-all drop target behind the whole split view: a message
         // released anywhere that isn't a folder row (the message list, the
         // reading pane, sidebar chrome) ends the drag so the sidebar flips
@@ -372,6 +336,29 @@ struct MailRootView: View {
                 )
             }
         }
+        // Addresses live in a trailing panel rather than the left sidebar,
+        // keeping the sidebar free for folders (and, later, feeds). Hidden by
+        // default; the toolbar `at` button (wide layouts) toggles it. Selecting
+        // an address still filters the message list via `selectedAddress`.
+        // `.inspector` is the native trailing sidebar on iOS/macOS; visionOS
+        // lacks it, so the same toggle drives a sheet there instead.
+        #if os(visionOS)
+        .sheet(isPresented: $addressInspectorPresented) {
+            AddressListView(
+                selection: $selectedAddress,
+                externalFilter: $addressListFilter
+            )
+            .environment(appState)
+        }
+        #else
+        .inspector(isPresented: $addressInspectorPresented) {
+            AddressListView(
+                selection: $selectedAddress,
+                externalFilter: $addressListFilter
+            )
+            .inspectorColumnWidth(min: 260, ideal: 300, max: 420)
+        }
+        #endif
     }
 
     #if os(macOS)
@@ -484,49 +471,27 @@ extension MailRootView {
     private var sidebar: some View {
         VStack(spacing: 0) {
             searchField
-            Picker(
-                "Sidebar",
-                selection: Binding(
-                    get: { effectiveSidebarTab },
-                    set: { sidebarTabRaw = $0.rawValue }
-                )
-            ) {
-                Text("Folders").tag(SidebarTab.folders)
-                Text("Addresses").tag(SidebarTab.addresses)
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .padding(.horizontal)
-            .padding(.top, 8)
-            .padding(.bottom, 4)
 
-            // The wide layout's per-context filter — and the New / Reload buttons
-            // that flank it — render inside the active list view's own header
-            // (`SidebarListHeaderRow`), below these tabs. Compact lets each list
+            // Folders own the sidebar; addresses moved to the trailing inspector
+            // (see `.inspector` in `body`). The wide layout's per-context filter —
+            // and the New / Reload buttons that flank it — render inside the list
+            // view's own header (`SidebarListHeaderRow`). Compact lets the list
             // keep its own top-of-sidebar `.searchable` and toolbar buttons.
-            switch effectiveSidebarTab {
-            case .folders:
-                FolderListView(
-                    selection: $selectedFolder,
-                    externalFilter: isWideSidebar ? $folderListFilter : nil,
-                    onFoldersLoaded: { folders in
-                        // First load: land on INBOX and, if a saved position is
-                        // still reachable, offer a resume toast (see
-                        // `landOnInboxAndOfferResume`). The Compose button lives
-                        // on the message-list toolbar, so a nil-selection state
-                        // would leave the user no way to start a new message;
-                        // INBOX is always present
-                        // (`FolderListViewModel.sortForSidebar` pins it first).
-                        guard selectedFolder == nil else { return }
-                        landOnInboxAndOfferResume(from: folders)
-                    }
-                )
-            case .addresses:
-                AddressListView(
-                    selection: $selectedAddress,
-                    externalFilter: isWideSidebar ? $addressListFilter : nil
-                )
-            }
+            FolderListView(
+                selection: $selectedFolder,
+                externalFilter: isWideSidebar ? $folderListFilter : nil,
+                onFoldersLoaded: { folders in
+                    // First load: land on INBOX and, if a saved position is
+                    // still reachable, offer a resume toast (see
+                    // `landOnInboxAndOfferResume`). The Compose button lives
+                    // on the message-list toolbar, so a nil-selection state
+                    // would leave the user no way to start a new message;
+                    // INBOX is always present
+                    // (`FolderListViewModel.sortForSidebar` pins it first).
+                    guard selectedFolder == nil else { return }
+                    landOnInboxAndOfferResume(from: folders)
+                }
+            )
         }
     }
 
@@ -616,6 +581,21 @@ extension MailRootView {
     @ViewBuilder
     fileprivate var decoratedContentColumn: some View {
         contentColumn
+            // Toggle for the trailing addresses inspector. Wide layouts only
+            // (macOS always; regular-width iPad via `showsSettingsGear`); compact
+            // iPhone reaches addresses through its dedicated bottom tab instead.
+            .toolbar {
+                if isWideSidebar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            addressInspectorPresented.toggle()
+                        } label: {
+                            Image(systemName: "at")
+                                .accessibilityLabel("Addresses")
+                        }
+                    }
+                }
+            }
             // App-level Settings gear, relocated next to the content column's
             // sidebar toggle now that the sidebar — its former home — starts
             // collapsed on iPad. Regular-width iPad only (compact keeps its

--- a/changelog.d/addresses-right-sidebar.changed.md
+++ b/changelog.d/addresses-right-sidebar.changed.md
@@ -1,0 +1,5 @@
+- The address list moved out of the left sidebar into a right-hand sidebar
+  that is hidden by default, freeing the left sidebar for folders (and future
+  additions). Toggle it from the new panel button in the header (web) or the
+  `@` toolbar button (iPad / macOS); iPhone keeps its Addresses tab. Selecting
+  an address still filters the message list.

--- a/react/admin/src/Email/Email.css
+++ b/react/admin/src/Email/Email.css
@@ -2,7 +2,8 @@
    Email — Phase 8 responsive layout.
    Mobile-first: single pane, full-width msglist. The reader slides over the
    list on phones; on tablets the reader docks next to the list; on desktop
-   the left rail (Folders + Addresses) becomes in-flow.
+   the left rail (Folders) becomes in-flow. The Addresses rail is an optional
+   trailing column, hidden by default and toggled from the Nav.
    Breakpoints: 768px (tablet), 1200px (desktop).
    ========================================================================= */
 
@@ -75,51 +76,36 @@ div.email {
   to   { opacity: 1; }
 }
 
-/* Resizable split between Folders and Addresses ------------------------ */
+/* Right-hand addresses rail --------------------------------------------
+   Hidden by default, revealed from the Nav. In-flow trailing column on
+   desktop; a right-slide drawer (mirror of the folder drawer) on narrower
+   widths. */
 
-.email__rail-pane {
+.email__addr-rail {
   display: flex;
   flex-direction: column;
-  flex: 0 1 50%;
-  min-height: 0;
+  background: var(--bg);
+  color: var(--ink);
+  box-sizing: border-box;
   overflow: hidden;
+  z-index: 110;
 }
 
-.email__rail-splitter {
-  flex: 0 0 7px;
-  position: relative;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid transparent;
-  background: transparent;
-  cursor: row-resize;
-  outline: none;
-  touch-action: none;
+.email__addr-rail--drawer {
+  position: fixed;
+  top: 56px;
+  bottom: 0;
+  right: 0;
+  width: 82%;
+  max-width: 320px;
+  border-left: 1px solid var(--border);
+  box-shadow: 0 20px 40px oklch(0 0 0 / 0.25);
+  animation: email-addr-drawer-in 180ms ease-out;
 }
 
-.email__rail-splitter:hover,
-.email__rail-splitter:focus-visible {
-  border-top-color: var(--accent);
-  border-bottom-color: var(--accent);
-  background: color-mix(in oklch, var(--accent) 12%, transparent);
-}
-
-.email__rail-splitter-grip {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 24px;
-  height: 1px;
-  border-radius: 1px;
-  background: var(--ink-quiet);
-  opacity: 0;
-  transition: opacity 120ms ease;
-  pointer-events: none;
-}
-
-.email__rail-splitter:hover .email__rail-splitter-grip,
-.email__rail-splitter:focus-visible .email__rail-splitter-grip {
-  opacity: 1;
+@keyframes email-addr-drawer-in {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
 }
 
 /* Vertical splitter — between rail|middle and msglist|reader. Drag axis
@@ -223,6 +209,16 @@ div.reader {
   }
   .email__rail--drawer { display: none; }
   .email__scrim        { display: none; }
+
+  /* Addresses rail becomes an in-flow trailing column; basis is set inline
+     from the address col-splitter state (22% is the pre-hydration fallback). */
+  .email__addr-rail {
+    position: static;
+    flex: 0 0 22%;
+    box-shadow: none;
+    animation: none;
+  }
+  .email__addr-rail--drawer { display: none; }
 }
 
 /* Composer view is now a floating card rendered by Email/ComposeOverlay —

--- a/react/admin/src/Email/index.jsx
+++ b/react/admin/src/Email/index.jsx
@@ -17,18 +17,15 @@ const EMPTY_ENVELOPE = {
   subject: ""
 };
 
-function Splitter({ split, orientation, ariaLabel }) {
-  const className = orientation === 'horizontal'
-    ? 'email__rail-splitter'
-    : 'email__col-splitter';
-  const gripClassName = orientation === 'horizontal'
-    ? 'email__rail-splitter-grip'
-    : 'email__col-splitter-grip';
+// Vertical column splitter (drag axis horizontal). The remaining columns —
+// folders rail | middle | addresses rail — all resize this way; the former
+// horizontal folders/addresses splitter was retired when addresses moved out.
+function Splitter({ split, ariaLabel }) {
   return (
     <div
-      className={className}
+      className="email__col-splitter"
       role="separator"
-      aria-orientation={orientation}
+      aria-orientation="vertical"
       aria-valuemin={split.min}
       aria-valuemax={split.max}
       aria-valuenow={Math.round(split.pct)}
@@ -39,7 +36,7 @@ function Splitter({ split, orientation, ariaLabel }) {
       onDoubleClick={split.reset}
       title="Drag to resize (double-click to reset)"
     >
-      <span className={gripClassName} aria-hidden="true" />
+      <span className="email__col-splitter-grip" aria-hidden="true" />
     </div>
   );
 }
@@ -86,13 +83,15 @@ function Email({
   const isTabletUp = useMediaQuery('(min-width: 768px)');
   const layout = isDesktop ? 'desktop' : isTabletUp ? 'tablet' : 'phone';
 
-  const railSplit = useSplit({
-    storageKey: 'cabal-rail-split',
-    defaultPct: 50, min: 15, max: 85, axis: 'y',
-  });
   const colRailSplit = useSplit({
     storageKey: 'cabal-col-rail-split',
     defaultPct: 22, min: 15, max: 30, axis: 'x',
+  });
+  // Right-hand addresses sidebar width. `anchor: 'end'` so pct is the pane's
+  // own width, measured from the container's trailing edge.
+  const colAddrSplit = useSplit({
+    storageKey: 'cabal-col-addr-split',
+    defaultPct: 22, min: 16, max: 40, axis: 'x', anchor: 'end',
   });
   const colMiddleSplit = useSplit({
     storageKey: 'cabal-col-middle-split',
@@ -105,12 +104,25 @@ function Email({
   const [envelope, setEnvelope] = useState({});
   const [flags, setFlags] = useState([]);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  // Right-hand addresses sidebar. Hidden by default; toggled from the Nav.
+  // On desktop it's an in-flow trailing column, on phone/tablet a right drawer.
+  const [addressSidebarOpen, setAddressSidebarOpen] = useState(false);
   // §4e: multiple compose windows coexist. Each entry carries its own
   // composeState so windows don't share recipients / subject / body.
   const [composeWindows, setComposeWindows] = useState([]);
 
   const closeDrawer = useCallback(() => setDrawerOpen(false), []);
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
+  const closeAddressSidebar = useCallback(() => setAddressSidebarOpen(false), []);
+
+  // Both horizontal splitters (left rail, right addresses rail) size relative
+  // to the full `.email` width, so they share its container node.
+  const railContainerRef = colRailSplit.containerRef;
+  const addrContainerRef = colAddrSplit.containerRef;
+  const setEmailRef = useCallback((node) => {
+    railContainerRef.current = node;
+    addrContainerRef.current = node;
+  }, [railContainerRef, addrContainerRef]);
 
   // Close drawer when layout reaches desktop — rail becomes in-flow and the
   // drawer UI would otherwise stay stuck open underneath.
@@ -125,6 +137,14 @@ function Email({
     const toggle = () => setDrawerOpen((v) => !v);
     window.addEventListener('cabal:toggle-nav-drawer', toggle);
     return () => window.removeEventListener('cabal:toggle-nav-drawer', toggle);
+  }, []);
+
+  // The Nav's right-panel button toggles the addresses sidebar via the same
+  // window-event pattern, so its state doesn't have to live in App.
+  useEffect(() => {
+    const toggle = () => setAddressSidebarOpen((v) => !v);
+    window.addEventListener('cabal:toggle-address-sidebar', toggle);
+    return () => window.removeEventListener('cabal:toggle-address-sidebar', toggle);
   }, []);
 
   const selectFolder = useCallback((f) => {
@@ -239,47 +259,24 @@ function Email({
       className="email"
       data-layout={layout}
       data-middle={middleMode}
-      ref={colRailSplit.containerRef}
+      ref={setEmailRef}
     >
       {layout === 'desktop' ? (
         <>
           <aside
             className="email__rail"
-            aria-label="Folders and addresses"
-            ref={railSplit.containerRef}
+            aria-label="Folders"
             style={{ flexBasis: `${colRailSplit.pct}%` }}
           >
-            <div
-              className="email__rail-pane"
-              style={{ flexBasis: `${railSplit.pct}%` }}
-            >
-              <Folders
-                folder={folder}
-                setFolder={selectFolder}
-                setMessage={setMessage}
-                onNewMessage={newEmail}
-              />
-            </div>
-            <Splitter
-              split={railSplit}
-              orientation="horizontal"
-              ariaLabel="Resize folder list"
+            <Folders
+              folder={folder}
+              setFolder={selectFolder}
+              setMessage={setMessage}
+              onNewMessage={newEmail}
             />
-            <div
-              className="email__rail-pane"
-              style={{ flexBasis: `${100 - railSplit.pct}%` }}
-            >
-              <AddressesRail
-                domains={domains}
-                setMessage={setMessage}
-                selectedAddress={addressFilter}
-                onSelectAddress={selectAddress}
-              />
-            </div>
           </aside>
           <Splitter
             split={colRailSplit}
-            orientation="vertical"
             ariaLabel="Resize folders sidebar"
           />
         </>
@@ -293,38 +290,16 @@ function Email({
             />
             <aside
               className="email__rail email__rail--drawer"
-              aria-label="Folders and addresses"
-              ref={railSplit.containerRef}
+              aria-label="Folders"
             >
-              <div
-                className="email__rail-pane"
-                style={{ flexBasis: `${railSplit.pct}%` }}
-              >
-                <Folders
-                  folder={folder}
-                  setFolder={selectFolder}
-                  setMessage={setMessage}
-                  onNewMessage={() => { setDrawerOpen(false); newEmail(); }}
-                  asDrawer
-                  onClose={closeDrawer}
-                />
-              </div>
-              <Splitter
-                split={railSplit}
-                orientation="horizontal"
-                ariaLabel="Resize folder list"
+              <Folders
+                folder={folder}
+                setFolder={selectFolder}
+                setMessage={setMessage}
+                onNewMessage={() => { setDrawerOpen(false); newEmail(); }}
+                asDrawer
+                onClose={closeDrawer}
               />
-              <div
-                className="email__rail-pane"
-                style={{ flexBasis: `${100 - railSplit.pct}%` }}
-              >
-                <AddressesRail
-                  domains={domains}
-                  setMessage={setMessage}
-                  selectedAddress={addressFilter}
-                  onSelectAddress={(a) => { setAddressFilter(a); setDrawerOpen(false); }}
-                />
-              </div>
             </aside>
           </>
         )
@@ -378,7 +353,6 @@ function Email({
         {layout !== 'phone' && (
           <Splitter
             split={colMiddleSplit}
-            orientation="vertical"
             ariaLabel="Resize message list"
           />
         )}
@@ -401,6 +375,49 @@ function Email({
           layout={layout}
         />
       </div>
+
+      {addressSidebarOpen && (
+        layout === 'desktop' ? (
+          <>
+            <Splitter
+              split={colAddrSplit}
+              ariaLabel="Resize addresses sidebar"
+            />
+            <aside
+              className="email__addr-rail"
+              aria-label="Addresses"
+              style={{ flexBasis: `${colAddrSplit.pct}%` }}
+            >
+              <AddressesRail
+                domains={domains}
+                setMessage={setMessage}
+                selectedAddress={addressFilter}
+                onSelectAddress={selectAddress}
+              />
+            </aside>
+          </>
+        ) : (
+          <>
+            <div
+              className="email__scrim"
+              role="presentation"
+              onClick={closeAddressSidebar}
+            />
+            <aside
+              className="email__addr-rail email__addr-rail--drawer"
+              aria-label="Addresses"
+            >
+              <AddressesRail
+                domains={domains}
+                setMessage={setMessage}
+                selectedAddress={addressFilter}
+                onSelectAddress={(a) => { selectAddress(a); closeAddressSidebar(); }}
+              />
+            </aside>
+          </>
+        )
+      )}
+
       {composeWindows.length > 0 && (
         <div className="compose-stack" aria-label="Compose windows">
           {composeWindows.map((w, i) => (

--- a/react/admin/src/Email/useSplit.js
+++ b/react/admin/src/Email/useSplit.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-export default function useSplit({ storageKey, defaultPct, min, max, axis }) {
+export default function useSplit({ storageKey, defaultPct, min, max, axis, anchor = 'start' }) {
   const [pct, setPct] = useState(() => {
     try {
       const raw = localStorage.getItem(storageKey);
@@ -28,10 +28,13 @@ export default function useSplit({ storageKey, defaultPct, min, max, axis }) {
     const rect = containerRef.current.getBoundingClientRect();
     const total = axis === 'y' ? rect.height : rect.width;
     if (total <= 0) return;
-    const offset = axis === 'y' ? e.clientY - rect.top : e.clientX - rect.left;
+    const pos = axis === 'y' ? e.clientY - rect.top : e.clientX - rect.left;
+    // `anchor: 'end'` panels (e.g. a right sidebar) measure their size from
+    // the container's trailing edge, so pct tracks the pane's own width.
+    const offset = anchor === 'end' ? total - pos : pos;
     const next = (offset / total) * 100;
     setPct(Math.min(max, Math.max(min, next)));
-  }, [axis, min, max]);
+  }, [axis, min, max, anchor]);
 
   const stop = useCallback(() => {
     if (!dragging.current) return;
@@ -57,8 +60,12 @@ export default function useSplit({ storageKey, defaultPct, min, max, axis }) {
   const reset = useCallback(() => setPct(defaultPct), [defaultPct]);
 
   const onKeyDown = useCallback((e) => {
-    const decKey = axis === 'y' ? 'ArrowUp' : 'ArrowLeft';
-    const incKey = axis === 'y' ? 'ArrowDown' : 'ArrowRight';
+    // For an `end`-anchored horizontal pane, ArrowLeft grows it (the divider
+    // moves left, the pane widens), so the inc/dec keys are swapped.
+    const horizDec = anchor === 'end' ? 'ArrowRight' : 'ArrowLeft';
+    const horizInc = anchor === 'end' ? 'ArrowLeft' : 'ArrowRight';
+    const decKey = axis === 'y' ? 'ArrowUp' : horizDec;
+    const incKey = axis === 'y' ? 'ArrowDown' : horizInc;
     if (e.key === decKey) {
       e.preventDefault();
       setPct((p) => Math.max(min, p - 2));
@@ -75,7 +82,7 @@ export default function useSplit({ storageKey, defaultPct, min, max, axis }) {
       e.preventDefault();
       reset();
     }
-  }, [axis, min, max, reset]);
+  }, [axis, min, max, reset, anchor]);
 
   return { pct, containerRef, onPointerDown, onKeyDown, reset, min, max };
 }

--- a/react/admin/src/Nav/Nav.css
+++ b/react/admin/src/Nav/Nav.css
@@ -64,6 +64,28 @@
   .nav__sidebar-toggle { display: none; }
 }
 
+/* Addresses sidebar toggle (right cluster, email view only) -------------- */
+
+.nav__address-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+
+.nav__address-toggle:hover {
+  background: var(--surface-hover);
+  color: var(--ink);
+}
+
 /* Brand ---------------------------------------------------------------- */
 
 .nav__brand {

--- a/react/admin/src/Nav/index.jsx
+++ b/react/admin/src/Nav/index.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Search, Check, PanelLeft, ExternalLink } from 'lucide-react';
+import { Search, Check, PanelLeft, PanelRight, ExternalLink } from 'lucide-react';
 import logoMarkup from '../assets/logo.svg?raw';
 import './Nav.css';
 
@@ -106,6 +106,13 @@ function Nav({
     window.dispatchEvent(new CustomEvent('cabal:toggle-nav-drawer'));
   }, []);
 
+  const toggleAddresses = useCallback(() => {
+    // Email listens for this and toggles the right-hand addresses sidebar
+    // (in-flow on desktop, a drawer on narrower widths). Same window-event
+    // pattern as the folder drawer above.
+    window.dispatchEvent(new CustomEvent('cabal:toggle-address-sidebar'));
+  }, []);
+
   return (
     <header
       className={`nav logged-${loggedIn ? 'in' : 'out'}${isAdmin ? ' is-admin' : ''}`}
@@ -148,6 +155,17 @@ function Nav({
       )}
 
       <div className="nav__right">
+        {loggedIn && view === 'Email' && (
+          <button
+            type="button"
+            className="nav__address-toggle"
+            aria-label="Toggle addresses sidebar"
+            title="Addresses"
+            onClick={toggleAddresses}
+          >
+            <PanelRight size={18} aria-hidden="true" />
+          </button>
+        )}
         {loggedIn ? (
           <div className="nav__menu-wrap" ref={menuRef}>
             <button


### PR DESCRIPTION
## What

Moves the address list out of the **left** sidebar into a **right-hand sidebar that is hidden by default**, across both clients. Motivation: the left sidebar is getting crowded ahead of future RSS/feed support, so this frees it up. Selecting an address still filters the message list.

Per the two design calls made up front: **iPhone keeps its existing Addresses tab** (no split view there to add a column to), and the reveal is a **toolbar/header button** (no keyboard shortcut).

## React (`react/admin`)
- Left rail is now **folders-only** — the folders/addresses vertical split and its horizontal splitter are removed.
- `AddressesRail` moves to a new trailing sidebar: an in-flow resizable column on desktop, a right-slide drawer on phone/tablet.
- New `PanelRight` button in the header (Email view) toggles it via a `cabal:toggle-address-sidebar` window event, mirroring the existing folder-drawer pattern.
- `useSplit` gains an `anchor: 'end'` option so the right rail resizes from its own trailing edge; both horizontal splits share the `.email` container node.

## Apple (`apple/`)
- `MailRootView`: removed the Folders/Addresses **segmented picker** and the now-obsolete drag-to-flip-to-folders override. Sidebar is folders-only.
- Addresses render in a trailing **`.inspector`** on iOS/macOS — hidden by default, toggled by an `@` toolbar button on wide layouts (iPad-regular / macOS).
- **visionOS lacks `.inspector`**, so the same toggle drives a **sheet** there instead.
- **iPhone (compact)** keeps its dedicated Addresses **tab** unchanged.

## Verification
- React: `npm run build` passes. (Test suite has pre-existing, unrelated jsdom `localStorage` failures on this box — identical counts on a clean tree.)
- Apple: `scripts/build-apple.sh all` — strict swiftlint + **iOS + macOS + visionOS** builds all pass.

Targets `stage` per the branch workflow (user-facing UI change → stage first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)