### PR TITLE
Harden mail API input validation and server-side authorization

### DIFF
--- a/changelog.d/address-and-admin-authz-hardening.security.md
+++ b/changelog.d/address-and-admin-authz-hardening.security.md
@@ -1,0 +1,9 @@
+- Tightened server-side validation on the address- and folder-management
+  endpoints: address revocation now derives the DNS records to delete from the
+  stored address row rather than client-supplied `subdomain`/`tld` (so a caller
+  can no longer target another user's records); new addresses store a
+  server-derived `address` key instead of a client-supplied one; the
+  folder-management endpoints (`new_folder`, `delete_folder`,
+  `subscribe_folder`, `unsubscribe_folder`, `folder_status`) now validate the
+  folder name like the read paths already did; and the admin-group check is an
+  exact membership test instead of a substring match.

--- a/changelog.d/mail-endpoint-host-ssrf.security.md
+++ b/changelog.d/mail-endpoint-host-ssrf.security.md
@@ -1,0 +1,5 @@
+- The mail API no longer trusts the client-supplied `host`/`smtp_host`
+  parameters. The IMAP/SMTP endpoints and the S3 cache bucket are now derived
+  server-side from the environment's control domain, closing a path by which an
+  authenticated user could aim a connection at a server they control and
+  capture the shared IMAP/SMTP master credential.

--- a/lambda/api/_shared/compose.py
+++ b/lambda/api/_shared/compose.py
@@ -16,6 +16,7 @@ from botocore.exceptions import ClientError # pylint: disable=import-error
 from helper import format_mailbox # pylint: disable=import-error
 from helper import get_object # pylint: disable=import-error
 from helper import user_authorized_for_sender # pylint: disable=import-error
+from helper import CACHE_BUCKET # pylint: disable=import-error
 
 # Attachments are uploaded to S3 via the /upload_url Lambda's presigned
 # PUT URLs (the cache bucket's 2-day lifecycle handles cleanup). Total
@@ -185,7 +186,7 @@ def compose_from_body(body, user):
     lookup, and MIME assembly. Raises ValueError on a rejected payload
     (callers translate it to a 400). Sender authorization is the caller's
     responsibility (see unauthorized_sender_response_or_none).'''
-    bucket = body['host'].replace('imap', 'cache')
+    bucket = CACHE_BUCKET
     validate_outbound_headers(body)
     attachments = load_attachments(body.get('attachments', []), bucket, user)
     # The visible From may carry the user's display-name preference, but the

--- a/lambda/api/_shared/helper.py
+++ b/lambda/api/_shared/helper.py
@@ -40,6 +40,36 @@ def get_mpw():
     return mpw
 
 
+# Canonical mail-tier endpoints and cache bucket, derived server-side from the
+# environment's control domain -- NEVER from a request field.
+#
+# The IMAP/SMTP host and the S3 cache bucket used to be taken from a client
+# `host`/`smtp_host` parameter (bucket = host.replace("imap","cache")). Because
+# get_imap_client logs in with the shared master password ({user}*admin / SMTP
+# `master`), a client-chosen host let any authenticated user point the
+# connection at a server they control and capture that master credential -- a
+# full multi-tenant compromise. These values are fixed per environment (the ELB
+# publishes imap.<domain>/smtp-out.<domain>; the bucket is cache.<domain>), so
+# we derive them here and ignore whatever the client sends. `.get` with a blank
+# default keeps helper importable in any function that lacks CONTROL_DOMAIN;
+# such functions never touch these paths.
+CONTROL_DOMAIN = os.environ.get('CONTROL_DOMAIN', '')
+IMAP_HOST = f'imap.{CONTROL_DOMAIN}'
+SMTP_HOST = f'smtp-out.{CONTROL_DOMAIN}'
+CACHE_BUCKET = f'cache.{CONTROL_DOMAIN}'
+
+
+def is_admin(groups_claim):
+    '''True when the caller's `cognito:groups` claim contains the exact `admin`
+    group. The claim is a serialized list -- API Gateway may render it as
+    "admin", "admin,users", or "[admin users]" -- so we split on commas and
+    whitespace and match a whole element. A substring test (`'admin' in claim`)
+    would wrongly admit any group whose name merely contains "admin"
+    (e.g. "admin-readonly", "nonadmin").'''
+    members = (groups_claim or '').strip('[]').replace(',', ' ').split()
+    return 'admin' in members
+
+
 # ---------------------------------------------------------------------------
 # Planned-maintenance signal.
 #
@@ -163,7 +193,7 @@ def maintenance_guard(handler):
 def admin_response_or_none(event):
     """Returns a 403 response when the caller lacks the admin group, else None"""
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if not is_admin(groups):
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})
@@ -184,8 +214,8 @@ def find_managed_apex(domains_map, domain):
                 best_zone = zone_id
     return (best_apex, best_zone)
 
-def get_imap_client(host, user, folder, read_only=False):
-    '''Returns an IMAP client for host/user with folder selected.
+def get_imap_client(_host, user, folder, read_only=False):
+    '''Returns an IMAP client for the current user with folder selected.
 
     Raises MaintenanceError when a planned IMAP roll is in progress, so callers
     short-circuit to a friendly 503 (via maintenance_guard) instead of dialing a
@@ -196,9 +226,15 @@ def get_imap_client(host, user, folder, read_only=False):
     Connection handling (including the optional warm-invocation pool) lives in
     imap_session; this wrapper just applies the maintenance gate first, then
     delegates. With pooling off (the default) the returned object is a bare
-    IMAPClient connected/authenticated/selected exactly as before.'''
+    IMAPClient connected/authenticated/selected exactly as before.
+
+    The `_host` argument is accepted for call-site compatibility but
+    deliberately IGNORED: every IMAP connection authenticates with the shared
+    master password, so honoring a client-supplied host would let any
+    authenticated caller exfiltrate that credential to a server they control. We
+    always dial the environment's canonical IMAP_HOST instead.'''
     _raise_if_maintenance()
-    return open_imap_client(host, user, folder, read_only, mpw)
+    return open_imap_client(IMAP_HOST, user, folder, read_only, mpw)
 
 
 def user_authorized_for_sender(user, sender):
@@ -746,15 +782,18 @@ def unsubscribe_folder(folder, host, user):
     client.logout()
     return return_value
 
-def get_message(host, user, folder, msg_id):
-    '''Gets a message from cache on s3 or from imap server'''
-    bucket = host.replace("imap", "cache")
+def get_message(_host, user, folder, msg_id):
+    '''Gets a message from cache on s3 or from imap server.
+
+    `_host` is ignored (see get_imap_client); the cache bucket and IMAP target
+    are derived from the environment, never from the request.'''
+    bucket = CACHE_BUCKET
     email_body_raw = b''
     key = f"{user}/{folder}/{msg_id}/raw"
     if key_exists(bucket, key):
         email_body_raw = get_object(bucket, key)
     else:
-        client = get_imap_client(host, user, folder, True)
+        client = get_imap_client(IMAP_HOST, user, folder, True)
         message = client.fetch([msg_id],['RFC822'])
         email_body_raw = message[msg_id][b'RFC822']
         client.logout()

--- a/lambda/api/append_sent/function.py
+++ b/lambda/api/append_sent/function.py
@@ -31,7 +31,6 @@ def _process(job):
     bucket = job['bucket']
     key = job['key']
     user = job['user']
-    host = job['host']
     message_id = job.get('message_id') or ''
 
     try:
@@ -48,7 +47,7 @@ def _process(job):
     # mailbox without a Sent folder still works. get_imap_client raises during a
     # planned IMAP roll, which is exactly when we WANT the job to retry, so it is
     # deliberately not guarded here.
-    client = get_imap_client(host, user, 'INBOX')
+    client = get_imap_client(None, user, 'INBOX')
     try:
         try:
             client.create_folder('Sent')

--- a/lambda/api/assign_address/function.py
+++ b/lambda/api/assign_address/function.py
@@ -17,7 +17,7 @@ cognito = boto3.client('cognito-idp')
 def handler(event, _context):
     '''Adds a user to an existing address'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/confirm_user/function.py
+++ b/lambda/api/confirm_user/function.py
@@ -10,7 +10,7 @@ user_pool_id = os.environ['USER_POOL_ID']
 def handler(event, _context):
     '''Confirms a pending user signup'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/delete_folder/function.py
+++ b/lambda/api/delete_folder/function.py
@@ -3,6 +3,7 @@ import json
 from helper import get_imap_client # pylint: disable=import-error
 from helper import get_folder_list # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
+from helper import validate_folder_name # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -14,8 +15,14 @@ def handler(event, _context):
     if error:
         return error
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    client = get_imap_client(body['host'], user, 'INBOX')
-    name = body['name'].replace("/",".")
+    try:
+        name = validate_folder_name(body.get('name')).replace("/", ".")
+    except ValueError as err:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"status": f"Invalid input: {err}"})
+        }
+    client = get_imap_client(None, user, 'INBOX')
     client.delete_folder(name)
     response = get_folder_list(client)
     client.logout()

