### PR TITLE
Add "Revoke" to the header address menu (Apple clients)

### DIFF
--- a/apple/Cabalmail/AppStateSignals.swift
+++ b/apple/Cabalmail/AppStateSignals.swift
@@ -39,6 +39,13 @@ struct Toast: Equatable, Sendable {
     static func addressCopied(_ address: String) -> Toast {
         Toast(kind: .success, message: "Address \(address) successfully copied")
     }
+
+    /// Confirmation shown after an address is revoked (e.g. from the message
+    /// header's per-address menu). Mirrors the wording of the address list's
+    /// revoke dialog: mail to it will now be rejected.
+    static func addressRevoked(_ address: String) -> Toast {
+        Toast(kind: .success, message: "Revoked \(address)")
+    }
 }
 
 /// Signal payload for a successful dispose action. Carries the folder path

--- a/apple/Cabalmail/Views/MessageDetailView+AddressMenu.swift
+++ b/apple/Cabalmail/Views/MessageDetailView+AddressMenu.swift
@@ -76,9 +76,17 @@ extension MessageDetailView {
         }
         if let owned = ownedMatch(for: address) {
             Button {
-                composeFrom(owned)
+                composeFrom(owned.address)
             } label: {
                 Label("Compose Message From", systemImage: "paperplane")
+            }
+            // Revoke is offered only for addresses we manage — the same gate as
+            // "Compose Message From" — since those are the only ones the
+            // `/revoke` API will accept.
+            Button(role: .destructive) {
+                pendingRevoke = owned
+            } label: {
+                Label("Revoke", systemImage: "xmark.bin")
             }
         }
 
