### PR TITLE
Preserve client IP on the SMTP relay target group

### DIFF
--- a/changelog.d/relay-preserve-client-ip.fixed.md
+++ b/changelog.d/relay-preserve-client-ip.fixed.md
@@ -1,0 +1,5 @@
+- Inbound SMTP connections now reach smtp-in with the real client
+  address (NLB client IP preservation on the relay target group). SPF
+  had been evaluated against the load balancer's own ENI and failed for
+  every external sender; sendmail's connection-rate throttle and access
+  map likewise treated all inbound mail as one client.

--- a/docs/0.10.x/inbound-auth-verification-plan.md
+++ b/docs/0.10.x/inbound-auth-verification-plan.md
@@ -245,6 +245,27 @@ with a forged `Authentication-Results` header claiming the control domain;
 confirm it is stripped. Confirm delivery latency is unchanged to within
 milter noise and no message is rejected.
 
+#### Phase 1 stage finding (2026-07-05) — NLB client IP preservation
+
+First stage test (known-good prod sender): `dkim=pass`, `dmarc=pass` (via
+DKIM alignment), but `spf=fail` on every message. The `Received:` line
+smtp-in wrote named the peer as an ip-10-64-x address — the stage NLB's
+own ENI. NLB client IP preservation is **disabled by default for ip-type
+TCP target groups**, so sendmail's peer was the load balancer, and
+opendmarc evaluated the sender's SPF record against the NLB's private
+address. The sending side was verified correct (prod's SPF publishes
+exactly its NAT EIPs).
+
+Fix: `preserve_client_ip = "true"` on the **relay target group only**
+(`terraform/infra/modules/ecs/locals.tf`). No SG change rides along —
+smtp-in already allows 25 from `0.0.0.0/0`. The imap TG must keep the
+default: the NLB terminates TLS (993→143) and Dovecot's
+`login_trusted_networks` treats the NLB forwarding path as the secured
+one, so preserving real client IPs there would break forwarded plain-auth
+logins. Side benefit on relay: `confCONNECTION_RATE_THROTTLE`,
+`greet_pause`, and `access_db` now key on real client IPs instead of
+treating the entire internet as one NLB-shaped client.
+
 ## Phase 2 — Lambda envelope surface
 
 - helper.py: extend `ENVELOPE_HEADER_FIELDS_KEY`, add the trusted-parse

--- a/terraform/infra/modules/ecs/locals.tf
+++ b/terraform/infra/modules/ecs/locals.tf
@@ -60,11 +60,26 @@ locals {
   # operator-debugging window by 3x. The smtp tiers roll with overlap
   # (min_healthy=100), so they keep the relaxed 30s probe. Phase 1 of
   # docs/0.10.x/imap-deploy-downtime-plan.md.
+  # preserve_client_ip: NLB client IP preservation is disabled by default
+  # for ip-type TCP targets, which hands sendmail the NLB ENI's private
+  # address as the SMTP peer. On the relay TG that broke inbound SPF
+  # evaluation (phase 1 of docs/0.10.x/inbound-auth-verification-plan.md:
+  # opendmarc checked the sender's SPF record against the NLB's own IP
+  # and failed every external message), and it also keyed sendmail's
+  # confCONNECTION_RATE_THROTTLE and access_db to a single "client".
+  # smtp-in's SG already allows 25 from 0.0.0.0/0, so no SG change rides
+  # along. The imap TG must stay at the default: the NLB terminates TLS
+  # (993->143) and Dovecot's login_trusted_networks treats the NLB
+  # forwarding CIDRs as the secured path - preserving real client IPs
+  # there would break plaintext auth on forwarded connections.
+  # submission/starttls are left at the default too: smtp-out's Dovecot
+  # auth posture is tuned for NLB-fronted peers, and nothing there needs
+  # the real IP today.
   target_groups = {
-    imap       = { port = 143, health_check_interval = 10 }
-    relay      = { port = 25, health_check_interval = 30 }
-    submission = { port = 465, health_check_interval = 30 } # Dovecot submission (implicit TLS); NLB passes through to container port 465
-    starttls   = { port = 587, health_check_interval = 30 }
+    imap       = { port = 143, health_check_interval = 10, preserve_client_ip = null }
+    relay      = { port = 25, health_check_interval = 30, preserve_client_ip = "true" }
+    submission = { port = 465, health_check_interval = 30, preserve_client_ip = null } # Dovecot submission (implicit TLS); NLB passes through to container port 465
+    starttls   = { port = 587, health_check_interval = 30, preserve_client_ip = null }
   }
 
   # Flatten per-tier port lists into a map keyed by "tier-port" for

--- a/terraform/infra/modules/ecs/target_groups.tf
+++ b/terraform/infra/modules/ecs/target_groups.tf
@@ -14,6 +14,9 @@ resource "aws_lb_target_group" "tier" {
   target_type          = "ip"
   vpc_id               = var.vpc_id
   deregistration_delay = var.deregistration_delay
+  # null = AWS default (disabled for ip-type TCP targets). See the
+  # per-function rationale on local.target_groups.
+  preserve_client_ip   = each.value.preserve_client_ip
 
   stickiness {
     type    = "source_ip"


### PR DESCRIPTION
## Summary

Fixes the `spf=fail` observed on every external message in phase-1 stage testing of the inbound-auth milters (#587).

**Diagnosis** (see the new "Phase 1 stage finding" note in the plan doc):
- Prod sending is correct: `airmail.ccarr.com → include:cabalmail.net → ip4:3.222.8.196, 3.221.244.254`, which are exactly prod's NAT EIPs.
- Stage smtp-in never saw that IP: the relay target group is `target_type = "ip"` with client IP preservation at the AWS default (**disabled** for ip-type TCP), so the SMTP peer was the NLB's own ENI — confirmed as `10.64.126.30` = `ELB net/cabal-nlb` interface. OpenDMARC evaluated SPF against the load balancer's address.
- DKIM passed (content-based) and DMARC passed via DKIM alignment, so the milters themselves are behaving correctly.

**Change**: `preserve_client_ip = "true"` on the **relay TG only**.
- No SG change needed — smtp-in already allows 25 from `0.0.0.0/0`, and NLB health checks remain covered.
- imap TG deliberately stays default: `login_trusted_networks` treats NLB-forwarded connections as the secured path; real client IPs would break forwarded plain-auth logins.
- submission/starttls stay default too (smtp-out auth posture unchanged); can be revisited if we ever want real IPs in Dovecot submission logs.
- Side benefit: `confCONNECTION_RATE_THROTTLE`/`greet_pause`/`access_db` now see real clients instead of one NLB-shaped client.

## Verification

After apply, resend the prod test loop: expect `spf=pass smtp.mailfrom=airmail.ccarr.com` and the real prod NAT EIP in smtp-in's `Received:` line. In-place TG attribute update; existing connections unaffected, applies to new connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)