### PR TITLE
Show Cabalmail mark on launch splash

### DIFF
--- a/apple/Cabalmail/ContentView.swift
+++ b/apple/Cabalmail/ContentView.swift
@@ -29,15 +29,20 @@ struct ContentView: View {
 }
 
 /// Neutral splash shown while `AppState.restoreIfPossible()` is validating
-/// the stored Cognito tokens. Kept deliberately minimal — mirrors the bundle
-/// name so a resumed user sees the same chrome as at launch rather than a
-/// generic spinner that looks like a hang.
+/// the stored Cognito tokens. Kept deliberately minimal — pairs the Cabalmail
+/// mark with the bundle name so a resumed user sees the same chrome as at
+/// launch rather than a generic spinner that looks like a hang. Reuses the
+/// sidebar's `CabalmailMark` asset and `LogoTint` colorset (see
+/// `SidebarBranding`) so the launch mark matches the one above the folder list.
 private struct RestoringSplash: View {
     var body: some View {
         VStack(spacing: 16) {
-            Image(systemName: "tray")
-                .font(.system(size: 48, weight: .semibold))
-                .foregroundStyle(.tint)
+            Image("CabalmailMark")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 132, height: 132)
+                .foregroundStyle(Color("LogoTint"))
+                .accessibilityHidden(true)
             Text("Cabalmail")
                 .font(.title)
             ProgressView()

--- a/changelog.d/apple-splash-logo.changed.md
+++ b/changelog.d/apple-splash-logo.changed.md
@@ -1,0 +1,3 @@
+- The Apple clients' launch splash now shows the Cabalmail mark (the same
+  asset as the folder-list sidebar branding) in place of the generic `tray`
+  system symbol.


### PR DESCRIPTION
## What

The Apple clients' restoring splash (shown briefly on cold launch while stored Cognito tokens are validated) used the generic `tray` SF Symbol. Replace it with the Cabalmail mark.

## How

Reuses the existing `CabalmailMark` imageset and theme-aware `LogoTint` colorset — the same assets that render the mark above the folder list in the sidebar (`SidebarBranding`) — rather than introducing a new asset. `ContentView.swift` is shared by the iOS/visionOS and macOS targets and both asset catalogs already carry these entries.

## Verify

- `scripts/build-apple.sh ios` — Build Succeeded
- `scripts/build-apple.sh macos` — Build Succeeded
- swiftlint clean on the touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)