@@ -108,7 +116,7 @@ extension MessageDetailView {
     func loadAddressMenuContext() async {
         contactsAuth = await appState.contactsStore.authorizationStatus
         if let client = appState.client, let list = try? await client.addresses() {
-            ownedAddresses = Set(list.map(\.address))
+            ownedAddresses = list
         }
     }
 
@@ -116,11 +124,12 @@ extension MessageDetailView {
         "\(address.mailbox)@\(address.host)"
     }
 
-    /// The user's own address string matching this header address
-    /// (case-insensitive), or nil when it isn't one they own.
-    private func ownedMatch(for address: EmailAddress) -> String? {
+    /// The user's own address matching this header address (case-insensitive),
+    /// or nil when it isn't one they own. Returns the full `Address` so callers
+    /// can both compose from it and revoke it.
+    private func ownedMatch(for address: EmailAddress) -> Address? {
         let target = canonicalEmail(for: address).lowercased()
-        return ownedAddresses.first { $0.lowercased() == target }
+        return ownedAddresses.first { $0.address.lowercased() == target }
     }
 
     private func copyName(for address: EmailAddress) {
@@ -150,6 +159,32 @@ extension MessageDetailView {
         presentCompose(seed: Draft(fromAddress: ownedAddress, composeIntent: .new))
     }
 
+    // MARK: - Revoke confirmation
+
+    /// Non-async entry point handed to `RevokeAddressConfirmation` (the dialog
+    /// runs its Button actions synchronously). Kicks the API call onto a Task.
+    func revoke(_ address: Address) {
+        Task { await revokeAddress(address) }
+    }
+
+    private func revokeAddress(_ address: Address) async {
+        guard let client = appState.client else { return }
+        do {
+            try await client.revokeAddress(
+                address: address.address,
+                subdomain: address.subdomain,
+                tld: address.tld,
+                publicKey: address.publicKey
+            )
+            // Drop it from the owned set so the menu's "Compose From" / "Revoke"
+            // items disappear on the next open without a full re-fetch.
+            ownedAddresses.removeAll { $0.address == address.address }
+            appState.showToast(.addressRevoked(address.address))
+        } catch {
+            appState.showToast(Toast(kind: .error, message: "Couldn't revoke \(address.address)"))
+        }
+    }
+
     #if os(iOS) || os(visionOS)
     private func requestContactEditor(_ mode: ContactEditorMode, for address: EmailAddress) {
         let email = canonicalEmail(for: address)
@@ -169,4 +204,34 @@ extension MessageDetailView {
         }
     }
     #endif
+}
+
+/// The header menu's "Revoke" confirmation dialog, extracted as a modifier so
+/// its title / actions / message live outside `MessageDetailView` and don't
+/// count against its SwiftLint type_body_length budget. Applied as a single
+/// `.modifier(...)` line in `body`. Mirrors the wording of the address list's
+/// own revoke dialog (`AddressListView`).
+struct RevokeAddressConfirmation: ViewModifier {
+    @Binding var pending: Address?
+    let perform: (Address) -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            pending.map { "Revoke \($0.address)?" } ?? "Revoke address?",
+            isPresented: Binding(
+                get: { pending != nil },
+                set: { if !$0 { pending = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pending
+        ) { address in
+            Button("Revoke", role: .destructive) {
+                pending = nil
+                perform(address)
+            }
+            Button("Cancel", role: .cancel) { pending = nil }
+        } message: { address in
+            Text("Mail sent to \(address.address) will be rejected. This can't be undone.")
+        }
+    }
 }

--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -38,7 +38,13 @@ struct MessageDetailView: View {
     // read by the `+AddressMenu` extension to gate the Contacts and "Compose
     // From" items.
     @State var contactsAuth: ContactsAuthorizationStatus = .notDetermined
-    @State var ownedAddresses: Set<String> = []
+    // The user's own addresses, kept as full `Address` values (not just the
+    // string) so the menu's "Revoke" item has the subdomain / tld / public key
+    // the `/revoke` API needs.
+    @State var ownedAddresses: [Address] = []
+    // Address staged for revocation by the header menu's "Revoke" item,
+    // confirmed before the (irreversible) API call.
+    @State var pendingRevoke: Address?
     #if os(iOS) || os(visionOS)
     @State var contactEditorRequest: ContactEditorRequest?
     #endif
@@ -110,6 +116,7 @@ struct MessageDetailView: View {
         } message: {
             Text("This message will be permanently deleted. This can't be undone.")
         }
+        .modifier(RevokeAddressConfirmation(pending: $pendingRevoke, perform: revoke))
         .onChange(of: appState.replyRequestTick) { _, _ in beginCompose(.reply) }
         .onChange(of: appState.replyAllRequestTick) { _, _ in beginCompose(.replyAll) }
         .onChange(of: appState.forwardRequestTick) { _, _ in beginCompose(.forward) }

--- a/changelog.d/apple-header-address-revoke.added.md
+++ b/changelog.d/apple-header-address-revoke.added.md
@@ -1,0 +1,3 @@
+- The Apple clients' per-address menu in the message header now offers a
+  "Revoke" action for addresses you manage — the same gate as "Compose
+  Message From" — with a confirmation dialog before the irreversible call.


### PR DESCRIPTION
Right-click / long-press on an address in a message header now offers a **Revoke** action, available only for addresses the user manages (and can therefore revoke). The gate is exactly the same predicate as the existing **Compose Message From** item — an owned-address match against `client.addresses()`.

## What changed

- **`MessageDetailView+AddressMenu.swift`** — adds the `Revoke` button inside the existing `if let owned = ownedMatch(...)` branch; `ownedMatch` now returns the full `Address` (not just the string) so the revoke call has the `subdomain` / `tld` / `public_key` the `/revoke` API needs. Revocation routes through the existing `CabalmailClient.revokeAddress(...)`, drops the address from the in-memory owned set, and toasts on success / failure. The confirmation dialog is a `RevokeAddressConfirmation` `ViewModifier` (keeps `MessageDetailView` under SwiftLint's `type_body_length` cap) and mirrors the wording of the address list's own revoke dialog.
- **`MessageDetailView.swift`** — `ownedAddresses` is now `[Address]`; adds `pendingRevoke` state and applies the dialog modifier.
- **`AppStateSignals.swift`** — `addressRevoked(_:)` success toast.

Data-plane parity: same authorization model as the Addresses view's revoke — the Lambda re-validates the caller owns the address regardless.

## Verification

- `swiftlint` clean on all changed files.
- `xcodebuild ... -destination 'generic/platform=iOS' build` succeeds (before and after merging `origin/stage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)