--- a/lambda/api/delete_user/function.py
+++ b/lambda/api/delete_user/function.py
@@ -14,7 +14,7 @@ user_domain_access_table = ddb.Table('cabal-user-domain-access')
 def handler(event, _context):
     '''Deletes a user account'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/disable_user/function.py
+++ b/lambda/api/disable_user/function.py
@@ -11,7 +11,7 @@ user_pool_id = os.environ['USER_POOL_ID']
 def handler(event, _context):
     '''Disables a user account'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/empty_trash/function.py
+++ b/lambda/api/empty_trash/function.py
@@ -4,6 +4,7 @@ from helper import ( # pylint: disable=import-error
     delete_prefix,
     get_imap_client,
     validate_trash_folder,
+    CACHE_BUCKET,
 )
 
 from helper import maintenance_guard # pylint: disable=import-error
@@ -21,9 +22,8 @@ def handler(event, _context):
         folder = validate_trash_folder(body.get('folder'))
     except ValueError as err:
         return _invalid(err)
-    host = body['host']
     imap_folder = folder.replace("/", ".")
-    client = get_imap_client(host, user, imap_folder)
+    client = get_imap_client(None, user, imap_folder)
     try:
         # "1:*" covers the whole mailbox without materializing a UID list,
         # so this stays one round trip however full the trash is. On an
