### PR TITLE
Inbound auth verification phase 1: observe-only milters on smtp-in

### DIFF
--- a/changelog.d/inbound-auth-verification.added.md
+++ b/changelog.d/inbound-auth-verification.added.md
@@ -1,0 +1,7 @@
+- Inbound mail is now verified against the sender's SPF, DKIM, and DMARC
+  records at the smtp-in relay (OpenDKIM in verify mode plus OpenDMARC in
+  monitor mode, built from source for AL2023). Verdicts are stamped as an
+  `Authentication-Results` header under the control-domain authserv-id,
+  and forged inbound headers claiming that authserv-id are stripped.
+  Observe-only: no message is rejected or quarantined regardless of the
+  sender's published policy.

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -187,7 +187,23 @@ if [ "$TIER" = "smtp-in" ]; then
     || echo "[entrypoint] WARN hosts-pin init returned non-zero; daemon will converge the pin"
 fi
 
-# ── Step 8: Sendmail preparation (smtp tiers only) ────────────
+# ── Step 8: Render inbound-auth milter configs (smtp-in only) ─
+# opendkim (verify mode) and opendmarc (monitor mode) stamp
+# Authentication-Results on inbound mail under the control-domain
+# authserv-id (phase 1 of docs/0.10.x/inbound-auth-verification-plan.md).
+# The config templates carry __CERT_DOMAIN__ placeholders; render them
+# the same way prepare-sendmail.sh renders sendmail.mc. Render only, no
+# chown: smtp-in's task definition drops CHOWN, so all ownership is set
+# at image build time (see docker/smtp-in/Dockerfile).
+if [ "$TIER" = "smtp-in" ]; then
+  echo "[entrypoint] Rendering inbound-auth milter configs..."
+  for _milter in opendkim opendmarc; do
+    sed "s/__CERT_DOMAIN__/${CERT_DOMAIN}/g" \
+      "/etc/${_milter}.conf.template" > "/etc/${_milter}.conf"
+  done
+fi
+
+# ── Step 9: Sendmail preparation (smtp tiers only) ────────────
 # Render sendmail.mc, generate maps from DynamoDB, compile sendmail.cf,
 # and (on imap) assemble aliases. On the smtp tiers sendmail is the
 # front-line listener, so this stays synchronous. On imap it is deferred
@@ -199,7 +215,7 @@ if [ "$TIER" != "imap" ]; then
   /usr/local/bin/prepare-sendmail.sh once
 fi
 
-# ── Step 9: Pre-flight mode (deploy validation) ───────────────
+# ── Step 10: Pre-flight mode (deploy validation) ──────────────
 # PREFLIGHT=1 is overlaid by the deploy pipeline's one-shot RunTask
 # (deploy-ecs-service.sh) to exercise this entrypoint - secrets, EFS
 # mount, Cognito, DynamoDB, sendmail compile - against a new image
@@ -216,6 +232,6 @@ if [ "${PREFLIGHT:-0}" = "1" ]; then
   exit 0
 fi
 
-# ── Step 10: Start services via supervisord ───────────────────
+# ── Step 11: Start services via supervisord ───────────────────
 echo "[entrypoint] Starting services via supervisord..."
 exec /usr/local/bin/supervisord -c /etc/supervisord.conf

