### PR TITLE
Sidebar branding: swatch wash, Cabalmail mark, forest accent (Apple clients)

### DIFF
--- a/apple/Cabalmail/Assets.xcassets/CabalmailMark.imageset/Contents.json
+++ b/apple/Cabalmail/Assets.xcassets/CabalmailMark.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "cabalmail-mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/apple/Cabalmail/Assets.xcassets/CabalmailMark.imageset/cabalmail-mark.svg
+++ b/apple/Cabalmail/Assets.xcassets/CabalmailMark.imageset/cabalmail-mark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <g fill="#2E5235" transform="translate(122 147) scale(2.036)">
+    
+    <path fill-rule="evenodd" d="&#xA;      M 0 180&#xA;      a 96 96 0 1 0 192 0&#xA;      a 96 96 0 1 0 -192 0&#xA;      Z&#xA;      M 38 180&#xA;      L 108 110&#xA;      L 108 146&#xA;      L 154 146&#xA;      L 154 214&#xA;      L 108 214&#xA;      L 108 250&#xA;      Z&#xA;    "></path>
+    
+    <path d="M 154 84 L 268 176 L 400 84 L 400 275 L 154 275 Z"></path>
+  </g>
+</svg>

--- a/apple/Cabalmail/Assets.xcassets/LogoTint.colorset/Contents.json
+++ b/apple/Cabalmail/Assets.xcassets/LogoTint.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3A",
-          "green" : "0x63",
-          "red" : "0x2B"
+          "blue" : "0x35",
+          "green" : "0x52",
+          "red" : "0x2E"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x89",
-          "green" : "0xC2",
-          "red" : "0x79"
+          "blue" : "0x99",
+          "green" : "0xC8",
+          "red" : "0x8D"
         }
       },
       "idiom" : "universal"

--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -29,7 +29,7 @@ struct FolderListView: View {
     var activeFilterText: String { externalFilter?.wrappedValue ?? filterQuery }
     /// Called exactly once, the first time the folder list successfully
     /// loads. `MailRootView` uses it to seed a default `selection` so the
-    /// signed-in user doesn't land on an empty "pick a mailbox" screen
+    /// signed-in user doesn't land on an empty "select a folder" screen
     /// (which would also hide the compose entry point on the message list).
     var onFoldersLoaded: ([Folder]) -> Void = { _ in }
 
@@ -127,7 +127,12 @@ struct FolderListView: View {
                 }
             }
         }
