### PR TITLE
Add plans for inbound auth verification and outbound DMARC reports

### DIFF
--- a/docs/0.10.x/inbound-auth-verification-plan.md
+++ b/docs/0.10.x/inbound-auth-verification-plan.md
@@ -1,0 +1,301 @@
+# Inbound Auth Verification Plan
+
+## Context
+
+The smtp-in tier is a pure relay. It accepts mail for hosted domains from the
+internet, routes it to the imap tier via mailertable, and performs **no**
+SPF, DKIM, or DMARC verification — [`docker/templates/in-sendmail.mc`](../../docker/templates/in-sendmail.mc)
+declares no `INPUT_MAIL_FILTER` at all. Meanwhile we hold *senders* to a
+strict standard: the control domain publishes `p=reject` with full
+SPF/DKIM/DMARC ([`terraform/infra/modules/app/global_dns.tf`](../../terraform/infra/modules/app/global_dns.tf)),
+and we ingest the aggregate reports other receivers send us
+(`lambda/api/process_dmarc`). We evaluate nothing in the other direction: a
+message claiming to be from `paypal.com` that fails every authentication
+check is delivered to the user's inbox looking identical to one that passes.
+
+This plan adds verification milters to smtp-in that evaluate SPF, DKIM, and
+DMARC on every inbound message and stamp the result as an
+`Authentication-Results` header (RFC 8601), then surfaces that result to the
+end user in the webmail and Apple clients. **Verification is observe-only:
+no message is rejected, quarantined, or rerouted based on the result,
+regardless of the sender's published policy.** The user sees the finding and
+decides. This is deliberate — a small personal MX misclassifying one real
+message costs more than a hundred correctly-flagged spoofs are worth.
+
+The stamped results are also the foundation for outbound DMARC aggregate
+report generation (reporting to *other* domains on how their mail
+authenticated here), which is scoped separately in
+[`docs/tentative/dmarc-outbound-reports-plan.md`](../tentative/dmarc-outbound-reports-plan.md).
+That plan depends on this one; this one does not depend on it.
+
+Four phases, strictly additive and independently shippable:
+
+1. **Verification milters on smtp-in.** OpenDKIM in verify-only mode plus
+   OpenDMARC in monitor mode (with its built-in SPF evaluation), stamping
+   `Authentication-Results` under our authserv-id. Includes stripping
+   forged inbound `Authentication-Results` headers that claim our
+   authserv-id.
+2. **Lambda envelope surface.** Fetch and parse the header in
+   `envelope_dict()` and expose a compact `auth_results` field to both
+   clients.
+3. **React display.** Failure indicator in the envelope row, per-method
+   breakdown in the message reading view.
+4. **Apple display.** Same, through `ApiEnvelope` → `Envelope` →
+   detail view.
+
+## Goals
+
+- Every message arriving through smtp-in carries an
+  `Authentication-Results` header with SPF, DKIM, and DMARC verdicts,
+  stamped under the control-domain authserv-id.
+- A forged `Authentication-Results` header presented by the connecting
+  client cannot survive to the mailbox claiming our authserv-id.
+- The envelope payload exposes the parsed verdicts; both clients render
+  them, with a visible warning on DMARC failure and an honest
+  "not verified" state for mail that predates the feature or bypassed
+  smtp-in.
+- Zero change to mail acceptance: no new 4xx/5xx paths, no reordering or
+  delay beyond milter latency.
+
+## Non-goals
+
+- **Rejecting or quarantining mail.** Even `p=reject` senders get
+  delivered. Enforcement can be revisited once we have months of
+  observe-only data; it is out of scope here.
+- Spam scoring, content filtering, or reputation lookups (no
+  SpamAssassin, no RBLs).
+- ARC (RFC 8617) sealing or validation. Forwarded mail will often fail
+  SPF and sometimes DMARC; the UI copy should avoid implying "fail" means
+  "malicious".
+- Verifying mail that does not transit smtp-in (locally-originated mail
+  routed from smtp-out to the imap tier). It renders as "not verified".
+- Outbound aggregate report generation — see the tentative plan linked
+  above.
+
+## Current state
+
+- [`docker/templates/in-sendmail.mc`](../../docker/templates/in-sendmail.mc):
+  features are `always_add_domain`, `nouucp`, `genericstable`,
+  `mailertable`, `access_db`, `greet_pause`, `blacklist_recipients`,
+  `no_default_msa`. No milters. AUTH was deliberately removed in phase 5
+  of [`container-runtime-hardening-plan.md`](./container-runtime-hardening-plan.md).
+- [`docker/smtp-in/Dockerfile`](../../docker/smtp-in/Dockerfile): installs
+  sendmail, procmail, rsyslog, awscli, supervisor. No OpenDKIM/OpenDMARC.
+- The milter precedent lives on smtp-out:
+  `INPUT_MAIL_FILTER('opendkim', 'S=inet:8891@localhost')` in
+  [`docker/templates/out-sendmail.mc`](../../docker/templates/out-sendmail.mc),
+  configured by
+  [`docker/smtp-out/configs/opendkim.conf`](../../docker/smtp-out/configs/opendkim.conf)
+  (`Mode sv`, loopback-only `TrustedHosts` per hardening phase 5),
+  supervised alongside sendmail in
+  [`docker/smtp-out/supervisord.conf`](../../docker/smtp-out/supervisord.conf).
+- The envelope pipeline fetches a fixed header set:
+  `ENVELOPE_HEADER_FIELDS_KEY = 'BODY[HEADER.FIELDS (X-PRIORITY REFERENCES)]'`
+  ([`lambda/api/_shared/helper.py:901`](../../lambda/api/_shared/helper.py)),
+  and `envelope_dict()` (helper.py:929) builds the JSON both clients
+  consume: `id`, `date`, `subject`, `from`, `to`, `cc`, `flags`, `struct`,
+  `priority`, `message_id`, `in_reply_to`, `references`. The threading
+  fields (0.10.x) are the model for adding a new field end to end.
+- `fetch_message` already hands clients a presigned URL to the raw RFC 822
+  message; the React `ViewSourceModal` parses and displays all headers, so
+  the full `Authentication-Results` text is inspectable today once
+  stamped — this plan is about *default-UI* surfacing.
+- No `Authentication-Results` handling exists anywhere in the codebase.
+  The only DMARC code is the admin-side aggregate-report ingest.
+
+## Design
+
+### Verification must run on smtp-in
+
+SPF evaluation needs the connecting client's IP, HELO name, and envelope
+sender. Only smtp-in sees the internet peer; by the time the imap tier
+receives the message the peer is smtp-in itself. DKIM and DMARC could
+technically run anywhere, but they belong beside SPF so a single milter
+pass produces one coherent header.
+
+### Milter stack
+
+Two milters, chained in declaration order in `in-sendmail.mc`:
+
+```
+INPUT_MAIL_FILTER(`opendkim', `S=inet:8891@localhost, F=T, T=R:2m')dnl
+INPUT_MAIL_FILTER(`opendmarc', `S=inet:8893@localhost, F=T, T=R:2m')dnl
+```
+
+- **OpenDKIM, verify-only** (`Mode v`). No KeyTable/SigningTable — verify
+  mode checks signatures against the sender's published DNS keys and needs
+  no per-domain generated config, so `generate-config.sh` is untouched.
+  Stamps `Authentication-Results` with the `dkim=` verdict.
+- **OpenDMARC, monitor mode** (`RejectFailures false`,
+  `SPFSelfValidate true`). Runs after OpenDKIM, reads its
+  `Authentication-Results`, performs its own SPF check, evaluates the
+  sender's published DMARC policy including alignment, and appends the
+  `spf=` and `dmarc=` verdicts. Monitor mode never rejects; the milter's
+  verdict is `accept` for every disposition.
+- Both configured with `AuthservID` set to the control domain (rendered
+  from `__CERT_DOMAIN__` the same way the sendmail template is), so one
+  stable, spoof-checkable identifier appears in the header.
+- `F=T` (temp-fail on milter outage) is the deliberate choice over `F=`
+  (accept unfiltered): if the milters are down, mail queues at the sender
+  and retries, rather than a window of unstamped mail that renders as
+  "not verified". Sendmail's 4xx here is safe — real MTAs retry for days.
+
+DNS resolution uses the VPC resolver as everything else does; on stage,
+DNSSEC validation (docs/dnssec.md) already covers these lookups.
+
+### Header hygiene: forged Authentication-Results
+
+Anyone can send a message that already contains
+`Authentication-Results: <control-domain>; dmarc=pass ...`. If that header
+survives to the mailbox, the Lambda parser and both clients would show a
+spoofed pass. The milter stage must therefore strip inbound
+`Authentication-Results` headers before stamping. OpenDKIM's
+`RemoveARFrom` (scoped to all external hosts) is the intended mechanism —
+confirm the exact knob and semantics against the packaged version during
+implementation; if it proves insufficient, a two-line header check in the
+sendmail config or a formail pass at local delivery are the fallbacks.
+The Lambda parser additionally only trusts headers whose authserv-id
+matches the control domain exactly, as defense in depth.
+
+### The `auth_results` envelope field
+
+`envelope_dict()` gains:
+
+```json
+"auth_results": {"spf": "pass", "dkim": "pass", "dmarc": "fail"}
+```
+
+- Parsed server-side once, in helper.py, from the first
+  `Authentication-Results` header bearing the trusted authserv-id; both
+  clients get identical, pre-digested verdicts.
+- Values are the RFC 8601 result tokens as-is (`pass`, `fail`, `none`,
+  `neutral`, `softfail`, `temperror`, `permerror`, `policy`). Clients
+  bucket them (ok / warn / unknown) rather than the Lambda deciding
+  presentation.
+- Key absent per method = method not evaluated. Whole field absent or
+  `null` = no trusted header on the message (old mail, internal mail).
+  **Absent must never render as pass.**
+- Parsing is a small stdlib affair (split on `;`, `method=result` pairs);
+  no new dependency in the per-function bundles.
+
+The IMAP fetch constant becomes:
+
+```python
+ENVELOPE_HEADER_FIELDS_KEY = 'BODY[HEADER.FIELDS (X-PRIORITY REFERENCES AUTHENTICATION-RESULTS)]'
+```
+
+`fetch_message` needs no change: the reading view receives the envelope,
+and the raw source view already exposes the full header text.
+
+### Client display
+
+Three states everywhere: **verified-ok** (dmarc pass), **warning** (dmarc
+fail/permerror, or dmarc absent with spf and dkim both fail), and
+**not verified** (no data — the quiet default for pre-feature and internal
+mail). Copy for the warning state says the message *could not be
+authenticated as coming from its claimed sender* — not "dangerous" — since
+forwarding legitimately breaks these checks.
+
+- **React envelope row**
+  ([`react/admin/src/Email/Messages/Envelope.jsx`](../../react/admin/src/Email/Messages/Envelope.jsx)):
+  add a warning icon to the existing `envelope-indicators` block (beside
+  important/paperclip/reply/star) for the warning state only. Pass and
+  not-verified show nothing in the list — the row's footprint stays
+  stable and the indicator area already varies by flags.
+- **React reading view**
+  ([`react/admin/src/Email/MessageOverlay/index.jsx`](../../react/admin/src/Email/MessageOverlay/index.jsx)):
+  a compact authentication line in the header area with per-method chips
+  (SPF / DKIM / DMARC, each colored by verdict), shown in all three
+  states ("Not verified" renders muted). Links to the existing view-source
+  modal for the full header.
+- **Apple**: `ApiEnvelope`
+  ([`apple/CabalmailKit/Sources/CabalmailKit/API/ApiClientTypes.swift`](../../apple/CabalmailKit/Sources/CabalmailKit/API/ApiClientTypes.swift))
+  gains an optional `authResults` decoded with `decodeIfPresent` (the
+  `isImportant` pattern); `Envelope`
+  ([`apple/CabalmailKit/Sources/CabalmailKit/Models/Envelope.swift`](../../apple/CabalmailKit/Sources/CabalmailKit/Models/Envelope.swift))
+  carries it; `makeEnvelope(_:)` in `ApiBackedImapClient` maps it. List
+  row shows the warning-state icon; `MessageDetailView` shows the chips.
+  Old clients ignore the extra JSON field; new clients treat absence as
+  not-verified — deployable in either order.
+
+## Phase 1 — Verification milters on smtp-in
+
+- `docker/smtp-in/Dockerfile`: install `opendkim` and `opendmarc` (see
+  open questions on opendmarc packaging), `COPY` the two milter configs.
+- New `docker/smtp-in/configs/opendkim-verify.conf` (`Mode v`,
+  `Socket inet:8891@localhost`, `AuthservID __CERT_DOMAIN__`,
+  AR-stripping per header-hygiene section) and
+  `docker/smtp-in/configs/opendmarc.conf` (`RejectFailures false`,
+  `SPFSelfValidate true`, `Socket inet:8893@localhost`,
+  `AuthservID __CERT_DOMAIN__`, `IgnoreHosts` loopback). Placeholder
+  rendering in `entrypoint.sh`, same as the sendmail template.
+- `docker/templates/in-sendmail.mc`: the two `INPUT_MAIL_FILTER` lines,
+  with a comment block explaining observe-only intent, in house style.
+- `docker/smtp-in/supervisord.conf`: two new supervised programs, started
+  before sendmail.
+- CI: new `COPY` sources must be added to the `docker_smtp-in` path filter
+  in `app.yml` — `check-docker-tier-filters.sh` enforces this.
+- No task-definition change (no new env vars, ports, or volumes), so no
+  revision-marker bump needed.
+
+**Verify:** send from a well-configured external sender (Gmail) and from a
+deliberately misaligned one; confirm stamped verdicts in the delivered
+message source and in maillog on CloudWatch. Send a message pre-loaded
+with a forged `Authentication-Results` header claiming the control domain;
+confirm it is stripped. Confirm delivery latency is unchanged to within
+milter noise and no message is rejected.
+
+## Phase 2 — Lambda envelope surface
+
+- helper.py: extend `ENVELOPE_HEADER_FIELDS_KEY`, add the trusted-parse
+  helper, add `auth_results` to `envelope_dict()`. helper.py grows in
+  place (it carries a scoped `too-many-lines` disable; do not split it).
+- pylint clean; local `python -m function` smoke on `list_envelopes`.
+
+**Verify:** envelopes for newly-delivered external mail carry
+`auth_results`; pre-feature messages carry none; a message with only a
+forged (untrusted-authserv-id) header parses as absent.
+
+## Phase 3 — React display
+
+- `Envelope.jsx` indicator, `MessageOverlay` chips, shared
+  verdict-bucketing util, styles. Vitest coverage for the bucketing logic
+  and the three states.
+
+## Phase 4 — Apple display
+
+- `ApiClientTypes.swift`, `Envelope.swift`, `ApiBackedImapClient.swift`
+  mapping, list-row icon, `MessageDetailView` chips. Kit tests for
+  decoding with the field present, absent, and partial
+  (`swift test` in `apple/CabalmailKit`).
+
+## Rollback
+
+Each phase is independently revertible. Phase 1: remove the two
+`INPUT_MAIL_FILTER` lines (and supervisord programs) and redeploy the
+tier — mail flows exactly as today; already-stamped headers are inert.
+Phases 2–4 are additive field/UI changes; clients already treat the field
+as optional, so reverting any one layer strands nothing.
+
+## Acceptance
+
+- External mail shows correct verdicts in webmail and Apple clients;
+  DMARC-failing mail shows the warning indicator in both list and reading
+  views; it is still delivered.
+- Forged AR headers cannot produce a pass.
+- Pre-feature and smtp-out-originated mail shows "not verified", not pass.
+- No change in inbound acceptance behavior; CI green across app, apple,
+  and docker-filter checks.
+
+## Open questions
+
+- **Is `opendmarc` packaged for AL2023?** `opendkim` is (smtp-out installs
+  it from dnf today); AL2023 has no EPEL, and opendmarc may be absent. If
+  so: build from a pinned release tarball in a Dockerfile build stage
+  (small autotools project; pin by tag + checksum, consistent with the
+  supply-chain plan) rather than vendoring a foreign RPM.
+- Exact AR-stripping knob (`RemoveARFrom` scope semantics) on the packaged
+  OpenDKIM version — verify before relying on it; fallbacks listed above.
+- Whether the envelope-row indicator should also appear for the
+  softfail/neutral middle ground, or only hard DMARC failure. Start with
+  hard failure only; widen with observed data.

--- a/docs/tentative/dmarc-outbound-reports-plan.md
+++ b/docs/tentative/dmarc-outbound-reports-plan.md
@@ -1,0 +1,179 @@
+# Outbound DMARC Aggregate Reports (tentative)
+
+**Status:** Tentative design, not on the roadmap. Written 2026-07-05.
+Depends on
+[`docs/0.10.x/inbound-auth-verification-plan.md`](../0.10.x/inbound-auth-verification-plan.md)
+shipping first — without inbound verification there is nothing to report.
+
+## Context
+
+We participate in the DMARC reporting ecosystem in one direction only. As a
+*sender*, we publish strict policies and ingest the aggregate reports other
+receivers send us (`lambda/api/process_dmarc` → `cabal-dmarc-reports` →
+admin Dmarc view). As a *receiver*, we send nothing: domains whose mail we
+accept never learn how their messages authenticated at our MX.
+
+Once the inbound verification plan lands, smtp-in evaluates SPF/DKIM/DMARC
+on every inbound message. This plan closes the loop: accumulate those
+per-message verdicts per sending domain, and once a day emit an RFC 7489
+aggregate report to each domain's published `rua=` address, exactly as
+Google and Microsoft do for us.
+
+**Honest value assessment:** we are a small MX. Our reports will be tiny
+and go mostly to large senders who will barely notice them. The reasons to
+do it anyway: it is correct ecosystem citizenship; the reports become
+genuinely useful to any smaller correspondent domain debugging its DMARC
+rollout; and the marginal cost on top of the verification plan is one
+DynamoDB table, one shipper daemon, and one Lambda. If that trade ever
+stops looking worthwhile, this doc stays tentative.
+
+## Goals
+
+- Every domain that (a) sent us mail through smtp-in during a UTC day and
+  (b) publishes a valid `rua=` destination receives one aggregate report
+  for that day, spec-compliant enough that the big receivers' pipelines
+  accept it (gzip XML, correct filename, correct subject, external
+  destination verification honored).
+- Report generation is idempotent per (domain, day) — a retried Lambda run
+  never double-sends.
+- The pipeline has a heartbeat and a runbook, mirroring the ingest side
+  (`docs/operations/runbooks/heartbeat-dmarc-ingest.md`).
+
+## Non-goals
+
+- Forensic/failure reports (`ruf=`). Privacy-sensitive, rarely consumed,
+  and a per-message real-time pipeline is a different shape of system.
+- Honoring `ri=` intervals other than daily. RFC 7489 explicitly blesses
+  a fixed daily cadence.
+- Reporting on mail that did not transit smtp-in.
+- Any change to inbound mail handling — this is a read-side consumer of
+  the verification plan's output.
+
+## Design
+
+### Capture: OpenDMARC history file + per-task shipper
+
+OpenDMARC (running in monitor mode per the verification plan) can write a
+per-message **history file**: an append-only record of exactly the fields
+an aggregate report row needs (source IP, header-from, envelope-from,
+SPF/DKIM/DMARC results and alignment, the sender's published policy,
+disposition). This is the purpose-built capture point — richer than
+anything reconstructable from maillog — but it is a local file, and
+smtp-in is a multi-task ECS service with stateless containers.
+
+Resolution: a small **shipper daemon** in the smtp-in container
+(supervisord program, same idiom as `docker/shared/reconfigure.sh`) that
+every ~10 minutes rotates the history file, parses the completed slice,
+and folds it into DynamoDB with `UpdateItem`/`ADD` counter increments.
+Properties:
+
+- **Multi-task safe.** Each task ships only its own slice; `ADD` merges
+  concurrent writers without coordination.
+- **Restart-tolerant.** A dying container loses at most the unshipped
+  ~10-minute window. Aggregate reports are best-effort counts; the spec
+  has no exactness requirement, and every large operator loses slices the
+  same way.
+- **No new movable parts on the mail path.** The milter writes locally;
+  shipping is fully asynchronous.
+
+Rejected alternatives: parsing CloudWatch maillog (opendmarc's syslog
+lines don't carry full row fidelity — alignment detail and published
+policy are missing) and mounting the history file on EFS (shared-write
+append from multiple tasks to one file is exactly the failure mode the
+stateless design avoids).
+
+**IAM note:** the smtp-in task role today only *reads* config state
+(`cabal-addresses` via `generate-config.sh`). Writing to the new stats
+table is a new permission — a real IAM delta, so this routes through
+stage, never direct-to-prod scaffolding.
+
+### Table: `cabal-dmarc-outbound-stats`
+
+Sibling of `cabal-dmarc-reports` in
+[`terraform/infra/modules/table/main.tf`](../../terraform/infra/modules/table/main.tf):
+
+- `pk` (S): `<policy-domain>#<YYYY-MM-DD>` (UTC day of receipt)
+- `sk` (S): `<source-ip>#<disposition>#<dkim-aligned>#<spf-aligned>` — the
+  RFC 7489 `<record>` grouping key
+- `count` (N): incremented via `ADD`
+- Published-policy attributes observed at evaluation time (`p`, `sp`,
+  `adkim`, `aspf`, `pct`) and representative per-method auth detail
+  (dkim domain/selector/result, spf domain/scope/result) — set once per
+  row, `if_not_exists`
+- `report_sent` (S): report-id, written by the generator for idempotency
+- `expires_at` (N): TTL, ~14 days (the `cabal-rate-limits` pattern)
+
+Volume is bounded by inbound mail volume × distinct (ip, verdict) tuples
+per domain — for this MX, trivially within on-demand pricing noise.
+
+### Generator: `lambda/api/generate_dmarc_reports`
+
+EventBridge-scheduled daily (shortly after 00:00 UTC, generating for the
+previous UTC day) — the `process_dmarc` orchestration pattern. Per policy
+domain with rows for the day:
+
+1. **Discover destinations.** Fresh DNS TXT lookup of
+   `_dmarc.<policy-domain>`; parse `rua=` mailto URIs (cap at 2
+   destinations, per spec allowance to limit). No record or no `rua=` →
+   skip silently; that's the common case and not an error.
+2. **External destination verification.** Where the `rua` address's
+   domain differs from the policy domain, require the
+   `<policy-domain>._report._dmarc.<destination-domain>` TXT
+   authorization record (RFC 7489 §7.1). Skipping this check produces
+   reports that compliant receivers discard — it is not optional.
+   Honor a `!10m`-style size suffix if present (our reports are far
+   smaller in practice).
+3. **Build.** RFC 7489 Appendix C XML: `report_metadata` (org = control
+   domain, contact = `dmarc-reports@mail-admin.<first-mail-domain>`,
+   report-id, epoch date range), `policy_published` from the stored
+   attributes, one `<record>` per sk row. Gzip. Filename
+   `<control-domain>!<policy-domain>!<begin>!<end>.xml.gz`; subject
+   `Report Domain: <policy-domain> Submitter: <control-domain>
+   Report-ID: <report-id>`.
+4. **Send.** SMTP submission through smtp-out as the existing `dmarc`
+   system account, from `dmarc-reports@mail-admin.<first-mail-domain>`
+   (the address already provisioned by
+   [`terraform/infra/modules/app/dmarc_user.tf`](../../terraform/infra/modules/app/dmarc_user.tf)
+   with full MX/SPF/DKIM/DMARC — our reports authenticate cleanly at the
+   receiving end). How the Lambda authenticates to Dovecot submission as
+   a system account is the main implementation detail to pin down:
+   master-user credentials from SSM (the IMAP-side pattern) if Dovecot's
+   submission service honors them, else a dedicated SSM-stored password
+   for the `dmarc` account.
+5. **Mark sent.** Write `report_sent = <report-id>` on the day's rows
+   (conditional on absence) before SMTP; a retried run skips marked
+   domains. Crash-between-mark-and-send loses one domain-day rather than
+   double-sending — the right side to err on.
+
+### Monitoring
+
+Healthchecks heartbeat ping per run (the `process_dmarc` pattern), a
+`heartbeat-dmarc-outbound.md` runbook, and structured per-domain
+sent/skipped/failed counts in the Lambda log
+(`/cabal/lambda/generate_dmarc_reports`).
+
+## Phases
+
+1. **Capture + table.** History file config on smtp-in, shipper daemon,
+   `cabal-dmarc-outbound-stats` table, task-role write grant. Verifiable
+   on stage by inspecting table rows after sending test mail — no reports
+   leave the system yet.
+2. **Generator + delivery.** The Lambda, its Terraform (role, schedule,
+   SSM access), first live sends on stage. Stage receives real inbound
+   mail from Google et al., so destinations are real: keep stage's
+   schedule disabled by default and fire manual test runs against a
+   single allowlisted domain first.
+3. **Ops.** Heartbeat, runbook, and (optional, symmetric with ingest) a
+   "reports we sent" tab in the admin Dmarc view reading the marked rows.
+
+## Open questions
+
+- OpenDMARC history-file record format stability across versions — parse
+  defensively; the shipper should skip-and-log unknown record types.
+- Whether Dovecot submission accepts master-user auth (determines step 4
+  above).
+- Whether to include our own domains' inbound mail (mail from one
+  cabalmail user to another arrives via smtp-out→imap, not smtp-in, so in
+  practice this is moot unless routing changes).
+- Whether the admin view in phase 3 is worth building before anyone asks
+  for it.