@@ -40,7 +40,7 @@ def handler(event, _context):
         }
     client.logout()
     # Best effort: drop the folder's cached raw bodies too.
-    delete_prefix(host.replace("imap", "cache"), f"{user}/{imap_folder}/")
+    delete_prefix(CACHE_BUCKET, f"{user}/{imap_folder}/")
     return {
         "statusCode": 200,
         "body": json.dumps({

--- a/lambda/api/enable_user/function.py
+++ b/lambda/api/enable_user/function.py
@@ -11,7 +11,7 @@ user_pool_id = os.environ['USER_POOL_ID']
 def handler(event, _context):
     '''Enables a disabled user account'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/fetch_attachment/function.py
+++ b/lambda/api/fetch_attachment/function.py
@@ -5,6 +5,7 @@ from helper import upload_object # pylint: disable=import-error
 from helper import sign_url # pylint: disable=import-error
 from helper import key_exists # pylint: disable=import-error
 from helper import get_message # pylint: disable=import-error
+from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -15,7 +16,7 @@ def handler(event, _context):
     and attachment serial number'''
     query_string = event['queryStringParameters']
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    bucket = query_string['host'].replace("imap", "cache")
+    bucket = CACHE_BUCKET
     key = f"{user}/{query_string['folder']}/{query_string['id']}/{query_string['filename']}"
     index = int(query_string['index'])
     message = get_message(query_string['host'], user,

--- a/lambda/api/fetch_inline_image/function.py
+++ b/lambda/api/fetch_inline_image/function.py
@@ -8,6 +8,7 @@ from helper import get_message # pylint: disable=import-error
 from helper import validate_content_id # pylint: disable=import-error
 from helper import validate_folder_name # pylint: disable=import-error
 from helper import validate_uid # pylint: disable=import-error
+from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -27,10 +28,10 @@ def handler(event, _context):
             "statusCode": 400,
             "body": json.dumps({"status": f"Invalid input: {err}"})
         }
-    bucket = query_string['host'].replace("imap", "cache")
+    bucket = CACHE_BUCKET
     key_prefix = f"{user}/{folder}/{msg_id}/{index}"
     key = ""
-    message = get_message(query_string['host'], user,
+    message = get_message(None, user,
                           folder.replace("/", "."), msg_id)
     for part in message.walk():
         content_type = part.get_content_type()

--- a/lambda/api/fetch_message/function.py
+++ b/lambda/api/fetch_message/function.py
@@ -3,6 +3,7 @@ import json
 import re
 from helper import get_message # pylint: disable=import-error
 from helper import sign_url # pylint: disable=import-error
+from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -55,7 +56,7 @@ def handler(event, _context):
         "statusCode": 200,
         "body": json.dumps({
             "message_raw": sign_url(
-                                    query_string['host'].replace("imap", "cache"),
+                                    CACHE_BUCKET,
                                     f"{user}/{query_string['folder']}/{query_string['id']}/raw"),
             "message_body_plain": body_plain_decoded,
             "message_body_html": body_html_decoded,

--- a/lambda/api/folder_status/function.py
+++ b/lambda/api/folder_status/function.py
@@ -2,6 +2,7 @@
 folder, plus an optional FLAGGED count.'''
 import json
 from helper import get_imap_client # pylint: disable=import-error
+from helper import validate_folder_name # pylint: disable=import-error
 from helper import maintenance_guard # pylint: disable=import-error
 
 ATTRS = ['MESSAGES', 'UNSEEN', 'UIDVALIDITY', 'UIDNEXT']
@@ -28,13 +29,19 @@ def handler(event, _context):
     '''
     query_string = event['queryStringParameters']
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    folder = query_string['folder'].replace("/", ".")
+    try:
+        folder = validate_folder_name(query_string.get('folder')).replace("/", ".")
+    except ValueError as err:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"status": f"Invalid input: {err}"})
+        }
     want_flagged = query_string.get('flagged') in TRUTHY
     # SEARCH runs against the selected mailbox, so a flagged count needs the
     # target folder selected; otherwise stay on INBOX (STATUS reads any folder
     # regardless of selection -- the cheap path the Apple idle poll uses).
     selected = folder if want_flagged else 'INBOX'
-    client = get_imap_client(query_string['host'], user, selected, True)
+    client = get_imap_client(None, user, selected, True)
     status = client.folder_status(folder, ATTRS)
     body = {
         "messages": status.get(b'MESSAGES'),

--- a/lambda/api/list_addresses_admin/function.py
+++ b/lambda/api/list_addresses_admin/function.py
@@ -10,7 +10,7 @@ table = ddb.Table('cabal-addresses')
 def handler(event, _context):
     '''Lists all addresses with their assigned users'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/list_dmarc_reports/function.py
+++ b/lambda/api/list_dmarc_reports/function.py
@@ -16,7 +16,7 @@ table = ddb.Table(table_name)
 def handler(event, _context):
     '''Returns DMARC report records in reverse chronological order'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/list_user_domain_access/function.py
+++ b/lambda/api/list_user_domain_access/function.py
@@ -14,7 +14,7 @@ table = ddb.Table('cabal-user-domain-access')
 def handler(event, _context):
     '''Returns the full allow list as a flat array of {user, domain} items.'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/list_users/function.py
+++ b/lambda/api/list_users/function.py
@@ -10,7 +10,7 @@ user_pool_id = os.environ['USER_POOL_ID']
 def handler(event, _context):
     '''Lists all users in the Cognito user pool'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/new/function.py
+++ b/lambda/api/new/function.py
@@ -73,23 +73,28 @@ def handler(event, _context):
                 'Error': f"Not permitted to create addresses on \"{body['tld']}\""
             })
         }
+    # Derive the address server-side rather than trusting body['address']: it is
+    # the DynamoDB primary key and the value user_authorized_for_sender matches
+    # on, so it must equal the real routing identity, not an arbitrary client
+    # string. username/subdomain/tld are all validated above.
+    address = f"{body['username']}@{body['subdomain']}.{body['tld']}"
     try:
         create_dns_records(domains[body['tld']], body['subdomain'], body['tld'])
-        record_address(user, body)
+        record_address(user, body, address)
         notify_containers()
     except Exception as err:  # pylint: disable=broad-exception-caught
-        print(f"Error creating address {body['address']}: {err}")
+        print(f"Error creating address {address}: {err}")
         return {
             'statusCode': 500,
             'body': json.dumps({
-                'address': body['address'],
+                'address': address,
                 'error': str(err)
             })
         }
     return {
         'statusCode': 201,
         'body': json.dumps({
-            'address': body['address']
+            'address': address
         })
     }
 
@@ -142,10 +147,10 @@ def create_dns_records(zone_id, subdomain, tld):
     r53.change_resource_record_sets(**params)
 
 
-def record_address(user, body):
+def record_address(user, body, address):
     '''Records the new address in DynamoDB'''
     table.put_item(Item={
-        'address': body['address'],
+        'address': address,
         'tld': body['tld'],
         'user': user,
         'username': body['username'],

--- a/lambda/api/new_address_admin/function.py
+++ b/lambda/api/new_address_admin/function.py
@@ -27,7 +27,7 @@ cognito = boto3.client('cognito-idp')
 def handler(event, _context):
     '''Creates a new email address assigned to one or more users'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})
@@ -59,6 +59,11 @@ def handler(event, _context):
             'statusCode': 400,
             'body': json.dumps({'Error': f'Invalid input: {err}'})
         }
+    # Derive the address server-side rather than trusting body['address']: it is
+    # the DynamoDB primary key and the value user_authorized_for_sender matches
+    # on, so it must equal the real routing identity. username/subdomain/tld are
+    # all validated above.
+    address = f"{body['username']}@{body['subdomain']}.{body['tld']}"
     try:
         for username in usernames:
             if not cognito_user_exists(username):
@@ -77,23 +82,23 @@ def handler(event, _context):
                     })
                 }
         create_dns_records(domains[body['tld']], body['subdomain'], body['tld'])
-        record_address(usernames, body)
+        record_address(usernames, body, address)
         notify_containers()
     except Exception as err:  # pylint: disable=broad-exception-caught
-        print(f"Error creating address {body['address']}: {err}")
-        audit_log(caller, 'new_address_admin', body.get('address', ''), 'failure')
+        print(f"Error creating address {address}: {err}")
+        audit_log(caller, 'new_address_admin', address, 'failure')
         return {
             'statusCode': 500,
             'body': json.dumps({
-                'address': body['address'],
+                'address': address,
                 'error': str(err)
             })
         }
-    audit_log(caller, 'new_address_admin', body.get('address', ''), 'success')
+    audit_log(caller, 'new_address_admin', address, 'success')
     return {
         'statusCode': 201,
         'body': json.dumps({
-            'address': body['address'],
+            'address': address,
             'user': '/'.join(usernames)
         })
     }
@@ -146,10 +151,10 @@ def create_dns_records(zone_id, subdomain, tld):
     r53.change_resource_record_sets(**params)
 
 
-def record_address(usernames, body):
+def record_address(usernames, body, address):
     '''Records the new address in DynamoDB'''
     table.put_item(Item={
-        'address': body['address'],
+        'address': address,
         'tld': body['tld'],
         'user': '/'.join(usernames),
         'username': body['username'],

--- a/lambda/api/new_folder/function.py
+++ b/lambda/api/new_folder/function.py
@@ -3,6 +3,7 @@ import json
 from helper import get_imap_client # pylint: disable=import-error
 from helper import get_folder_list # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
+from helper import validate_folder_name # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -14,12 +15,24 @@ def handler(event, _context):
     if error:
         return error
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    client = get_imap_client(body['host'], user, 'INBOX')
-    if body['parent'] == "":
-        client.create_folder(body['name'])
+    # Validate the folder path the same way every read/message-op handler does,
+    # so a mutating call can't inject an empty/traversal-shaped mailbox name.
+    try:
+        name = validate_folder_name(body.get('name'))
+        parent = body.get('parent') or ""
+        if parent:
+            parent = validate_folder_name(parent)
+    except ValueError as err:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"status": f"Invalid input: {err}"})
+        }
+    client = get_imap_client(None, user, 'INBOX')
+    if parent == "":
+        client.create_folder(name)
     else:
-        parent = body['parent'].replace("/",".")
-        client.create_folder(f"{parent}.{body['name']}")
+        parent = parent.replace("/",".")
+        client.create_folder(f"{parent}.{name}")
     response = get_folder_list(client)
     client.logout()
     return {

--- a/lambda/api/purge_messages/function.py
+++ b/lambda/api/purge_messages/function.py
@@ -5,6 +5,7 @@ from helper import ( # pylint: disable=import-error
     get_imap_client,
     validate_trash_folder,
     validate_uid_list,
+    CACHE_BUCKET,
 )
 
 from helper import maintenance_guard # pylint: disable=import-error
@@ -25,9 +26,8 @@ def handler(event, _context):
         return _invalid(err)
     if not ids:
         return _invalid('ids is empty')
-    host = body['host']
     imap_folder = folder.replace("/", ".")
-    client = get_imap_client(host, user, imap_folder)
+    client = get_imap_client(None, user, imap_folder)
     try:
         client.delete_messages(ids)
         # UID EXPUNGE (Dovecot supports UIDPLUS), so only the requested
@@ -44,9 +44,8 @@ def handler(event, _context):
     client.logout()
     # Best effort: drop cached raw bodies so a purged message is not
     # retrievable from the cache bucket afterwards.
-    bucket = host.replace("imap", "cache")
     for msg_id in ids:
-        delete_object(bucket, f"{user}/{imap_folder}/{msg_id}/raw")
+        delete_object(CACHE_BUCKET, f"{user}/{imap_folder}/{msg_id}/raw")
     return {
         "statusCode": 200,
         "body": json.dumps({

--- a/lambda/api/revoke/function.py
+++ b/lambda/api/revoke/function.py
@@ -7,8 +7,6 @@ import boto3  # pylint: disable=import-error
 from helper import assert_zone_owns_apex  # pylint: disable=import-error
 from helper import parse_json_body  # pylint: disable=import-error
 from helper import user_authorized_for_sender  # pylint: disable=import-error
-from helper import validate_dns_apex  # pylint: disable=import-error
-from helper import validate_dns_subdomain  # pylint: disable=import-error
 
 domains = json.loads(os.environ['DOMAINS'])
 control_domain = os.environ['CONTROL_DOMAIN']
@@ -26,23 +24,7 @@ def handler(event, _context):
     if error:
         return error
     address = body['address']
-    subdomain = body['subdomain']
-    tld = body['tld']
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    if tld not in domains:
-        return {
-            'statusCode': 400,
-            'body': json.dumps({'Error': f'Unknown domain "{tld}"'})
-        }
-    try:
-        validate_dns_apex(tld)
-        validate_dns_subdomain(subdomain)
-    except ValueError as err:
-        return {
-            'statusCode': 400,
-            'body': json.dumps({'Error': f'Invalid input: {err}'})
-        }
-    zone_id = domains[tld]
     if not user_authorized_for_sender(user, address):
         return {
             'statusCode': 403,
@@ -50,8 +32,20 @@ def handler(event, _context):
                 'Error': 'Address not associated with authenticated user'
             })
         }
+    # Take subdomain/tld/zone from the STORED row for `address`, never from the
+    # request body. Authorization above is on `address` only, so honoring a
+    # client-supplied subdomain/tld would let a caller who owns any one address
+    # delete another user's DNS records: delete_dns_records targets
+    # `{subdomain}.{tld}`, and the co-tenant guard (other_addresses_on_subdomain)
+    # returns False for a single-tenant victim subdomain, so the DELETE would
+    # proceed. The caller owns `address`, so its row is the authoritative source.
+    item = table.get_item(Key={'address': address}).get('Item') or {}
+    subdomain = item.get('subdomain')
+    tld = item.get('tld')
+    zone_id = item.get('zone-id') or domains.get(tld)
     try:
-        if not other_addresses_on_subdomain(subdomain, tld, address):
+        if subdomain and tld and zone_id and \
+                not other_addresses_on_subdomain(subdomain, tld, address):
             delete_dns_records(zone_id, subdomain, tld)
         revoke_address(address)
         notify_containers()

--- a/lambda/api/save_draft/function.py
+++ b/lambda/api/save_draft/function.py
@@ -29,6 +29,7 @@ from helper import ( # pylint: disable=import-error
     maintenance_guard,
     parse_json_body,
     validate_uid,
+    CACHE_BUCKET,
 )
 
 
@@ -140,12 +141,11 @@ def _parse_replaces(body):
     return (validate_uid(uid), validate_uid(uidvalidity))
 
 
-def _drop_cached_raw(host, user, uid):
+def _drop_cached_raw(_host, user, uid):
     '''Best effort: drop the cached raw body so an expunged draft is not
     retrievable from the cache bucket afterwards (same hygiene as
-    purge_messages).'''
-    bucket = host.replace('imap', 'cache')
-    delete_object(bucket, f'{user}/{DRAFTS_FOLDER}/{uid}/raw')
+    purge_messages). `_host` is ignored; the bucket is derived server-side.'''
+    delete_object(CACHE_BUCKET, f'{user}/{DRAFTS_FOLDER}/{uid}/raw')
 
 
 def _invalid(err):

--- a/lambda/api/send/function.py
+++ b/lambda/api/send/function.py
@@ -20,6 +20,7 @@ from helper import get_mpw # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
 from helper import upload_object # pylint: disable=import-error
 from helper import validate_uid # pylint: disable=import-error
+from helper import CACHE_BUCKET, SMTP_HOST # pylint: disable=import-error
 from helper import MaintenanceError, maintenance_response # pylint: disable=import-error
 
 # Sending is SMTP-first: outbound delivery never blocks on IMAP. The Bcc-free
@@ -99,7 +100,7 @@ def handler(event, _context):  # pylint: disable=too-many-return-statements
         if addr
     ]
 
-    return_from_send = send(msg, body['smtp_host'], sender, recipients)
+    return_from_send = send(msg, SMTP_HOST, sender, recipients)
     if return_from_send['statusCode'] != 200:
         # Delivery failed, so release the claim - the user's retry must be
         # allowed to actually send.
@@ -168,8 +169,7 @@ def _discard_draft_copy(body, user):
             # Drop the cached raw body so the expunged draft is not
             # retrievable from the cache bucket afterwards (same hygiene as
             # purge_messages).
-            bucket = body['host'].replace('imap', 'cache')
-            delete_object(bucket, f'{user}/{DRAFTS_FOLDER}/{uid}/raw')
+            delete_object(CACHE_BUCKET, f'{user}/{DRAFTS_FOLDER}/{uid}/raw')
     except Exception as err:  # pylint: disable=broad-except
         print(f'[send] WARN failed to discard draft copy: {err}')
 
@@ -184,11 +184,13 @@ def _append_sent_queue_url():
     return url
 
 
-def _queue_sent_copy(msg, host, user, message_id):
+def _queue_sent_copy(msg, _host, user, message_id):
     '''Stages the Bcc-free Sent copy to S3 and enqueues an append job. Best
     effort: a failure means the message was delivered but its Sent copy is not
-    recorded, which we log rather than surface as a send failure.'''
-    bucket = host.replace('imap', 'cache')
+    recorded, which we log rather than surface as a send failure.
+
+    `_host` is ignored; the cache bucket is derived server-side (CACHE_BUCKET).'''
+    bucket = CACHE_BUCKET
     key = f'{SENT_PENDING_PREFIX}/{user}/{uuid.uuid4()}'
     try:
         upload_object(bucket, key, 'message/rfc822', msg.as_string().encode())
@@ -198,7 +200,6 @@ def _queue_sent_copy(msg, host, user, message_id):
                 'bucket': bucket,
                 'key': key,
                 'user': user,
-                'host': host,
                 'message_id': message_id or '',
             })
         )

--- a/lambda/api/set_user_domain_access/function.py
+++ b/lambda/api/set_user_domain_access/function.py
@@ -25,7 +25,7 @@ cognito = boto3.client('cognito-idp')
 def handler(event, _context):
     '''Add or remove a (user, domain) deny entry.'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/subscribe_folder/function.py
+++ b/lambda/api/subscribe_folder/function.py
@@ -1,7 +1,9 @@
 '''Marks the specified folder as subscribed'''
+# pylint: disable=duplicate-code
 import json
 from helper import subscribe_folder # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
+from helper import validate_folder_name # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -13,7 +15,14 @@ def handler(event, _context):
     if error:
         return error
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    status = subscribe_folder(body['folder'].replace("/","."), body['host'], user)
+    try:
+        folder = validate_folder_name(body.get('folder')).replace("/", ".")
+    except ValueError as err:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"status": f"Invalid input: {err}"})
+        }
+    status = subscribe_folder(folder, None, user)
     return {
         "statusCode": 200,
         "body": json.dumps({

--- a/lambda/api/unassign_address/function.py
+++ b/lambda/api/unassign_address/function.py
@@ -15,7 +15,7 @@ sns = boto3.client('sns')
 def handler(event, _context):
     '''Removes a user from an address'''
     groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
-    if 'admin' not in groups:
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
         return {
             'statusCode': 403,
             'body': json.dumps({'Error': 'Admin access required'})

--- a/lambda/api/unsubscribe_folder/function.py
+++ b/lambda/api/unsubscribe_folder/function.py
@@ -1,7 +1,9 @@
 '''Marks the specified folder as unsubscribed'''
+# pylint: disable=duplicate-code
 import json
 from helper import unsubscribe_folder # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
+from helper import validate_folder_name # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
 
@@ -13,7 +15,14 @@ def handler(event, _context):
     if error:
         return error
     user = event['requestContext']['authorizer']['claims']['cognito:username']
-    status = unsubscribe_folder(body['folder'].replace("/","."), body['host'], user)
+    try:
+        folder = validate_folder_name(body.get('folder')).replace("/", ".")
+    except ValueError as err:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"status": f"Invalid input: {err}"})
+        }
+    status = unsubscribe_folder(folder, None, user)
     return {
         "statusCode": 200,
         "body": json.dumps({

--- a/lambda/api/upload_url/function.py
+++ b/lambda/api/upload_url/function.py
@@ -17,6 +17,7 @@ import os
 import re
 import uuid
 from helper import sign_put_url # pylint: disable=import-error
+from helper import CACHE_BUCKET # pylint: disable=import-error
 
 KEY_PREFIX = 'outbound'
 MAX_FILES_PER_REQUEST = 32
@@ -55,10 +56,7 @@ def _build_uploads(event, user):
     if len(files) > MAX_FILES_PER_REQUEST:
         raise _RequestError(400, f"at most {MAX_FILES_PER_REQUEST} files per request")
 
-    host = body.get('host')
-    if not host or not isinstance(host, str):
-        raise _RequestError(400, "host is required")
-    bucket = host.replace('imap', 'cache')
+    bucket = CACHE_BUCKET
 
     uploads = []
     for index, entry in enumerate(files):


### PR DESCRIPTION
Follow-up to the address-input audit (the leading-space-username incident). Closes the server-side input-trust gaps the audit confirmed. The audit's client-side findings ship separately.

> **Stacked on #582** (the whitespace fix). Until #582 merges, this PR's diff includes that commit too; it'll drop out once #582 lands in `stage`.

## HIGH

**H1 — client-controlled `host`/`smtp_host` → master-credential exfiltration.** Every IMAP/SMTP connection authenticates with the shared `/cabal/master_password` (`{user}*admin` / SMTP `master`), and the host came from the request (`bucket = host.replace("imap","cache")`). Any authenticated user could point the connection at a server they control (valid TLS cert) and capture that credential — full multi-tenant compromise. Now `get_imap_client`/`get_message` ignore the passed host and dial `helper.IMAP_HOST`; all bucket derivations use `helper.CACHE_BUCKET`; `send()` uses `helper.SMTP_HOST`. All three are derived from `CONTROL_DOMAIN` (matches what the ELB publishes and what clients already send, so no client change needed).

**H2 — `revoke` deleted DNS built from client `subdomain`/`tld`.** Authorization was on `address` only, so a caller owning any one address could delete another user's records on a single-tenant subdomain. Now the delete is built from the stored row for the authorized `address`.

## MED

- **M1** — `new`/`new_address_admin` store a server-derived `address` (`{username}@{subdomain}.{tld}`) instead of a client-supplied key (it's the authz key `user_authorized_for_sender` matches on).
- **M2** — folder-management handlers (`new_folder`, `delete_folder`, `subscribe_folder`, `unsubscribe_folder`, `folder_status`) now call `validate_folder_name`, matching the read/message-op paths.
- **M4** — admin check is exact membership (`helper.is_admin`), not a substring test (`'admin' in 'admin-readonly'`). Done inline in the 12 handlers (no `helper` import added — that would pull the master-password read into functions whose roles may not allow it).

## Not included (deliberate)
- **M3** (validate `folder`/`id`/`filename` in `fetch_message`/`fetch_attachment`): the audit rated this HIGH for cross-user S3 reads via `../`, but **S3 keys are literal — `..` doesn't collapse** and the first segment is pinned to the caller. Real residual is input hygiene only; left for a later pass per scope.
- Client-side validation and the React DOMPurify cleanup ship in a separate PR.

## Verification
`pylint --rcfile .pylintrc` → 10.00/10; `py_compile` clean; `test_imap_pool.py` passes. No test referenced the removed `host`/`smtp_host` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)