-        .navigationTitle("")
+        // "Folders" (not "Mailboxes" — the mailbox is the per-user singleton;
+        // this list is its folders). In the Mail sidebar the visible text is
+        // suppressed and the Cabalmail mark stands in (see `MailRootView`);
+        // the string stays for VoiceOver and the back button. The compact
+        // Folders management tab shows it as a regular title.
+        .navigationTitle("Folders")
         .sidebarFilterSearchable(text: $filterQuery, enabled: externalFilter == nil, prompt: "Filter folders")
         .toolbar {
             // Compact keeps New / Reload in the toolbar; the wide sidebar moves
@@ -170,7 +175,7 @@ struct FolderListView: View {
         )
         // Sign-out used to live here; Phase 6's Settings tab is the
         // canonical place for it now. Leaving a duplicate confused the UI —
-        // the Mailboxes toolbar is about mailbox navigation, not account
+        // the folder-list toolbar is about folder navigation, not account
         // state.
         .task {
             if model == nil, let client = appState.client {

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -173,7 +173,7 @@ struct MailRootView: View {
             ContentUnavailableView(
                 "Select a folder",
                 systemImage: "sidebar.left",
-                description: Text("Pick a mailbox from the sidebar to browse messages.")
+                description: Text("Pick a folder from the sidebar to browse messages.")
             )
         }
     }
@@ -470,6 +470,19 @@ extension MailRootView {
     @ViewBuilder
     private var sidebar: some View {
         VStack(spacing: 0) {
+            #if os(macOS)
+            // Brand mark at the top of the sidebar, below the traffic-light /
+            // toolbar row and above the search field. macOS never displaced a
+            // title here (the sidebar column never showed one); the mark is
+            // purely additive. iOS/iPadOS host theirs in the toolbar below.
+            HStack {
+                CabalmailMark(size: 30)
+                Spacer()
+            }
+            .padding(.leading, 16)
+            .padding(.top, 12)
+            #endif
+
             searchField
 
             // Folders own the sidebar; addresses moved to the trailing inspector
@@ -493,6 +506,43 @@ extension MailRootView {
                 }
             )
         }
+        // Sidebar branding (see `SidebarBranding.swift`): the wash paints this
+        // column only — the entire folder screen on compact iPhone, where
+        // this column IS the screen; the floating sidebar on iPad; the sidebar
+        // material on macOS. Hiding the list's scroll background (inherited by
+        // the folder `List` below) lets the wash show through the native
+        // material instead of being painted over by the system background.
+        .scrollContentBackground(.hidden)
+        .background { SidebarWash().ignoresSafeArea() }
+        #if !os(macOS)
+        // The Cabalmail mark stands in for the sidebar's "Folders" title:
+        // inline display mode suppresses the large title, the clear principal
+        // item suppresses the inline text, and `FolderListView`'s
+        // `.navigationTitle("Folders")` string stays for VoiceOver and the
+        // back button. The mark itself rides the leading toolbar slot — the
+        // system sidebar toggle and the compact New / Reload buttons keep
+        // their own slots.
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Color.clear.frame(width: 1, height: 1)
+            }
+            // On OS 26's liquid glass, a bare toolbar item gets wrapped in a
+            // glass capsule, which makes the decorative mark read as a button.
+            // Detach it from the shared glass background where the API exists;
+            // earlier systems render toolbar images plain anyway.
+            if #available(iOS 26.0, visionOS 26.0, *) {
+                ToolbarItem(placement: .topBarLeading) {
+                    CabalmailMark(size: isWideSidebar ? 34 : 44)
+                }
+                .sharedBackgroundVisibility(.hidden)
+            } else {
+                ToolbarItem(placement: .topBarLeading) {
+                    CabalmailMark(size: isWideSidebar ? 34 : 44)
+                }
+            }
+        }
+        #endif
     }
 
 }