### PR DESCRIPTION
## Summary

Two forward-looking plan docs for making Cabalmail a DMARC-participating *receiver*:

- **`docs/0.10.x/inbound-auth-verification-plan.md`** — observe-only SPF/DKIM/DMARC verification on smtp-in (OpenDKIM verify mode + OpenDMARC monitor mode with `SPFSelfValidate`), stamping `Authentication-Results` under the control-domain authserv-id, stripping forged AR headers, and surfacing verdicts to end users end to end: `envelope_dict()` → React envelope row + reading view → Apple `ApiEnvelope`/`Envelope`. **No mail is rejected** regardless of sender policy; three display states (ok / warning / not-verified) with absent-never-renders-as-pass as an invariant.

- **`docs/tentative/dmarc-outbound-reports-plan.md`** — RFC 7489 aggregate report generation: OpenDMARC history-file capture shipped per-task into a new `cabal-dmarc-outbound-stats` table (`ADD`-merged, multi-task safe), plus a daily `generate_dmarc_reports` Lambda handling `rua=` discovery, external destination verification (§7.1), XML/gzip/filename/subject conventions, idempotent send-marking, and delivery via smtp-out from the existing `dmarc-reports@mail-admin.*` address. Tentative per the docs convention; depends on the verification plan.

Docs only — no code, infra, or behavior changes; no changelog fragment since nothing ships.

## Notes for review

- Key open question flagged in the 0.10.x plan: whether `opendmarc` is packaged for AL2023 (no EPEL). Fallback is a pinned-tarball source build.
- The verification plan chooses `F=T` (temp-fail when milters are down) over accept-unfiltered — worth a deliberate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)