--- a/docker/smtp-in/Dockerfile
+++ b/docker/smtp-in/Dockerfile
@@ -1,8 +1,45 @@
+# ── Builder stage: OpenDMARC from source ─────────────────────────────
+# AL2023 does not package opendmarc (confirmed against the core repo
+# metadata, 2026-07-05; opendkim IS packaged) and the OpenDMARC project
+# publishes no dist tarballs, only release tags, so this compiles the
+# pinned tag archive with autotools. libspf2 is also not packaged for
+# AL2023, so --with-spf enables OpenDMARC's internal SPF implementation
+# (consumed via SPFSelfValidate in opendmarc.conf). Phase 1 of
+# docs/0.10.x/inbound-auth-verification-plan.md.
+FROM amazonlinux:2023@sha256:32f61af6a24e178e8142fb7b0079f4af3a5cda6816cd53d2c611a921ef029ca0 AS opendmarc-build
+
+RUN dnf install -y \
+      gcc make autoconf automake libtool \
+      sendmail-milter-devel \
+      tar gzip \
+    && dnf clean all
+
+# Pin by tag + checksum of the GitHub tag archive (supply-chain plan
+# style). A checksum mismatch fails the build loudly.
+ARG OPENDMARC_TAG=rel-opendmarc-1-4-2
+ARG OPENDMARC_SHA256=ee1dcdd158fd5fd2b16de2b86980c4a4be60a070641ca19591a713da4e4008bb
+
+RUN curl -fsSL -o /tmp/opendmarc.tar.gz \
+      "https://github.com/trusteddomainproject/OpenDMARC/archive/refs/tags/${OPENDMARC_TAG}.tar.gz" \
+    && echo "${OPENDMARC_SHA256}  /tmp/opendmarc.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/opendmarc.tar.gz -C /tmp \
+    && cd "/tmp/OpenDMARC-${OPENDMARC_TAG}" \
+    && autoreconf -fiv \
+    && ./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib64 \
+         --with-spf --with-milter=/usr \
+    && make \
+    && make DESTDIR=/stage install
+
+# ── Runtime stage ─────────────────────────────────────────────────────
 FROM amazonlinux:2023@sha256:32f61af6a24e178e8142fb7b0079f4af3a5cda6816cd53d2c611a921ef029ca0
 
-# System packages
+# System packages. opendkim runs in verify-only mode as the first
+# inbound-auth milter; sendmail-milter provides the libmilter shared
+# library the source-built opendmarc links against.
 RUN dnf install -y \
       sendmail sendmail-cf \
+      sendmail-milter \
+      opendkim \
       procmail \
       rsyslog \
       make \
@@ -15,8 +52,25 @@ RUN dnf install -y \
     && sed -i 's/^UID_MAX.*/UID_MAX                 2147483647/' /etc/login.defs \
     && sed -i 's/^GID_MAX.*/GID_MAX                 2147483647/' /etc/login.defs
 
+# OpenDMARC binary + library from the builder stage (opendmarc-check and
+# the perl reporting tools are deliberately not copied), plus a service
+# account and runtime dir. Ownership is set here at build time: the
+# smtp-in task definition drops CHOWN, so the entrypoint cannot chown.
+COPY --from=opendmarc-build /stage/usr/sbin/opendmarc /usr/sbin/opendmarc
+COPY --from=opendmarc-build /stage/usr/lib64/ /usr/lib64/
+RUN groupadd -r opendmarc \
+    && useradd -r -g opendmarc -s /sbin/nologin -d /var/tmp opendmarc \
+    && install -d -o opendmarc -g opendmarc /var/run/opendmarc
+
 # Sendmail .mc template (placeholder for cert domain)
 COPY templates/in-sendmail.mc               /etc/mail/sendmail.mc.template
+
+# Inbound-auth milter config templates (rendered by entrypoint.sh, which
+# substitutes __CERT_DOMAIN__ the same way prepare-sendmail.sh renders
+# sendmail.mc) and the opendmarc connection-ignore list.
+COPY smtp-in/configs/opendkim.conf          /etc/opendkim.conf.template
+COPY smtp-in/configs/opendmarc.conf         /etc/opendmarc.conf.template
+COPY smtp-in/configs/opendmarc.ignore.hosts /etc/opendmarc.ignore.hosts
 
 # Sendmail service switch: consult /etc/hosts before DNS so the
 # hosts-pin.sh IMAP pin is honored (see docker/shared/hosts-pin.sh).