--- a/apple/Cabalmail/Views/SidebarBranding.swift
+++ b/apple/Cabalmail/Views/SidebarBranding.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+// Sidebar branding: the swatch color wash and the Cabalmail mark.
+//
+// Both come from the sidebar-branding design handoff. The wash and the
+// mark are decorative only — fixed values, no state, no interactions —
+// and sit behind / above the native sidebar chrome without replacing
+// any system control.
+
+// MARK: - Color wash
+
+/// The four admin-app address swatches as soft radial blobs behind the
+/// sidebar material, at a fixed 20% opacity. Scope differs per platform
+/// (`MailRootView` applies it): the whole folder screen on iPhone,
+/// the sidebar column only on iPad and macOS. The native list above it
+/// hides its scroll background (`.scrollContentBackground(.hidden)`) so
+/// the wash reads as color seen through the system material.
+struct SidebarWash: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// One swatch from `react/admin/src/utils/addressSwatch.js`, as the
+    /// sRGB approximations pinned in the design handoff.
+    private struct Swatch {
+        let light: Color
+        let dark: Color
+
+        init(light: UInt32, dark: UInt32) {
+            self.light = Color(rgb: light)
+            self.dark = Color(rgb: dark)
+        }
+    }
+
+    /// One wash blob: a swatch plus its center and extent as fractions of
+    /// the wash container.
+    private struct Blob {
+        let swatch: Swatch
+        let center: UnitPoint
+        let extent: CGSize
+    }
+
+    // Blob geometry from the handoff: each gradient fades to transparent
+    // at 70% of its radius. Extents overshoot the container on purpose
+    // (the blobs bleed past the edges), so the body clips to bounds.
+    private static let blobs: [Blob] = [
+        Blob(
+            swatch: Swatch(light: 0x286CAB, dark: 0x79BDFF), // azure
+            center: UnitPoint(x: 0.12, y: 0.04),
+            extent: CGSize(width: 0.90, height: 0.55)
+        ),
+        Blob(
+            swatch: Swatch(light: 0xA16100, dark: 0xFAB45F), // amber
+            center: UnitPoint(x: 0.92, y: 0.22),
+            extent: CGSize(width: 0.75, height: 0.45)
+        ),
+        Blob(
+            swatch: Swatch(light: 0x2B633A, dark: 0x79C289), // forest
+            center: UnitPoint(x: 0.10, y: 0.62),
+            extent: CGSize(width: 0.85, height: 0.50)
+        ),
+        Blob(
+            swatch: Swatch(light: 0x793974, dark: 0xE39BDC), // plum
+            center: UnitPoint(x: 0.88, y: 0.98),
+            extent: CGSize(width: 0.90, height: 0.55)
+        ),
+    ]
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack {
+                ForEach(Self.blobs.indices, id: \.self) { index in
+                    gradient(for: Self.blobs[index], in: geo.size)
+                }
+            }
+        }
+        .opacity(0.20)
+        .clipped()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private func gradient(for blob: Blob, in size: CGSize) -> some View {
+        let color = colorScheme == .dark ? blob.swatch.dark : blob.swatch.light
+        return EllipticalGradient(
+            stops: [
+                .init(color: color, location: 0),
+                .init(color: color.opacity(0), location: 0.7),
+            ],
+            center: .center,
+            startRadiusFraction: 0,
+            endRadiusFraction: 0.5
+        )
+        // The gradient ellipse matches its frame's aspect, so a frame of
+        // twice the extent centered on the blob's anchor reproduces the
+        // handoff's `radial-gradient(w h at x y)` geometry exactly.
+        .frame(
+            width: blob.extent.width * 2 * size.width,
+            height: blob.extent.height * 2 * size.height
+        )
+        .position(
+            x: blob.center.x * size.width,
+            y: blob.center.y * size.height
+        )
+    }
+}
+
+private extension Color {
+    /// sRGB color from a 24-bit `0xRRGGBB` literal.
+    init(rgb: UInt32) {
+        self.init(
+            .sRGB,
+            red: Double((rgb >> 16) & 0xFF) / 255,
+            green: Double((rgb >> 8) & 0xFF) / 255,
+            blue: Double(rgb & 0xFF) / 255
+        )
+    }
+}
+
+// MARK: - Cabalmail mark
+
+/// The Cabalmail mark (mark only, never the wordmark), tinted per theme
+/// via the `LogoTint` colorset. The size is the mark's square bounding
+/// box (the handoff's 44 pt iPhone / 34 pt iPad / 30 pt macOS values);
+/// the ink itself carries the asset's built-in padding. Decorative — it
+/// stands in for the sidebar's "Folders" title, so it carries that
+/// accessibility label rather than being hidden.
+struct CabalmailMark: View {
+    let size: CGFloat
+
+    var body: some View {
+        Image("CabalmailMark")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .foregroundStyle(Color("LogoTint"))
+            .accessibilityLabel("Folders")
+    }
+}

--- a/apple/CabalmailMac/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apple/CabalmailMac/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,33 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3A",
+          "green" : "0x63",
+          "red" : "0x2B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x89",
+          "green" : "0xC2",
+          "red" : "0x79"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/apple/CabalmailMac/Assets.xcassets/CabalmailMark.imageset/Contents.json
+++ b/apple/CabalmailMac/Assets.xcassets/CabalmailMark.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "cabalmail-mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/apple/CabalmailMac/Assets.xcassets/CabalmailMark.imageset/cabalmail-mark.svg
+++ b/apple/CabalmailMac/Assets.xcassets/CabalmailMark.imageset/cabalmail-mark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <g fill="#2E5235" transform="translate(122 147) scale(2.036)">
+    
+    <path fill-rule="evenodd" d="&#xA;      M 0 180&#xA;      a 96 96 0 1 0 192 0&#xA;      a 96 96 0 1 0 -192 0&#xA;      Z&#xA;      M 38 180&#xA;      L 108 110&#xA;      L 108 146&#xA;      L 154 146&#xA;      L 154 214&#xA;      L 108 214&#xA;      L 108 250&#xA;      Z&#xA;    "></path>
+    
+    <path d="M 154 84 L 268 176 L 400 84 L 400 275 L 154 275 Z"></path>
+  </g>
+</svg>

