### PR TITLE
Don't offer resume when saved position is bare INBOX

### DIFF
--- a/apple/Cabalmail/NavStateCoordinator.swift
+++ b/apple/Cabalmail/NavStateCoordinator.swift
@@ -126,6 +126,12 @@ final class NavStateCoordinator {
         lastSeenUpdatedAt = max(lastSeenUpdatedAt, cursor.updatedAt ?? 0)
         // The folder must still exist (another client may have deleted it).
         guard folders.contains(where: { $0.path == cursor.folder }) else { return nil }
+        // A folder-only cursor pointing at INBOX is where launch already lands
+        // the user, so there's nothing to resume — don't offer the prompt.
+        if cursor.messageID == nil, cursor.uid == nil,
+           cursor.folder.caseInsensitiveCompare("INBOX") == .orderedSame {
+            return nil
+        }
         // A folder-only cursor has no message to verify; a message cursor must
         // still be reachable in that folder.
         if cursor.messageID != nil || cursor.uid != nil {

--- a/changelog.d/nav-resume-inbox-only.changed.md
+++ b/changelog.d/nav-resume-inbox-only.changed.md
@@ -1,0 +1,3 @@
+- The Apple clients no longer offer to resume where you left off when the
+  saved position is INBOX with no message selected. Launch already lands you
+  there, so the prompt was a no-op.


### PR DESCRIPTION
## Summary

When the Apple clients launch, they land the user in INBOX and then offer an opt-in "Pick up where you left off" toast if there's a resumable saved position. But if the *saved* position is itself just INBOX with no specific message selected, that prompt resumes to the exact place the user is already standing — a no-op.

This adds an early bail in `NavStateCoordinator.launchResumeCandidate`: a folder-only cursor (no `messageID`, no `uid`) that points at INBOX (case-insensitive) returns `nil`, so no toast is offered. `MailRootView` then simply materializes the INBOX landing it had provisionally suppressed.

Unaffected:
- Message cursors (INBOX or elsewhere) — still gated by the top-50 reachability check.
- Folder-only cursors for non-INBOX folders — still offered.

## Testing

- `scripts/build-apple.sh ios` — Build Succeeded
- swiftlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)