--- a/docker/smtp-in/configs/opendkim.conf
+++ b/docker/smtp-in/configs/opendkim.conf
@@ -1,0 +1,24 @@
+# OpenDKIM in verify-only mode on the inbound relay. Phase 1 of
+# docs/0.10.x/inbound-auth-verification-plan.md: stamps the dkim=
+# verdict into Authentication-Results for opendmarc (and ultimately the
+# clients) to consume. No KeyTable/SigningTable — verify mode checks
+# signatures against the sender's published DNS keys and signs nothing,
+# so generate-config.sh is not involved. __CERT_DOMAIN__ is rendered by
+# entrypoint.sh at startup.
+AutoRestart Yes
+AutoRestartRate 10/1h
+pidFile /var/run/opendkim/opendkim.pid
+Mode v
+Syslog yes
+SyslogSuccess yes
+LogWhy Yes
+UserID opendkim:opendkim
+Socket inet:8891@localhost
+Umask 002
+AuthservID __CERT_DOMAIN__
+# Strip inbound Authentication-Results headers that claim our
+# authserv-id before stamping fresh ones: without this, a sender could
+# pre-load a forged "dmarc=pass" header that the Lambda parser and the
+# clients would trust. RemoveARFrom matches the authserv-id named in the
+# header field, not the connecting host.
+RemoveARFrom __CERT_DOMAIN__

--- a/docker/smtp-in/configs/opendmarc.conf
+++ b/docker/smtp-in/configs/opendmarc.conf
@@ -1,0 +1,24 @@
+# OpenDMARC in monitor mode on the inbound relay. Phase 1 of
+# docs/0.10.x/inbound-auth-verification-plan.md: evaluates the sender's
+# published DMARC policy — reading the dkim= verdict opendkim stamped
+# (TrustedAuthservIDs) and performing its own SPF check
+# (SPFSelfValidate; the binary is built --with-spf because libspf2 is
+# not packaged for AL2023) — then appends spf= and dmarc= to
+# Authentication-Results. Observe-only: RejectFailures false means every
+# disposition is accept. The finding is surfaced to the user by the
+# clients, never enforced here. __CERT_DOMAIN__ is rendered by
+# entrypoint.sh at startup.
+AuthservID __CERT_DOMAIN__
+TrustedAuthservIDs __CERT_DOMAIN__
+AutoRestart true
+AutoRestartRate 10/1h
+PidFile /var/run/opendmarc/opendmarc.pid
+Syslog true
+UserID opendmarc:opendmarc
+Socket inet:8893@localhost
+UMask 002
+SPFSelfValidate true
+SPFIgnoreResults true
+RejectFailures false
+FailureReports false
+IgnoreHosts /etc/opendmarc.ignore.hosts

--- a/docker/smtp-in/configs/opendmarc.ignore.hosts
+++ b/docker/smtp-in/configs/opendmarc.ignore.hosts
@@ -1,0 +1,4 @@
+# Connections opendmarc skips entirely: loopback only (sendmail's local
+# submissions and health probes; never internet mail).
+127.0.0.1
+::1

--- a/docker/smtp-in/supervisord.conf
+++ b/docker/smtp-in/supervisord.conf
@@ -35,6 +35,27 @@ startsecs=5
 stopwaitsecs=15
 priority=10
 
+# Inbound-auth verification milters, observe-only (phase 1 of
+# docs/0.10.x/inbound-auth-verification-plan.md). Start order relative
+# to sendmail is not load-bearing: sendmail's F=T milter flag tempfails
+# inbound mail while a socket is down, so autorestart here plus sender
+# retries cover any gap.
+[program:opendkim]
+command=/usr/sbin/opendkim -f -x /etc/opendkim.conf
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+autorestart=true
+priority=20
+
+[program:opendmarc]
+command=/usr/sbin/opendmarc -f -c /etc/opendmarc.conf
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+autorestart=true
+priority=21
+
 [program:reconfigure]
 command=/usr/local/bin/reconfigure.sh
 stdout_logfile=/dev/fd/1

