### PR TITLE
Pin folder/address icons to the brand accent on wide layouts

### DIFF
--- a/apple/Cabalmail/Views/AddressListView.swift
+++ b/apple/Cabalmail/Views/AddressListView.swift
@@ -237,7 +237,11 @@ struct AddressListView: View {
     private func row(for address: Address) -> some View {
         HStack {
             Image(systemName: address.favorite ? "star.fill" : "at")
-                .foregroundStyle(address.favorite ? Color.yellow : Color.accentColor)
+                // The asset-catalog accent, pinned like the folder icons
+                // (see `iconForeground` in FolderListView+Helpers.swift):
+                // `Color.accentColor` follows the macOS system accent when
+                // that isn't "multicolor", leaving the icons off-brand.
+                .foregroundStyle(address.favorite ? Color.yellow : Color("AccentColor"))
             VStack(alignment: .leading, spacing: 2) {
                 Text(address.address)
                 if let comment = address.comment, !comment.isEmpty {

--- a/apple/Cabalmail/Views/FolderListView+Helpers.swift
+++ b/apple/Cabalmail/Views/FolderListView+Helpers.swift
@@ -66,10 +66,17 @@ extension FolderListView {
     }
 
     func iconForeground(isSelected: Bool) -> AnyShapeStyle {
+        // Folder icons carry the brand accent from the asset catalog,
+        // pinned explicitly rather than ridden through `.tint`: macOS
+        // repaints environment tints with the user's system accent
+        // (System Settings > Appearance) whenever that isn't
+        // "multicolor", which left the wide layouts' icons off-brand.
+        // The pinned color resolves the same light/dark variants on
+        // every platform, so compact renders identically to before.
         #if os(macOS)
-        return AnyShapeStyle(.tint)
+        return AnyShapeStyle(Color("AccentColor"))
         #else
-        return isSelected ? AnyShapeStyle(Color.white) : AnyShapeStyle(.tint)
+        return isSelected ? AnyShapeStyle(Color.white) : AnyShapeStyle(Color("AccentColor"))
         #endif
     }
 


### PR DESCRIPTION
Follow-up to #576, addressing review feedback: on wide screens (macOS, iPadOS) the folder icons in the folder list and the `@` icons in the address list must render in the highlight (forest accent) color.

## Why they weren't
Both icon sets rode the environment accent (`.tint` in `iconForeground()`, `Color.accentColor` in the address rows). On macOS the OS repaints those with the **system** accent (System Settings → Appearance) whenever it isn't "multicolor", so the sidebar icons came out off-brand. (On iPadOS the environment accent resolves correctly in isolation — verified in a simulator harness — but pinning covers any context that remaps the tint, and guarantees the two icon sets match across platforms.)

## Fix
Resolve the icon color from the `AccentColor` asset directly (`Color("AccentColor")`) in `iconForeground()` and the address row. Light/dark variants still come from the colorset; the iOS/iPadOS white-icon-on-selected-row logic is untouched; compact renders identically to before.

No changelog fragment: the pending `sidebar-branding` fragment already describes the accent outcome this ships.

## Verification
- iOS + macOS builds clean, swiftlint clean.
- `Color("AccentColor")` resolution through the compiled catalog (light + dark) was verified via rendered output in the #576 work (same mechanism as `LogoTint`).
- Worth an on-device look on the Mac, since the macOS system-accent interaction is exactly what a headless session can't reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)