### PR TITLE
Triple the sidebar mark's dimensions (9x area)

### DIFF
--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -476,7 +476,7 @@ extension MailRootView {
             // title here (the sidebar column never showed one); the mark is
             // purely additive. iOS/iPadOS host theirs in the toolbar below.
             HStack {
-                CabalmailMark(size: 30)
+                CabalmailMark(size: 90)
                 Spacer()
             }
             .padding(.leading, 16)
@@ -533,12 +533,12 @@ extension MailRootView {
             // earlier systems render toolbar images plain anyway.
             if #available(iOS 26.0, visionOS 26.0, *) {
                 ToolbarItem(placement: .topBarLeading) {
-                    CabalmailMark(size: isWideSidebar ? 34 : 44)
+                    CabalmailMark(size: isWideSidebar ? 102 : 132)
                 }
                 .sharedBackgroundVisibility(.hidden)
             } else {
                 ToolbarItem(placement: .topBarLeading) {
-                    CabalmailMark(size: isWideSidebar ? 34 : 44)
+                    CabalmailMark(size: isWideSidebar ? 102 : 132)
                 }
             }
         }

--- a/apple/Cabalmail/Views/SidebarBranding.swift
+++ b/apple/Cabalmail/Views/SidebarBranding.swift
@@ -119,10 +119,11 @@ private extension Color {
 
 /// The Cabalmail mark (mark only, never the wordmark), tinted per theme
 /// via the `LogoTint` colorset. The size is the mark's square bounding
-/// box (the handoff's 44 pt iPhone / 34 pt iPad / 30 pt macOS values);
-/// the ink itself carries the asset's built-in padding. Decorative — it
-/// stands in for the sidebar's "Folders" title, so it carries that
-/// accessibility label rather than being hidden.
+/// box — 132 pt iPhone / 102 pt iPad / 90 pt macOS, three times the
+/// handoff's original values (the asset's built-in padding left the ink
+/// too small at the handoff sizes). Decorative — it stands in for the
+/// sidebar's "Folders" title, so it carries that accessibility label
+/// rather than being hidden.
 struct CabalmailMark: View {
     let size: CGFloat
 


### PR DESCRIPTION
Follow-up to #576/#577: the Cabalmail mark's box goes from 44/34/30 pt (iPhone/iPad/macOS) to **132/102/90 pt** — 3x each dimension, 9x area. The SVG carries generous built-in padding, so the original handoff sizes rendered the ink quite small; this brings it to real prominence.

## Verification
- Simulator screenshots (iPhone 17 + iPad Pro 11, iOS 26.5) via the sidebar harness: the toolbar-hosted mark renders unclipped at the new size on both — the leading item grows the bar region naturally, the filter/search fields and folder list flow below, and the `+`/refresh (iPhone) and sidebar-toggle (iPad) items keep their slots.
- macOS: header-row placement just grows; build-verified (headless session can't screenshot Mac windows).
- iOS + macOS builds clean, swiftlint clean.

No changelog fragment: the pending `sidebar-branding` fragment describes the mark without pinning sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)