--- a/docker/templates/in-sendmail.mc
+++ b/docker/templates/in-sendmail.mc
@@ -62,5 +62,16 @@ FEATURE(`greet_pause', 5000)dnl
 FEATURE(`blacklist_recipients')dnl
 FEATURE(`no_default_msa')dnl
 DAEMON_OPTIONS(`Name=MTA')dnl
+dnl Observe-only inbound authentication (phase 1 of
+dnl docs/0.10.x/inbound-auth-verification-plan.md): opendkim (verify
+dnl mode) then opendmarc (monitor mode) stamp Authentication-Results
+dnl under the control-domain authserv-id. Declaration order matters -
+dnl opendmarc reads the dkim= verdict opendkim stamped. Neither milter
+dnl rejects (opendmarc runs RejectFailures false, so every disposition
+dnl is accept). F=T tempfails inbound mail while a milter is down -
+dnl real MTAs queue and retry for days - rather than delivering
+dnl unstamped mail that would render as "not verified" in the clients.
+INPUT_MAIL_FILTER(`opendkim', `S=inet:8891@localhost, F=T, T=R:2m')dnl
+INPUT_MAIL_FILTER(`opendmarc', `S=inet:8893@localhost, F=T, T=R:2m')dnl
 MAILER(procmail)dnl
 MAILER(smtp)dnl

--- a/docs/0.10.x/inbound-auth-verification-plan.md
+++ b/docs/0.10.x/inbound-auth-verification-plan.md
@@ -289,11 +289,14 @@ as optional, so reverting any one layer strands nothing.
 
 ## Open questions
 
-- **Is `opendmarc` packaged for AL2023?** `opendkim` is (smtp-out installs
-  it from dnf today); AL2023 has no EPEL, and opendmarc may be absent. If
-  so: build from a pinned release tarball in a Dockerfile build stage
-  (small autotools project; pin by tag + checksum, consistent with the
-  supply-chain plan) rather than vendoring a foreign RPM.
+- ~~Is `opendmarc` packaged for AL2023?~~ **Resolved (2026-07-05): it is
+  not** (confirmed against the AL2023 core repo metadata; `opendkim`,
+  `sendmail-milter-devel`, and the autotools chain are packaged; `libspf2`
+  is not). The smtp-in image builds OpenDMARC from the pinned
+  `rel-opendmarc-1-4-2` tag archive (checksum-verified; the project
+  publishes no dist tarballs) in a Dockerfile builder stage, configured
+  `--with-spf` for the internal SPF implementation, and copies the binary
+  and library into the runtime image.
 - Exact AR-stripping knob (`RemoveARFrom` scope semantics) on the packaged
   OpenDKIM version — verify before relying on it; fallbacks listed above.
 - Whether the envelope-row indicator should also appear for the


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/0.10.x/inbound-auth-verification-plan.md`](https://github.com/cabalmail/cabal-infra/blob/stage/docs/0.10.x/inbound-auth-verification-plan.md): smtp-in verifies SPF/DKIM/DMARC on inbound mail and stamps `Authentication-Results` under the control-domain authserv-id. **Observe-only** — OpenDMARC runs in monitor mode (`RejectFailures false`); no message is rejected or quarantined regardless of the sender's published policy.

- **OpenDMARC built from source**: not packaged for AL2023 (confirmed against the core repo metadata, and no dist tarballs exist upstream), so a Dockerfile builder stage compiles the pinned `rel-opendmarc-1-4-2` tag archive (sha256-verified) with `--with-spf` (libspf2 is also unpackaged; internal SPF engine used via `SPFSelfValidate`).
- **OpenDKIM verify-only** (`Mode v`, dnf-packaged): no signing tables, no `generate-config.sh` involvement. `RemoveARFrom` strips forged inbound AR headers claiming our authserv-id before fresh ones are stamped.
- **Milter chain in `in-sendmail.mc`**: opendkim → opendmarc (order matters; opendmarc reads the `dkim=` verdict via `TrustedAuthservIDs`). `F=T` tempfails while a milter is down — senders queue and retry — rather than delivering unstamped mail.
- **Hardening posture respected**: both milters loopback-only; ownership set at image build time because smtp-in's task definition drops `CHOWN`; the retained `SETUID`/`SETGID` cover the milters' privilege drop. No task-definition changes.

## Verification

- `check-docker-tier-filters.sh` passes (new configs covered by `docker/smtp-in/**`); `bash -n` on entrypoint.sh.
- Image build not run locally (no container runtime on this box) — CI's docker job on stage is the first real build. Rollout failure leaves the old task serving.
- On stage, per the plan's acceptance checks: confirm stamped verdicts on external mail (Gmail + a misaligned sender), confirm a pre-loaded forged `Authentication-Results` header is stripped, confirm no rejections.

Phase 2 (Lambda envelope surfacing) follows once stamping is confirmed on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)