### PR TITLE
Inbound auth verification phase 4: verdict display in the Apple clients

### DIFF
--- a/apple/Cabalmail/Views/AuthResultsLine.swift
+++ b/apple/Cabalmail/Views/AuthResultsLine.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import CabalmailKit
+
+/// Compact authentication line for the message-detail header: one chip per
+/// method (SPF / DKIM / DMARC) colored by verdict, plus a short warning
+/// sentence when the message failed authentication. Rendered in all three
+/// `AuthVerificationState`s — "Not verified" shows muted so absent data is
+/// honest without being alarming, and never dresses up as a pass.
+///
+/// Compiled into both the iOS and macOS targets (this directory is shared
+/// per `project.yml`); the bucketing itself lives in CabalmailKit.
+struct AuthResultsLine: View {
+    let results: AuthResults?
+
+    var body: some View {
+        if let results, !results.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    chip(method: "SPF", token: results.spf)
+                    chip(method: "DKIM", token: results.dkim)
+                    chip(method: "DMARC", token: results.dmarc)
+                }
+                if AuthVerificationState(results) == .warning {
+                    // Deliberately "could not be authenticated", not
+                    // "dangerous" — forwarding legitimately breaks these
+                    // checks.
+                    Label(Self.warningCopy, systemImage: "exclamationmark.shield.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                }
+            }
+        } else {
+            Text("Not verified")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Sender authentication: not verified")
+        }
+    }
+
+    /// Shared with the list row's warning icon so both surfaces speak with
+    /// one voice.
+    static let warningCopy =
+        "This message could not be authenticated as coming from its claimed sender."
+
+    /// One method chip. An absent token renders an em dash on the neutral
+    /// tint — a method that wasn't evaluated must look distinct from a
+    /// pass. Fixed padding keeps the chip footprint stable across verdicts.
+    private func chip(method: String, token: String?) -> some View {
+        HStack(spacing: 3) {
+            Text(method)
+                .fontWeight(.semibold)
+            Text(token ?? "—")
+        }
+        .font(.caption2)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .foregroundStyle(color(for: token))
+        .background(color(for: token).opacity(0.12), in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(method) \(token ?? "not checked")")
+    }
+
+    private func color(for token: String?) -> Color {
+        switch AuthMethodSeverity(token: token) {
+        case .ok: return .green
+        case .bad: return .orange
+        case .neutral: return .secondary
+        }
+    }
+}

--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -250,6 +250,10 @@ struct MessageDetailView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                    // Sender-authentication verdicts, rendered in all three
+                    // states ("Not verified" muted). Bucketing lives in
+                    // CabalmailKit; see `AuthResultsLine`.
+                    AuthResultsLine(results: envelope.authResults)
                 }
                 Spacer(minLength: 0)
             }

