### PR TITLE
Make sender-initials avatar color deterministic across launches

### DIFF
--- a/apple/Cabalmail/Views/AvatarView.swift
+++ b/apple/Cabalmail/Views/AvatarView.swift
@@ -97,13 +97,23 @@ struct AvatarView: View {
     /// the same swatch — easier to scan than randomly-rotating colors.
     /// Hash the full mailbox+host so two senders at the same domain
     /// don't collide visually.
+    ///
+    /// Uses a fixed FNV-1a hash over the UTF-8 bytes rather than
+    /// `String.hashValue`, which is seeded with a per-process random value
+    /// and so would pick a different color on every app launch.
     private var backgroundColor: Color {
         let key = "\(sender?.mailbox ?? "")@\(sender?.host ?? "")"
         let palette: [Color] = [
             .blue, .teal, .indigo, .purple, .pink,
             .orange, .brown, .green, .mint, .cyan
         ]
-        let index = abs(key.hashValue) % palette.count
+        // FNV-1a (64-bit): deterministic across launches and platforms.
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in key.utf8 {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0100_0000_01b3
+        }
+        let index = Int(hash % UInt64(palette.count))
         return palette[index]
     }
 

--- a/changelog.d/avatar-deterministic-color.fixed.md
+++ b/changelog.d/avatar-deterministic-color.fixed.md
@@ -1,0 +1,4 @@
+- Apple clients: the initials-avatar background color for a sender with no
+  BIMI logo or contact photo is now deterministic across app launches. It
+  previously used Swift's per-process-seeded `String.hashValue`, so the same
+  correspondent could show a different color each time the app was launched.


### PR DESCRIPTION
## Problem

In the Apple clients, when a sender has no BIMI logo and no contact photo, `AvatarView` renders their initials on a colored background. The color was consistent for a given sender *within* a single app run but changed on every launch.

## Cause

The color index came from `abs(key.hashValue) % palette.count`. Swift seeds `String.hashValue` with a per-process random value (a security measure against hash-flooding), so the same `mailbox@host` string hashes differently in each process.

## Fix

Replace `hashValue` with a fixed 64-bit **FNV-1a** hash over the `mailbox@host` UTF-8 bytes. This is deterministic across launches and platforms, so a given sender always maps to the same palette swatch. Also removes the latent `abs(Int.min)` overflow trap.

No behavior change to the palette itself (still the same 10 colors); only the mapping is now stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)