### PR TITLE
Remove "Mailboxes" title from Apple folder list

### DIFF
--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -127,7 +127,7 @@ struct FolderListView: View {
                 }
             }
         }
-        .navigationTitle("Mailboxes")
+        .navigationTitle("")
         .sidebarFilterSearchable(text: $filterQuery, enabled: externalFilter == nil, prompt: "Filter folders")
         .toolbar {
             // Compact keeps New / Reload in the toolbar; the wide sidebar moves

--- a/changelog.d/folder-list-mailboxes-title.changed.md
+++ b/changelog.d/folder-list-mailboxes-title.changed.md
@@ -1,0 +1,2 @@
+- Removed the "Mailboxes" title from the top of the folder list in the
+  Apple clients.


### PR DESCRIPTION
Removes the "Mailboxes" navigation title from the top of the folder list in the Apple clients (iOS/macOS shared `FolderListView`). The toolbar (New / Reload) and all navigation behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)