### PR TITLE
Fix plain-text email open crash from scroll-offset overflow

### DIFF
--- a/apple/Cabalmail/Views/MessageDetailView+Scroll.swift
+++ b/apple/Cabalmail/Views/MessageDetailView+Scroll.swift
@@ -123,8 +123,9 @@ extension MessageDetailView {
     /// densely during a drag, so skip sub-8pt deltas to avoid churning the save
     /// debounce.
     func reportPlainScroll(_ offsetY: CGFloat) {
+        guard offsetY.isFinite else { return }
         let offset = max(0, Int(offsetY))
-        if abs(offset - lastReportedPlainOffset) < 8 { return }
+        if let last = lastReportedPlainOffset, abs(offset - last) < 8 { return }
         lastReportedPlainOffset = offset
         reportMessageScroll(offset: offset, anchor: nil)
     }

--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -57,7 +57,9 @@ struct MessageDetailView: View {
     @State var restoreScrollOffset: Int?
     @State var didConsumeScrollRestore = false
     @State var plainScrollPosition = ScrollPosition(edge: .top)
-    @State var lastReportedPlainOffset = Int.min
+    // `nil` until the first scroll report — a sentinel `Int.min` would overflow
+    // the `offset - lastReportedPlainOffset` delta on the first callback.
+    @State var lastReportedPlainOffset: Int?
 
     var body: some View {
         GeometryReader { proxy in

--- a/changelog.d/plain-scroll-overflow-crash.fixed.md
+++ b/changelog.d/plain-scroll-overflow-crash.fixed.md
@@ -1,0 +1,5 @@
+- Fixed a crash in the Apple clients when opening a plain-text email. The
+  in-message scroll reporter used an `Int.min` sentinel for the last reported
+  offset, so the first scroll callback overflowed computing `offset -
+  lastReportedPlainOffset`. The sentinel is now optional and non-finite scroll
+  offsets are ignored.


### PR DESCRIPTION
## Problem

Opening any plain-text email crashes the macOS and iOS clients (reported via TestFlight feedback #6, `testflight_feedback-6.zip`). The crash log points to an arithmetic overflow (`EXC_BREAKPOINT`) in `MessageDetailView.reportPlainScroll(_:)` at `MessageDetailView+Scroll.swift:127`.

## Root cause

`lastReportedPlainOffset` was seeded with `Int.min` as a "nothing reported yet" sentinel. On the first `onScrollGeometryChange` callback for a plain-text body, the throttle computed:

```swift
let offset = max(0, Int(offsetY))          // >= 0, typically 0 on open
if abs(offset - lastReportedPlainOffset) < 8 { return }   // abs(0 - Int.min)
```

`0 - Int.min` is `Int.max + 1` — not representable — so the subtraction traps. Crash registers confirm it (`x8 = x23 = 0x8000000000000000` = `Int.min`).

Only plain-text bodies hit this: HTML bodies render in a `WKWebView` and never enter this path. The `test-mail-loop` probes are all `text/plain`, so every one crashes.

## Fix

- Make `lastReportedPlainOffset` an `Int?`, `nil` until the first report, so the first callback reports unconditionally and the subtraction can never see `Int.min`.
- Guard `offsetY.isFinite` before `Int(offsetY)`, which also traps on NaN/±infinity (SwiftUI can emit non-finite offsets during bounce/layout).

swiftlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)