--- a/apple/CabalmailMac/Assets.xcassets/LogoTint.colorset/Contents.json
+++ b/apple/CabalmailMac/Assets.xcassets/LogoTint.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3A",
-          "green" : "0x63",
-          "red" : "0x2B"
+          "blue" : "0x35",
+          "green" : "0x52",
+          "red" : "0x2E"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x89",
-          "green" : "0xC2",
-          "red" : "0x79"
+          "blue" : "0x99",
+          "green" : "0xC8",
+          "red" : "0x8D"
         }
       },
       "idiom" : "universal"

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -93,8 +93,11 @@ targets:
         # every archive uploads as CFBundleVersion=1.
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
-        UILaunchScreen:
-          UIColorName: AccentColor
+        # Plain system-background launch screen. This used to point at
+        # AccentColor, which was harmless while that colorset was empty;
+        # now that the accent is the forest brand color, keeping the
+        # reference would flash a solid green screen on every launch.
+        UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
           - UIInterfaceOrientationLandscapeLeft

--- a/changelog.d/sidebar-branding.changed.md
+++ b/changelog.d/sidebar-branding.changed.md
@@ -1,0 +1,6 @@
+- Apple clients: sidebar branding. A subtle four-color wash (the admin
+  app's address swatches) sits behind the folder sidebar — the whole
+  folder screen on iPhone, the sidebar column on iPad and macOS — and
+  the app accent changes from system blue to forest green. The Cabalmail
+  mark now sits above the folder list; "Folders" (formerly "Mailboxes")
+  remains the screen's title for VoiceOver and the back button.


### PR DESCRIPTION
Implements the **sidebar-branding design handoff** (`Cabalmail Apple Clients.zip`) for iOS, iPadOS, and macOS. Exactly two treatments, everything else untouched.

## Treatment 1 — Color wash + accent
- New `SidebarWash` view: the four admin address swatches (azure/amber/forest/plum, light + dark sets, exact handoff sRGB values) as elliptical-gradient blobs at the handoff geometry, fixed 20% opacity.
- Applied as a `.background` of the Mail sidebar column only — whole folder screen on iPhone, floating sidebar on iPad, sidebar material on macOS. `.scrollContentBackground(.hidden)` lets it show through the native `List`; no system control or material replaced.
- `AccentColor` = forest (light `#2B633A` / dark `#79C289`) in both catalogs. Folder icons, tab items, and selection pick it up via the existing `.tint` plumbing (`iconForeground()` untouched; white-on-selected still works).

## Treatment 2 — Logo
- `cabalmail-mark.svg` imported as a template vector imageset (both catalogs) + `LogoTint` colorset (light `#2E5235` / dark `#8DC899`).
- iPhone 44 pt / iPad 34 pt in the sidebar's leading toolbar slot; macOS 30 pt header row above "Search all mail". On OS 26 the item is detached from the shared glass background (`sharedBackgroundVisibility(.hidden)`, availability-guarded) so the decorative mark doesn't render as a glass-capsule button.

## Terminology: Mailboxes → Folders
Per discussion: the mailbox is the per-user singleton in Cabalmail's domain model; the sidebar lists its **folders**. The navigation title returns as `"Folders"` (visible text suppressed where the mark stands in) so VoiceOver and the back button say "Folders" — #575 had removed the string entirely, which lost the back-button label. The compact Folders management tab shows "Folders" as a regular title again (matches the Addresses tab). Also: the empty-state copy now says "Pick a folder…", and two stale comments were updated. The macOS `CommandMenu("Mailbox")` was considered and **kept** — singular "Mailbox" matches both Apple Mail's menu convention and the singleton model.

## Side effect neutralized
`project.yml` pointed the iOS launch screen at `AccentColor`; harmless while that colorset was empty, but it would now flash solid forest green on launch. Pinned to the plain system background.

## Verification
- iOS + macOS builds clean (`CODE_SIGNING_ALLOWED=NO`), CabalmailKit tests pass, swiftlint clean.
- Compiled-asset render check: mark's even-odd cutout and light/dark template tinting verified through the real `actool` pipeline; built app's `Info.plist` carries `NSAccentColorName` and `UILaunchScreen = {}`.
- Simulator screenshots (iPhone 17 + iPad Pro 11, iOS 26.5, light + dark) via a harness reproducing the exact sidebar modifier stack: wash geometry matches the mocks, title suppressed, logo placement correct, iPad wash confined to the sidebar column, no glass capsule.
- **Not visually verified**: the real signed-in app (needs Cognito login) and the macOS window (headless session — no display to capture). Layout/composition risk there is low; worth an eyeball on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)