### PR TITLE
Fix Acknowledgements navigation on the macOS Settings scene

### DIFF
--- a/apple/Cabalmail/Views/SettingsView.swift
+++ b/apple/Cabalmail/Views/SettingsView.swift
@@ -288,21 +288,54 @@ struct SettingsView: View {
 /// `SettingsView` so that view's body stays within the type-body-length
 /// budget; it holds no state of its own.
 private struct AboutSettingsSection: View {
+    #if os(macOS)
+    // The macOS Settings scene hosts this form without a NavigationStack (by
+    // design — see SettingsView's top comment; one there breaks Form
+    // scrolling and duplicates window chrome), so a NavigationLink renders
+    // permanently disabled. Present Acknowledgements as a sheet on macOS;
+    // iOS/visionOS push it onto their Settings NavigationStack.
+    @State private var showingAcknowledgements = false
+    #endif
+
     var body: some View {
         Section("About") {
             LabeledContent("Version", value: Self.marketingVersion)
             LabeledContent("Build", value: Self.buildNumber)
-            NavigationLink {
-                AcknowledgementsView()
-            } label: {
-                Label("Acknowledgements", systemImage: "doc.text")
-            }
+            acknowledgementsRow
             Link(
                 destination: URL(string: "https://github.com/cabalmail/cabal-infra/issues")!
             ) {
                 Label("Report an issue", systemImage: "arrow.up.right.square")
             }
         }
+    }
+
+    @ViewBuilder
+    private var acknowledgementsRow: some View {
+        #if os(macOS)
+        Button {
+            showingAcknowledgements = true
+        } label: {
+            Label("Acknowledgements", systemImage: "doc.text")
+        }
+        .sheet(isPresented: $showingAcknowledgements) {
+            NavigationStack {
+                AcknowledgementsView()
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { showingAcknowledgements = false }
+                        }
+                    }
+            }
+            .frame(minWidth: 480, minHeight: 420)
+        }
+        #else
+        NavigationLink {
+            AcknowledgementsView()
+        } label: {
+            Label("Acknowledgements", systemImage: "doc.text")
+        }
+        #endif
     }
 
     private static var marketingVersion: String {


### PR DESCRIPTION
## Problem

After #589 shipped the Acknowledgements screen, the **Acknowledgements row is dimmed and unclickable on macOS** (iOS works).

## Root cause

The macOS Settings scene hosts `SettingsView`'s form **without a `NavigationStack`** — a deliberate choice documented at the top of `SettingsView` (a NavigationStack there breaks Form scrolling and duplicates window chrome). A `NavigationLink` with no enclosing `NavigationStack` renders **permanently disabled** on macOS. iOS/visionOS wrap the form in a `NavigationStack`, so the push worked there.

## Fix

Present Acknowledgements as a **sheet on macOS** (`Button` + `.sheet`, with a `NavigationStack` inside the sheet for its title bar and a Done button); keep the `NavigationLink` push on iOS/visionOS. No change to the deliberately-NavigationStack-free macOS Settings form.

## Note

The pre-existing **Debug Log** link (Diagnostics) has the *identical* latent bug — visible as dimmed in the same screenshot — but is out of scope here and left untouched. Happy to give it the same sheet treatment in a follow-up.

## Verification

- **iOS and macOS targets both build** (`BUILD SUCCEEDED`); **swiftlint clean**.
- Runtime UI verification of the sheet couldn't run in this environment (no renderable display — `screencapture`/accessibility automation are unavailable headlessly). The fix structurally removes the failure mode: `Button`+`.sheet` has no `NavigationStack` dependency, unlike the disabled `NavigationLink` it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)