--- a/apple/Cabalmail/Views/MessageListView+Rows.swift
+++ b/apple/Cabalmail/Views/MessageListView+Rows.swift
@@ -368,6 +368,18 @@ private struct MessageRow: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                    // Sender-authentication warning only — pass and
+                    // not-verified show nothing here (the quiet default),
+                    // so the indicator area's footprint matches the other
+                    // flag-driven icons. Copy says "could not be
+                    // authenticated", not "dangerous": forwarding
+                    // legitimately breaks these checks.
+                    if envelope.authVerification == .warning {
+                        Image(systemName: "exclamationmark.shield.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .accessibilityLabel(AuthResultsLine.warningCopy)
+                    }
                     if envelope.hasAttachments {
                         Image(systemName: "paperclip")
                             .font(.caption)

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClientTypes.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClientTypes.swift
@@ -65,12 +65,20 @@ public struct ApiEnvelope: Sendable, Codable, Hashable {
     public let messageId: [String]?
     public let inReplyTo: [String]?
     public let references: [String]?
+    /// SPF/DKIM/DMARC verdicts parsed server-side from the trusted
+    /// `Authentication-Results` header. Optional (synthesized
+    /// `decodeIfPresent`, the `priority` pattern) so it tolerates both an
+    /// absent key and JSON `null` — pre-feature Lambdas, pre-feature mail,
+    /// and internally-routed mail all decode to nil, which renders as
+    /// "not verified", never as pass.
+    public let authResults: AuthResults?
 
     private enum CodingKeys: String, CodingKey {
         case id, date, subject, from, to, cc, flags, priority, references
         case structure = "struct"
         case messageId = "message_id"
         case inReplyTo = "in_reply_to"
+        case authResults = "auth_results"
     }
 
     public init(
@@ -85,7 +93,8 @@ public struct ApiEnvelope: Sendable, Codable, Hashable {
         priority: [String]?,
         messageId: [String]? = nil,
         inReplyTo: [String]? = nil,
-        references: [String]? = nil
+        references: [String]? = nil,
+        authResults: AuthResults? = nil
     ) {
         self.id = id
         self.date = date
@@ -99,6 +108,7 @@ public struct ApiEnvelope: Sendable, Codable, Hashable {
         self.messageId = messageId
         self.inReplyTo = inReplyTo
         self.references = references
+        self.authResults = authResults
     }
 }
 
@@ -303,12 +313,16 @@ public struct ApiSearchEnvelope: Sendable, Hashable, Codable {
     public let messageId: [String]?
     public let inReplyTo: [String]?
     public let references: [String]?
+    /// Auth verdicts; same shape and optionality as `ApiEnvelope` — the
+    /// search Lambda builds rows with the same `envelope_dict()`.
+    public let authResults: AuthResults?
 
     private enum CodingKeys: String, CodingKey {
         case id, date, subject, from, to, cc, flags, priority, folder, references
         case structure = "struct"
         case messageId = "message_id"
         case inReplyTo = "in_reply_to"
+        case authResults = "auth_results"
     }
 
     public init(
@@ -324,7 +338,8 @@ public struct ApiSearchEnvelope: Sendable, Hashable, Codable {
         folder: String,
         messageId: [String]? = nil,
         inReplyTo: [String]? = nil,
-        references: [String]? = nil
+        references: [String]? = nil,
+        authResults: AuthResults? = nil
     ) {
         self.id = id
         self.date = date
@@ -339,6 +354,7 @@ public struct ApiSearchEnvelope: Sendable, Hashable, Codable {
         self.messageId = messageId
         self.inReplyTo = inReplyTo
         self.references = references
+        self.authResults = authResults
     }
 }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ApiBackedImapClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ApiBackedImapClient.swift
@@ -278,7 +278,8 @@ public actor ApiBackedImapClient: ImapClient {
             internalDate: date,
             size: nil,
             hasAttachments: raw.structure?.hasAttachments ?? false,
-            isImportant: Self.isImportant(priority: raw.priority)
+            isImportant: Self.isImportant(priority: raw.priority),
+            authResults: raw.authResults
         )
     }
 
@@ -391,7 +392,8 @@ extension ApiBackedImapClient {
                 priority: wire.priority,
                 messageId: wire.messageId,
                 inReplyTo: wire.inReplyTo,
-                references: wire.references
+                references: wire.references,
+                authResults: wire.authResults
             )
             return SearchedEnvelope(envelope: Self.makeEnvelope(inner), folder: wire.folder)
         }

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/AuthResults.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/AuthResults.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// SPF / DKIM / DMARC verdicts for one message, parsed server-side from the
+/// trusted `Authentication-Results` header the smtp-in milters stamp (see
+/// docs/0.10.x/inbound-auth-verification-plan.md). Values are RFC 8601
+/// result tokens, lowercased (`pass`, `fail`, `none`, `neutral`,
+/// `softfail`, `temperror`, `permerror`, `policy`).
+///
+/// A `nil` method means it was not evaluated. A `nil` (or empty) whole
+/// value means no trusted header existed on the message — pre-feature
+/// mail, or mail that never transited smtp-in. **Absence must never
+/// render as pass**; it is the quiet "not verified" state.
+public struct AuthResults: Sendable, Codable, Hashable {
+    public let spf: String?
+    public let dkim: String?
+    public let dmarc: String?
+
+    public init(spf: String? = nil, dkim: String? = nil, dmarc: String? = nil) {
+        self.spf = spf
+        self.dkim = dkim
+        self.dmarc = dmarc
+    }
+
+    /// True when no method carries a verdict — treated identically to a
+    /// missing field (the Lambda never emits `{}`, but a defensive decoder
+    /// shouldn't distinguish it from `null`).
+    public var isEmpty: Bool {
+        spf == nil && dkim == nil && dmarc == nil
+    }
+}
+
+/// The three display states both clients bucket verdicts into. Bucketing
+/// lives here (not in the views) so the iOS and macOS targets share it and
+/// it stays unit-testable.
+public enum AuthVerificationState: Sendable, Hashable {
+    /// DMARC passed — the message authenticated as coming from its
+    /// claimed sender.
+    case verifiedOk
+    /// DMARC failed hard (`fail` / `permerror`), or DMARC was not
+    /// evaluated while SPF and DKIM both failed. Copy for this state says
+    /// the message *could not be authenticated as coming from its claimed
+    /// sender* — not "dangerous" — since forwarding legitimately breaks
+    /// these checks.
+    case warning
+    /// No verdict data (nil / empty), or a middle-ground verdict that is
+    /// neither a pass nor a hard failure (e.g. `dmarc=none`,
+    /// `spf=softfail`). The quiet default.
+    case notVerified
+
+    public init(_ results: AuthResults?) {
+        guard let results, !results.isEmpty else {
+            self = .notVerified
+            return
+        }
+        switch results.dmarc {
+        case "pass":
+            self = .verifiedOk
+        case "fail", "permerror":
+            self = .warning
+        case nil:
+            self = (results.spf == "fail" && results.dkim == "fail") ? .warning : .notVerified
+        default:
+            self = .notVerified
+        }
+    }
+}
+
+/// Chip coloring for a single method's verdict token in the detail view:
+/// `pass` is the only ok; `fail` / `permerror` are bad; everything else —
+/// including an absent method — is neutral, so absence can never dress up
+/// as a pass.
+public enum AuthMethodSeverity: Sendable, Hashable {
+    case ok
+    case bad
+    case neutral
+
+    public init(token: String?) {
+        switch token {
+        case "pass":
+            self = .ok
+        case "fail", "permerror":
+            self = .bad
+        default:
+            self = .neutral
+        }
+    }
+}

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/Envelope.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/Envelope.swift
@@ -74,7 +74,20 @@ public struct Envelope: Sendable, Codable, Hashable, Identifiable {
     /// snapshot.
     public let isImportant: Bool
 
+    /// SPF/DKIM/DMARC verdicts stamped by smtp-in and parsed by the
+    /// Lambda. Nil for pre-feature mail, internally-routed mail, and
+    /// envelopes cached before the field existed — all of which must
+    /// render as "not verified", never as pass (see `AuthResults`).
+    public let authResults: AuthResults?
+
     public var id: UInt32 { uid }
+
+    /// Display bucket for `authResults` — the list row shows a warning
+    /// icon only for `.warning`; the detail view chips render in all
+    /// three states.
+    public var authVerification: AuthVerificationState {
+        AuthVerificationState(authResults)
+    }
 
     public init(
         uid: UInt32,
@@ -93,7 +106,8 @@ public struct Envelope: Sendable, Codable, Hashable, Identifiable {
         internalDate: Date? = nil,
         size: UInt32? = nil,
         hasAttachments: Bool = false,
-        isImportant: Bool = false
+        isImportant: Bool = false,
+        authResults: AuthResults? = nil
     ) {
         self.uid = uid
         self.messageId = messageId
@@ -112,6 +126,7 @@ public struct Envelope: Sendable, Codable, Hashable, Identifiable {
         self.size = size
         self.hasAttachments = hasAttachments
         self.isImportant = isImportant
+        self.authResults = authResults
     }
 
     public init(from decoder: Decoder) throws {
@@ -140,6 +155,9 @@ public struct Envelope: Sendable, Codable, Hashable, Identifiable {
         // snapshot decode failure followed by a refetch) is correct but
         // costs the user a wait on every first launch after the upgrade.
         self.isImportant = try container.decodeIfPresent(Bool.self, forKey: .isImportant) ?? false
+        // Nil (not-verified) for cache snapshots predating the field —
+        // absent auth data must never decode into anything pass-shaped.
+        self.authResults = try container.decodeIfPresent(AuthResults.self, forKey: .authResults)
     }
 }
 
@@ -172,7 +190,8 @@ extension Envelope {
             internalDate: internalDate,
             size: size,
             hasAttachments: hasAttachments,
-            isImportant: isImportant
+            isImportant: isImportant,
+            authResults: authResults
         )
     }
 }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/AuthResultsTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/AuthResultsTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import CabalmailKit
+
+/// Phase 4 of docs/0.10.x/inbound-auth-verification-plan.md: decoding the
+/// `auth_results` envelope field and bucketing verdicts into the three
+/// display states. The load-bearing invariant throughout: absent data must
+/// NEVER render as pass.
+final class AuthResultsTests: XCTestCase {
+
+    // MARK: - Wire decoding
+
+    private func decodeEnvelope(authResultsJson: String?) throws -> ApiEnvelope {
+        let field = authResultsJson.map { ", \"auth_results\": \($0)" } ?? ""
+        let json = """
+        {
+          "id": 7, "date": "2026-07-01 10:30:45+00:00", "subject": "hi",
+          "from": ["a@x.com"], "to": ["b@y.com"], "cc": [], "flags": []\(field)
+        }
+        """
+        return try JSONDecoder().decode(ApiEnvelope.self, from: Data(json.utf8))
+    }
+
+    func testDecodesAuthResultsWhenPresent() throws {
+        let env = try decodeEnvelope(
+            authResultsJson: #"{"spf": "pass", "dkim": "pass", "dmarc": "fail"}"#
+        )
+        XCTAssertEqual(env.authResults?.spf, "pass")
+        XCTAssertEqual(env.authResults?.dkim, "pass")
+        XCTAssertEqual(env.authResults?.dmarc, "fail")
+    }
+
+    func testDecodesAbsentKeyAsNil() throws {
+        let env = try decodeEnvelope(authResultsJson: nil)
+        XCTAssertNil(env.authResults)
+        XCTAssertEqual(AuthVerificationState(env.authResults), .notVerified)
+    }
+
+    func testDecodesJsonNullAsNil() throws {
+        let env = try decodeEnvelope(authResultsJson: "null")
+        XCTAssertNil(env.authResults)
+        XCTAssertEqual(AuthVerificationState(env.authResults), .notVerified)
+    }
+
+    func testDecodesPartialMethods() throws {
+        let env = try decodeEnvelope(authResultsJson: #"{"dkim": "pass"}"#)
+        XCTAssertNil(env.authResults?.spf)
+        XCTAssertEqual(env.authResults?.dkim, "pass")
+        XCTAssertNil(env.authResults?.dmarc)
+        XCTAssertEqual(env.authResults?.isEmpty, false)
+    }
+
+    func testMakeEnvelopeCarriesAuthResults() throws {
+        let raw = try decodeEnvelope(
+            authResultsJson: #"{"spf": "fail", "dkim": "fail"}"#
+        )
+        let envelope = ApiBackedImapClient.makeEnvelope(raw)
+        XCTAssertEqual(envelope.authResults, AuthResults(spf: "fail", dkim: "fail"))
+        XCTAssertEqual(envelope.authVerification, .warning)
+    }
+
+    func testSearchEnvelopeDecodesAuthResults() throws {
+        let json = """
+        {
+          "id": 3, "from": [], "to": [], "cc": [], "flags": [],
+          "folder": "INBOX", "auth_results": {"dmarc": "pass"}
+        }
+        """
+        let env = try JSONDecoder().decode(ApiSearchEnvelope.self, from: Data(json.utf8))
+        XCTAssertEqual(env.authResults?.dmarc, "pass")
+    }
+
+    // MARK: - Envelope cache compatibility
+
+    func testEnvelopeSnapshotWithoutFieldDecodesAsNotVerified() throws {
+        // A cache snapshot written before the field existed: encode with a
+        // pre-field shape by stripping the key from a fresh encode.
+        let encoded = try JSONEncoder().encode(Envelope(uid: 9))
+        var dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        dict.removeValue(forKey: "authResults")
+        let legacy = try JSONSerialization.data(withJSONObject: dict)
+        let envelope = try JSONDecoder().decode(Envelope.self, from: legacy)
+        XCTAssertNil(envelope.authResults)
+        XCTAssertEqual(envelope.authVerification, .notVerified)
+    }
+
+    func testWithThreadingPreservesAuthResults() {
+        let results = AuthResults(spf: "pass", dkim: "pass", dmarc: "pass")
+        let envelope = Envelope(uid: 4, authResults: results)
+            .withThreading(messageId: "<m@x>", inReplyTo: nil, references: [])
+        XCTAssertEqual(envelope.authResults, results)
+    }
+
+    // MARK: - State bucketing
+
+    func testDmarcPassIsVerifiedOk() {
+        let state = AuthVerificationState(AuthResults(spf: "fail", dkim: "none", dmarc: "pass"))
+        XCTAssertEqual(state, .verifiedOk)
+    }
+
+    func testDmarcHardFailureIsWarning() {
+        XCTAssertEqual(AuthVerificationState(AuthResults(dmarc: "fail")), .warning)
+        XCTAssertEqual(AuthVerificationState(AuthResults(dmarc: "permerror")), .warning)
+    }
+
+    func testDmarcAbsentWithBothMethodsFailingIsWarning() {
+        let state = AuthVerificationState(AuthResults(spf: "fail", dkim: "fail"))
+        XCTAssertEqual(state, .warning)
+    }
+
+    func testAbsentDataIsNotVerified() {
+        XCTAssertEqual(AuthVerificationState(nil), .notVerified)
+        XCTAssertEqual(AuthVerificationState(AuthResults()), .notVerified)
+    }
+
+    func testMiddleGroundVerdictsAreNotVerified() {
+        // Data exists but is neither a pass nor a hard failure: the quiet
+        // default, not a warning and definitely not a pass.
+        XCTAssertEqual(AuthVerificationState(AuthResults(spf: "pass", dkim: "pass", dmarc: "none")), .notVerified)
+        XCTAssertEqual(AuthVerificationState(AuthResults(spf: "softfail", dkim: "fail")), .notVerified)
+        XCTAssertEqual(AuthVerificationState(AuthResults(dmarc: "temperror")), .notVerified)
+    }
+
+    func testAbsentNeverPasses() {
+        // The invariant by construction: nothing nil-shaped may bucket ok.
+        XCTAssertNotEqual(AuthVerificationState(nil), .verifiedOk)
+        XCTAssertNotEqual(AuthVerificationState(AuthResults()), .verifiedOk)
+        XCTAssertNotEqual(AuthVerificationState(AuthResults(spf: "pass", dkim: "pass")), .verifiedOk)
+        XCTAssertNotEqual(AuthMethodSeverity(token: nil), .ok)
+    }
+
+    // MARK: - Per-method chip severity
+
+    func testMethodSeverityBuckets() {
+        XCTAssertEqual(AuthMethodSeverity(token: "pass"), .ok)
+        XCTAssertEqual(AuthMethodSeverity(token: "fail"), .bad)
+        XCTAssertEqual(AuthMethodSeverity(token: "permerror"), .bad)
+        XCTAssertEqual(AuthMethodSeverity(token: "none"), .neutral)
+        XCTAssertEqual(AuthMethodSeverity(token: "neutral"), .neutral)
+        XCTAssertEqual(AuthMethodSeverity(token: "softfail"), .neutral)
+        XCTAssertEqual(AuthMethodSeverity(token: "temperror"), .neutral)
+        XCTAssertEqual(AuthMethodSeverity(token: "policy"), .neutral)
+        XCTAssertEqual(AuthMethodSeverity(token: nil), .neutral)
+    }
+}

--- a/changelog.d/apple-auth-results-display.added.md
+++ b/changelog.d/apple-auth-results-display.added.md
@@ -1,0 +1,5 @@
+- Apple clients now display inbound SPF/DKIM/DMARC authentication verdicts:
+  a warning icon in the message list for mail that could not be
+  authenticated as coming from its claimed sender, and per-method verdict
+  chips (with an honest muted "Not verified" state) in the message detail
+  header on both iOS and macOS.


### PR DESCRIPTION
## Summary

Phase 4 of [`docs/0.10.x/inbound-auth-verification-plan.md`](https://github.com/cabalmail/cabal-infra/blob/stage/docs/0.10.x/inbound-auth-verification-plan.md): the Apple clients decode and display the `auth_results` envelope field shipped in #595.

- **CabalmailKit**: new `AuthResults` model + `AuthVerificationState` (verified-ok / warning / not-verified, exactly the plan's rules) + `AuthMethodSeverity` chip coloring — shared, unit-tested bucketing. `ApiEnvelope` **and** `ApiSearchEnvelope` gain `auth_results` via `decodeIfPresent` (tolerates absent key, JSON null, and pre-field cache snapshots); `makeEnvelope` and the search path map it; `Envelope.withThreading` preserves it.
- **Views** (shared by iOS/macOS/visionOS targets per `project.yml`): warning-state-only `exclamationmark.shield.fill` in the message-row indicator cluster (pass/not-verified show nothing; footprint matches sibling flag icons); `AuthResultsLine` in the detail header with per-method chips in all three states, muted "Not verified", and the warning sentence — "could not be authenticated as coming from its claimed sender", deliberately not "dangerous".
- Invariant enforced at every layer: **absent data never renders as pass**.

Deviations from the plan, both deliberate: search envelopes included (same Lambda `envelope_dict()`; omitting would silently drop warnings from search), and middle-ground verdicts (`dmarc=none`, softfail, etc.) bucket to not-verified per the plan's "start with hard failure only" open question.

## Verification

- `swift test`: **306 tests, 0 failures** (14 new: decode present/absent/null/partial, search decode, mapping, cache-snapshot decode, state buckets, absent-never-pass, severity table).
- `scripts/build-apple.sh ios` and `macos`: both **Build Succeeded**.
- `swiftlint --strict` from `apple/`: clean.
- Note: `build-apple.sh visionos` fails on stage-identical code (`sharedBackgroundVisibility` unavailable in the local visionOS SDK) — pre-existing, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)