### PR TITLE
Add third-party Acknowledgements screen to the Apple apps

### DIFF
--- a/apple/Cabalmail/Views/AcknowledgementsView.swift
+++ b/apple/Cabalmail/Views/AcknowledgementsView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import CabalmailKit
+
+/// Settings ▸ About ▸ Acknowledgements. Lists the third-party open-source
+/// components bundled into the app and reproduces each one's license text in
+/// full, satisfying the attribution terms that attach because the app is
+/// distributed through the App Store.
+///
+/// The data comes from `CabalmailKit.Acknowledgements`, which owns the
+/// bundled license resources; this view only presents it. It mirrors the
+/// React admin app's "Third-party notices" section, which does the same for
+/// the web client's bundled dependencies.
+struct AcknowledgementsView: View {
+    private let components = Acknowledgements.bundledComponents()
+
+    var body: some View {
+        Form {
+            Section {
+                Text(
+                    "The Cabalmail app bundles the open-source components below into its "
+                    + "rich-text composer. Each component's copyright and license notice is "
+                    + "reproduced in full to satisfy the license's attribution requirements."
+                )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(components) { component in
+                Section {
+                    LabeledContent("License", value: component.license)
+                    Link(destination: URL(string: component.url)!) {
+                        Label("Project home", systemImage: "arrow.up.right.square")
+                    }
+                    DisclosureGroup("License text") {
+                        Text(licenseText(for: component))
+                            .font(.system(.footnote, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                } header: {
+                    Text(component.name)
+                } footer: {
+                    Text(component.summary)
+                }
+            }
+        }
+        #if os(macOS)
+        .formStyle(.grouped)
+        #endif
+        .navigationTitle("Acknowledgements")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    /// Falls back to a clear message rather than an empty pane when the
+    /// vendored license resource is missing (a local build that skipped
+    /// `sync-vendored.sh`). Production and CI builds always run it.
+    private func licenseText(for component: ThirdPartyComponent) -> String {
+        component.licenseText.isEmpty
+            ? "License text is unavailable in this build. See \(component.url)."
+            : component.licenseText
+    }
+}

--- a/apple/Cabalmail/Views/SettingsView.swift
+++ b/apple/Cabalmail/Views/SettingsView.swift
@@ -72,7 +72,7 @@ struct SettingsView: View {
             actionsSection(bindable: preferences)
             appearanceSection(bindable: preferences)
             diagnosticsSection(bindable: preferences)
-            aboutSection
+            AboutSettingsSection()
         }
         #if os(macOS)
         .formStyle(.grouped)
@@ -226,19 +226,6 @@ struct SettingsView: View {
         }
     }
 
-    @ViewBuilder
-    private var aboutSection: some View {
-        Section("About") {
-            LabeledContent("Version", value: Self.marketingVersion)
-            LabeledContent("Build", value: Self.buildNumber)
-            Link(
-                destination: URL(string: "https://github.com/cabalmail/cabal-infra/issues")!
-            ) {
-                Label("Report an issue", systemImage: "arrow.up.right.square")
-            }
-        }
-    }
-
     // MARK: - Bindings
 
     /// Wraps the `defaultFromAddress` preference for the picker, with a
@@ -294,8 +281,29 @@ struct SettingsView: View {
             }
         }
     }
+}
 
-    // MARK: - About values
+/// About block for the Settings form: app version/build, the third-party
+/// Acknowledgements screen, and an issue-report link. Extracted from
+/// `SettingsView` so that view's body stays within the type-body-length
+/// budget; it holds no state of its own.
+private struct AboutSettingsSection: View {
+    var body: some View {
+        Section("About") {
+            LabeledContent("Version", value: Self.marketingVersion)
+            LabeledContent("Build", value: Self.buildNumber)
+            NavigationLink {
+                AcknowledgementsView()
+            } label: {
+                Label("Acknowledgements", systemImage: "doc.text")
+            }
+            Link(
+                destination: URL(string: "https://github.com/cabalmail/cabal-infra/issues")!
+            ) {
+                Label("Report an issue", systemImage: "arrow.up.right.square")
+            }
+        }
+    }
 
     private static var marketingVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String

--- a/apple/CabalmailKit/Sources/CabalmailKit/Acknowledgements.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Acknowledgements.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A third-party open-source component bundled into the Apple clients,
+/// paired with the license text that must ship alongside it.
+///
+/// The Apple app is distributed through the App Store, so the permissive
+/// attribution terms of its bundled dependencies genuinely attach — unlike
+/// the server-side Docker/Lambda artifacts, which are built and run only on
+/// our own infrastructure and convey no copies to third parties.
+/// `CabalmailKit` has no third-party Swift dependencies; the only bundled
+/// third-party code is the pair of JavaScript libraries vendored into the
+/// rich-text composer's `WKWebView` (see `apple/scripts/sync-vendored.sh`).
+public struct ThirdPartyComponent: Identifiable, Sendable {
+    public var id: String { name }
+
+    /// Human-readable component name, e.g. `"marked"`.
+    public let name: String
+
+    /// One-line description of what the component does and why it ships.
+    public let summary: String
+
+    /// SPDX license identifier, e.g. `"MIT"`.
+    public let license: String
+
+    /// Upstream project home page.
+    public let url: String
+
+    /// Full license text exactly as published upstream, loaded from the
+    /// bundled `*-LICENSE` resource. Empty only when the vendored resource
+    /// is absent — a local build that skipped `sync-vendored.sh`; CI and
+    /// release builds always run it.
+    public let licenseText: String
+}
+
+/// Third-party attribution surfaced in the app's Settings ▸ About ▸
+/// Acknowledgements screen. Mirrors the React admin app's "Third-party
+/// notices" section, which does the same for the web client's bundle.
+public enum Acknowledgements {
+    /// The open-source components bundled into the shipped app, each with
+    /// its full upstream license text. Order is fixed for stable display.
+    public static func bundledComponents() -> [ThirdPartyComponent] {
+        [
+            ThirdPartyComponent(
+                name: "marked",
+                summary: "Markdown parser powering the rich-text composer.",
+                license: "MIT",
+                url: "https://github.com/markedjs/marked",
+                licenseText: licenseText(resource: "marked-LICENSE", extension: "md")
+            ),
+            ThirdPartyComponent(
+                name: "turndown",
+                summary: "HTML-to-Markdown converter powering the rich-text composer.",
+                license: "MIT",
+                url: "https://github.com/mixmark-io/turndown",
+                licenseText: licenseText(resource: "turndown-LICENSE", extension: nil)
+            ),
+        ]
+    }
+
+    /// Loads a vendored license file from the bundle. The composer resources
+    /// land under the `Resources` subdirectory via `.copy("Compose/Resources")`
+    /// in `Package.swift` — the same location `RichTextEditorController`
+    /// loads `editor.html` from.
+    private static func licenseText(resource: String, extension ext: String?) -> String {
+        guard
+            let url = Bundle.module.url(
+                forResource: resource,
+                withExtension: ext,
+                subdirectory: "Resources"
+            ),
+            let text = try? String(contentsOf: url, encoding: .utf8)
+        else {
+            return ""
+        }
+        return text
+    }
+}

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/AcknowledgementsTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/AcknowledgementsTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import CabalmailKit
+
+final class AcknowledgementsTests: XCTestCase {
+    func testBundlesMarkedAndTurndown() {
+        let names = Set(Acknowledgements.bundledComponents().map(\.name))
+        XCTAssertTrue(names.contains("marked"))
+        XCTAssertTrue(names.contains("turndown"))
+    }
+
+    func testEveryComponentCarriesItsBundledLicenseText() {
+        for component in Acknowledgements.bundledComponents() {
+            XCTAssertEqual(component.license, "MIT", "\(component.name) license id")
+            XCTAssertFalse(
+                component.licenseText.isEmpty,
+                "\(component.name) is missing its bundled license text — did sync-vendored.sh run?"
+            )
+            // The MIT grant clause is present in both vendored license files
+            // (marked's also carries the original Markdown BSD notice, which
+            // rides along in the same reproduced text).
+            XCTAssertTrue(
+                component.licenseText.contains("Permission is hereby granted"),
+                "\(component.name) license text does not look like the MIT license"
+            )
+        }
+    }
+}

--- a/changelog.d/apple-acknowledgements.added.md
+++ b/changelog.d/apple-acknowledgements.added.md
@@ -1,0 +1,6 @@
+- Added a Settings → About → Acknowledgements screen to the iOS and macOS
+  apps that reproduces, in full, the MIT license texts for the bundled
+  `marked` and `turndown` JavaScript libraries the rich-text composer
+  ships. These attribution terms attach because the app is distributed
+  through the App Store, unlike the server-side images that run only on
+  our own infrastructure.


### PR DESCRIPTION
## What

Adds **Settings → About → Acknowledgements** to the iOS and macOS apps. It
lists the third-party open-source components bundled into the app and
reproduces each one's license text in full.

Only two components qualify: the **`marked`** and **`turndown`** JavaScript
libraries (both MIT) vendored into the rich-text composer's `WKWebView`.
`CabalmailKit` itself has zero third-party Swift dependencies.

## Why

The Apple app is **distributed** through the App Store, so the permissive
attribution terms of its bundled dependencies genuinely attach — unlike the
server-side Docker images and Lambda zips, which are built and run only on
our own infrastructure and convey no copies to third parties. This is the
Apple-side equivalent of the React admin app's existing "Third-party
notices" section.

## How

- `CabalmailKit` gains a public `Acknowledgements.bundledComponents()` that
  loads the already-vendored `marked-LICENSE.md` / `turndown-LICENSE`
  resources from its bundle (materialized by `scripts/sync-vendored.sh`,
  same mechanism as the composer JS).
- `AcknowledgementsView` (shared by both app targets via `Cabalmail/Views/`)
  renders the list with per-component collapsible full license text.
- The About block was extracted out of `SettingsView` into its own
  `AboutSettingsSection` so the view body stays under the
  `type_body_length` cap.

## Verification

- New `AcknowledgementsTests` (Kit): asserts both components are present and
  each carries non-empty MIT license text. **Full Kit suite: 291 passed, 0
  failures.**
- **iOS and macOS app targets both build** (`xcodebuild ... BUILD SUCCEEDED`).
- **swiftlint clean** on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)