### PR TITLE
Inbound auth verification phase 3: verdict display in the webmail

### DIFF
--- a/changelog.d/webmail-auth-results-display.added.md
+++ b/changelog.d/webmail-auth-results-display.added.md
@@ -1,0 +1,5 @@
+- Webmail now displays the SPF/DKIM/DMARC authentication verdicts stamped
+  on inbound mail: messages that could not be authenticated as coming from
+  their claimed sender get a warning indicator in the message list, and
+  the reading view shows a per-method chip line (muted "Not verified" for
+  mail that predates the feature or bypassed the inbound relay).

--- a/react/admin/src/Email/MessageOverlay/MessageOverlay.css
+++ b/react/admin/src/Email/MessageOverlay/MessageOverlay.css
@@ -471,7 +471,8 @@
   grid-template-areas:
     "avatar subject subject"
     "avatar sender  timestamp"
-    "avatar to      to";
+    "avatar to      to"
+    "avatar auth    auth";
   column-gap: 14px;
   row-gap: 4px;
   align-items: start;
@@ -570,6 +571,66 @@
 .reader-to .reader-to-label {
   margin-right: 4px;
 }
+
+/* --- Authentication line (SPF / DKIM / DMARC verdicts) ------------------
+   Rendered in all three states so the header footprint stays stable:
+   per-method chips when smtp-in stamped verdicts, a muted "Not verified"
+   otherwise. The whole line opens the original headers in the view-source
+   modal. The ok hue mirrors the "forest" accent tokens (light/dark). */
+
+.reader-auth {
+  grid-area: auth;
+  --auth-ok: oklch(0.45 0.09 150);
+  min-height: 20px;
+  display: flex;
+  align-items: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  .reader-auth { --auth-ok: oklch(0.75 0.11 150); }
+}
+
+.reader-auth-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: var(--font-ui, inherit);
+  color: inherit;
+}
+
+.reader-auth-chip {
+  --auth-chip: var(--ink-quiet);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--auth-chip) 12%, transparent);
+  color: var(--auth-chip);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.reader-auth-chip--ok { --auth-chip: var(--auth-ok); }
+.reader-auth-chip--bad { --auth-chip: var(--ink-danger); }
+
+.reader-auth-chip-label {
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+
+.reader-auth-none {
+  font-size: 12px;
+  color: var(--ink-quiet);
+}
+.reader-auth-line:hover .reader-auth-none { color: var(--ink-soft); }
 
 /* --- Body -------------------------------------------------------------- */
 

--- a/react/admin/src/Email/MessageOverlay/MessageOverlay.test.jsx
+++ b/react/admin/src/Email/MessageOverlay/MessageOverlay.test.jsx
@@ -323,4 +323,60 @@ describe('MessageOverlay (Reader)', () => {
       }
     });
   });
+
+  describe('authentication line', () => {
+    it('renders per-method chips colored by verdict for the warning state', async () => {
+      const { unmount, container } = renderOverlay({
+        envelope: {
+          ...testEnvelope,
+          auth_results: { spf: 'pass', dkim: 'fail', dmarc: 'fail' },
+        },
+      });
+      try {
+        await waitFor(() => expect(screen.getByText('Test Subject')).toBeInTheDocument());
+        expect(container.querySelector('.reader-auth--warning')).toBeTruthy();
+        const chips = container.querySelectorAll('.reader-auth-chip');
+        expect(chips.length).toBe(3);
+        expect(chips[0].className).toContain('reader-auth-chip--ok'); // SPF pass
+        expect(chips[1].className).toContain('reader-auth-chip--bad'); // DKIM fail
+        expect(chips[2].className).toContain('reader-auth-chip--bad'); // DMARC fail
+        expect(chips[2].textContent).toContain('DMARC');
+        expect(chips[2].textContent).toContain('fail');
+        // Warning copy avoids "dangerous" framing.
+        const line = container.querySelector('.reader-auth-line');
+        expect(line.title).toContain('could not be authenticated as coming from its claimed sender');
+      } finally {
+        unmount();
+      }
+    });
+
+    it('renders all three chips in the verified-ok state, with absent methods neutral', async () => {
+      const { unmount, container } = renderOverlay({
+        envelope: { ...testEnvelope, auth_results: { dkim: 'pass', dmarc: 'pass' } },
+      });
+      try {
+        await waitFor(() => expect(screen.getByText('Test Subject')).toBeInTheDocument());
+        expect(container.querySelector('.reader-auth--ok')).toBeTruthy();
+        const chips = container.querySelectorAll('.reader-auth-chip');
+        expect(chips.length).toBe(3);
+        // SPF was not evaluated: neutral chip, no verdict token.
+        expect(chips[0].className).toContain('reader-auth-chip--neutral');
+        expect(chips[0].textContent).toContain('SPF');
+      } finally {
+        unmount();
+      }
+    });
+
+    it('renders a muted "Not verified" when auth_results is absent — never a pass', async () => {
+      const { unmount, container } = renderOverlay(); // testEnvelope has no auth_results
+      try {
+        await waitFor(() => expect(screen.getByText('Test Subject')).toBeInTheDocument());
+        expect(container.querySelector('.reader-auth--not-verified')).toBeTruthy();
+        expect(container.querySelectorAll('.reader-auth-chip').length).toBe(0);
+        expect(screen.getByText('Not verified')).toBeInTheDocument();
+      } finally {
+        unmount();
+      }
+    });
+  });
 });

--- a/react/admin/src/Email/MessageOverlay/index.jsx
+++ b/react/admin/src/Email/MessageOverlay/index.jsx
@@ -25,6 +25,9 @@ import {
 import {
   extractName, extractEmail, formatReaderTimestamp, initialsFor,
 } from '../../utils/formatDate';
+import {
+  authState, methodVerdict, hasAuthData, AUTH_WARNING, AUTH_WARNING_COPY,
+} from '../../utils/authResults';
 import { folderMeta } from '../../utils/folderMeta';
 import './MessageOverlay.css';
 
@@ -373,6 +376,41 @@ function MessageOverlay({
     : 'Undisclosed recipients';
   const timestamp = formatReaderTimestamp(envelope.date);
 
+  // Authentication verdicts ride on the envelope (parsed server-side from
+  // the Authentication-Results header), same as subject/from — not on the
+  // fetch_message payload. Absent data renders as a muted "Not verified",
+  // never as a pass.
+  const authResults = envelope.auth_results;
+  const authStateValue = authState(authResults);
+  const authTitle = authStateValue === AUTH_WARNING
+    ? `${AUTH_WARNING_COPY} Click to view the original headers.`
+    : 'Authentication results. Click to view the original headers.';
+  const authLine = (
+    <div className={`reader-auth reader-auth--${authStateValue}`}>
+      <button
+        type="button"
+        className="reader-auth-line"
+        onClick={openHeaders}
+        title={authTitle}
+        aria-label="Authentication results — view original headers"
+      >
+        {hasAuthData(authResults) ? (
+          ['spf', 'dkim', 'dmarc'].map((method) => (
+            <span
+              key={method}
+              className={`reader-auth-chip reader-auth-chip--${methodVerdict(authResults[method])}`}
+            >
+              <span className="reader-auth-chip-label">{method.toUpperCase()}</span>
+              {typeof authResults[method] === 'string' ? authResults[method] : '—'}
+            </span>
+          ))
+        ) : (
+          <span className="reader-auth-none">Not verified</span>
+        )}
+      </button>
+    </div>
+  );
+
   return (
     <div className="reader" data-layout={sheetAttr} role="region" aria-label="Message">
       {phoneBackBar}
@@ -482,6 +520,7 @@ function MessageOverlay({
             <span className="reader-to-label">to</span>
             <span>{toList}</span>
           </div>
+          {authLine}
         </header>
 
         <ReaderBody

--- a/react/admin/src/Email/Messages/Envelope.jsx
+++ b/react/admin/src/Email/Messages/Envelope.jsx
@@ -8,6 +8,7 @@ import {
 import 'react-swipeable-list/dist/styles.css';
 import Icon from './icons';
 import BimiAvatar from './BimiAvatar';
+import { authState, AUTH_WARNING, AUTH_WARNING_COPY } from '../../utils/authResults';
 import formatDate, { extractName } from '../../utils/formatDate';
 
 function Envelope({
@@ -23,6 +24,7 @@ function Envelope({
   from,
   flags,
   struct,
+  auth_results,
   folder,
   is_checked,
   dom_id,
@@ -37,6 +39,10 @@ function Envelope({
   const hasAttachment = struct && struct[1] === 'mixed';
   const isImportant = Array.isArray(priority)
     && priority.some((p) => p === 'priority-1' || p === 'priority-2');
+  // Warning state only: verified-ok and not-verified show nothing in the
+  // list, so the indicator area's footprint varies exactly as it already
+  // does for the other flag-driven icons.
+  const authWarning = authState(auth_results) === AUTH_WARNING;
   const fromName = extractName(from && from[0]) || (from && from[0]) || '';
   const relDate = formatDate(date);
   // `folder` is only set when the row is rendered inside a cross-folder
@@ -141,6 +147,14 @@ function Envelope({
           </div>
         </div>
         <div className="envelope-indicators" aria-hidden="true">
+          {authWarning && (
+            <Icon
+              name="shield-alert"
+              size={13}
+              className="indicator-auth"
+              title={AUTH_WARNING_COPY}
+            />
+          )}
           {isImportant && <Icon name="important" size={13} className="indicator-important" />}
           {hasAttachment && <Icon name="paperclip" size={13} />}
           {answered && <Icon name="reply" size={13} />}

--- a/react/admin/src/Email/Messages/Envelopes.css
+++ b/react/admin/src/Email/Messages/Envelopes.css
@@ -215,6 +215,9 @@
 .envelope-indicators .icon { opacity: 0.75; }
 .envelope-row.flagged .indicator-flagged { color: var(--accent); opacity: 1; }
 .envelope-row.important .indicator-important { color: var(--ink-danger); opacity: 1; }
+/* Authentication warning (DMARC failure): the message could not be
+   authenticated as coming from its claimed sender. */
+.envelope-indicators .indicator-auth { color: var(--ink-danger); opacity: 1; }
 
 /* ---- Important rail (priority) ---- */
 .envelope-row.important .envelope-content::after {

--- a/react/admin/src/Email/Messages/Envelopes.jsx
+++ b/react/admin/src/Email/Messages/Envelopes.jsx
@@ -329,6 +329,7 @@ function Envelopes({
         from={e.from}
         flags={e.flags}
         struct={e.struct}
+        auth_results={e.auth_results}
         is_checked={selected.has(id)}
         dom_id={e.id}
         bulkMode={bulkMode}

--- a/react/admin/src/Email/Messages/Envelopes.test.jsx
+++ b/react/admin/src/Email/Messages/Envelopes.test.jsx
@@ -222,6 +222,35 @@ describe('Envelopes', () => {
     expect(container.querySelectorAll('.envelope-row').length).toBe(1);
   });
 
+  it('shows the auth warning indicator only for the warning state', async () => {
+    const envelopes = {
+      // Warning: hard DMARC failure.
+      '1': makeEnvelope(1, { auth_results: { spf: 'pass', dkim: 'pass', dmarc: 'fail' } }),
+      // Warning: no DMARC verdict, but SPF and DKIM both fail.
+      '2': makeEnvelope(2, { auth_results: { spf: 'fail', dkim: 'fail' } }),
+      // Verified-ok: nothing in the list.
+      '3': makeEnvelope(3, { auth_results: { spf: 'pass', dkim: 'pass', dmarc: 'pass' } }),
+      // Not verified (pre-feature / cached envelope): nothing in the list.
+      '4': makeEnvelope(4),
+      '5': makeEnvelope(5, { auth_results: null }),
+    };
+    mockGetEnvelopes.mockResolvedValue({ data: { envelopes } });
+
+    const { container } = render(<Harness message_ids={[1, 2, 3, 4, 5]} />);
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+    const rows = container.querySelectorAll('.envelope-row');
+    expect(rows.length).toBe(5);
+    expect(rows[0].querySelector('.indicator-auth')).toBeTruthy();
+    expect(rows[1].querySelector('.indicator-auth')).toBeTruthy();
+    expect(rows[2].querySelector('.indicator-auth')).toBeNull();
+    expect(rows[3].querySelector('.indicator-auth')).toBeNull();
+    expect(rows[4].querySelector('.indicator-auth')).toBeNull();
+    // The warning copy avoids "dangerous"/"phishing" framing.
+    expect(rows[0].querySelector('.indicator-auth title').textContent)
+      .toContain('could not be authenticated as coming from its claimed sender');
+  });
+
   it('shift-clicking range-selects contiguous rows', async () => {
     const ids = [1, 2, 3, 4, 5];
     const envelopes = {};

--- a/react/admin/src/Email/Messages/icons.jsx
+++ b/react/admin/src/Email/Messages/icons.jsx
@@ -49,9 +49,16 @@ const PATHS = {
       <circle cx="11" cy="17" r="1" fill="currentColor" />
     </>
   ),
+  'shield-alert': (
+    <>
+      <path d="M11 3l7 2.5v5.2c0 4.3-2.8 7.2-7 8.3-4.2-1.1-7-4-7-8.3V5.5L11 3z" />
+      <path d="M11 8v4" />
+      <circle cx="11" cy="15" r="0.5" fill="currentColor" />
+    </>
+  ),
 };
 
-function Icon({ name, size = 16, className = '' }) {
+function Icon({ name, size = 16, className = '', title = null }) {
   const path = PATHS[name];
   if (!path) return null;
   return (
@@ -67,6 +74,7 @@ function Icon({ name, size = 16, className = '' }) {
       strokeLinejoin="round"
       aria-hidden="true"
     >
+      {title && <title>{title}</title>}
       {path}
     </svg>
   );

--- a/react/admin/src/Email/Search/index.jsx
+++ b/react/admin/src/Email/Search/index.jsx
@@ -586,6 +586,7 @@ function Search({
                   from={e.from}
                   flags={e.flags}
                   struct={e.struct}
+                  auth_results={e.auth_results}
                   folder={!thisFolderOnly && e.folder ? e.folder : null}
                   is_checked={selected.has(id)}
                   dom_id={e.id}

--- a/react/admin/src/utils/authResults.js
+++ b/react/admin/src/utils/authResults.js
@@ -1,0 +1,80 @@
+/* =========================================================================
+   Bucketing for the `auth_results` envelope field — the SPF/DKIM/DMARC
+   verdicts stamped by smtp-in (Authentication-Results, RFC 8601) and
+   parsed server-side into `{"spf": ..., "dkim": ..., "dmarc": ...}`.
+   Values are lowercased RFC 8601 result tokens (pass, fail, none, neutral,
+   softfail, temperror, permerror, policy). A method key may be absent
+   (method not evaluated); the whole field may be null or missing (mail
+   that predates the feature, or bypassed smtp-in). Absent data must NEVER
+   render as a pass.
+   ========================================================================= */
+
+// Message-level display states.
+export const AUTH_OK = 'ok';
+export const AUTH_WARNING = 'warning';
+export const AUTH_NOT_VERIFIED = 'not-verified';
+
+// Per-method chip colorings.
+export const VERDICT_OK = 'ok';
+export const VERDICT_BAD = 'bad';
+export const VERDICT_NEUTRAL = 'neutral';
+
+// Shared warning copy. Deliberately says "could not be authenticated",
+// not "dangerous" — forwarding legitimately breaks these checks.
+export const AUTH_WARNING_COPY = 'This message could not be authenticated as '
+  + 'coming from its claimed sender. Forwarded mail often fails these checks.';
+
+/**
+ * Normalizes a result token: lowercased string, or null for anything that
+ * isn't a string (absent method, malformed payload).
+ * @param {*} token raw method value from auth_results
+ * @returns {?string} lowercased token or null
+ */
+function normalize(token) {
+  return typeof token === 'string' ? token.toLowerCase() : null;
+}
+
+/**
+ * Buckets an envelope's auth_results into one of the three display states:
+ *   - AUTH_OK: dmarc passed;
+ *   - AUTH_WARNING: dmarc failed hard (fail/permerror), or dmarc was not
+ *     evaluated while both spf and dkim failed;
+ *   - AUTH_NOT_VERIFIED: everything else — no data at all, or the
+ *     softfail/neutral/none middle ground. The quiet default.
+ * @param {?Object} authResults the envelope's auth_results field
+ * @returns {string} one of AUTH_OK, AUTH_WARNING, AUTH_NOT_VERIFIED
+ */
+export function authState(authResults) {
+  if (!authResults || typeof authResults !== 'object') return AUTH_NOT_VERIFIED;
+  const dmarc = normalize(authResults.dmarc);
+  const spf = normalize(authResults.spf);
+  const dkim = normalize(authResults.dkim);
+  if (dmarc === 'pass') return AUTH_OK;
+  if (dmarc === 'fail' || dmarc === 'permerror') return AUTH_WARNING;
+  if (!dmarc && spf === 'fail' && dkim === 'fail') return AUTH_WARNING;
+  return AUTH_NOT_VERIFIED;
+}
+
+/**
+ * Maps a single method's result token to a chip coloring: pass is ok,
+ * fail/permerror is bad, everything else (including absent) is neutral.
+ * @param {*} token raw method value from auth_results
+ * @returns {string} one of VERDICT_OK, VERDICT_BAD, VERDICT_NEUTRAL
+ */
+export function methodVerdict(token) {
+  const t = normalize(token);
+  if (t === 'pass') return VERDICT_OK;
+  if (t === 'fail' || t === 'permerror') return VERDICT_BAD;
+  return VERDICT_NEUTRAL;
+}
+
+/**
+ * True when auth_results carries at least one evaluated method — i.e. the
+ * reading view has verdicts to chip rather than the muted "Not verified".
+ * @param {?Object} authResults the envelope's auth_results field
+ * @returns {boolean} whether any of spf/dkim/dmarc is present
+ */
+export function hasAuthData(authResults) {
+  if (!authResults || typeof authResults !== 'object') return false;
+  return ['spf', 'dkim', 'dmarc'].some((m) => typeof authResults[m] === 'string');
+}

--- a/react/admin/src/utils/authResults.test.js
+++ b/react/admin/src/utils/authResults.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  authState, methodVerdict, hasAuthData,
+  AUTH_OK, AUTH_WARNING, AUTH_NOT_VERIFIED,
+  VERDICT_OK, VERDICT_BAD, VERDICT_NEUTRAL,
+} from './authResults';
+
+describe('authState', () => {
+  it('is ok when dmarc passes', () => {
+    expect(authState({ spf: 'pass', dkim: 'pass', dmarc: 'pass' })).toBe(AUTH_OK);
+    // DMARC is the aggregate verdict — it wins even over individual failures.
+    expect(authState({ spf: 'fail', dkim: 'fail', dmarc: 'pass' })).toBe(AUTH_OK);
+    expect(authState({ dmarc: 'pass' })).toBe(AUTH_OK);
+  });
+
+  it('warns on hard dmarc failure', () => {
+    expect(authState({ spf: 'pass', dkim: 'pass', dmarc: 'fail' })).toBe(AUTH_WARNING);
+    expect(authState({ dmarc: 'permerror' })).toBe(AUTH_WARNING);
+  });
+
+  it('warns when dmarc is absent but spf and dkim both fail', () => {
+    expect(authState({ spf: 'fail', dkim: 'fail' })).toBe(AUTH_WARNING);
+  });
+
+  it('never renders absent or null data as a pass', () => {
+    expect(authState(null)).toBe(AUTH_NOT_VERIFIED);
+    expect(authState(undefined)).toBe(AUTH_NOT_VERIFIED);
+    expect(authState({})).toBe(AUTH_NOT_VERIFIED);
+  });
+
+  it('treats partial methods without a dmarc verdict as not verified', () => {
+    // spf/dkim passing alone is not a dmarc pass.
+    expect(authState({ spf: 'pass', dkim: 'pass' })).toBe(AUTH_NOT_VERIFIED);
+    // A single failure without dmarc is not the both-fail warning case.
+    expect(authState({ spf: 'fail' })).toBe(AUTH_NOT_VERIFIED);
+    expect(authState({ spf: 'fail', dkim: 'pass' })).toBe(AUTH_NOT_VERIFIED);
+  });
+
+  it('leaves the softfail/neutral/none middle ground quiet', () => {
+    expect(authState({ spf: 'softfail', dkim: 'none', dmarc: 'none' })).toBe(AUTH_NOT_VERIFIED);
+    expect(authState({ dmarc: 'temperror' })).toBe(AUTH_NOT_VERIFIED);
+    expect(authState({ dmarc: 'neutral' })).toBe(AUTH_NOT_VERIFIED);
+  });
+});
+
+describe('methodVerdict', () => {
+  it('maps pass to ok', () => {
+    expect(methodVerdict('pass')).toBe(VERDICT_OK);
+  });
+
+  it('maps fail and permerror to bad', () => {
+    expect(methodVerdict('fail')).toBe(VERDICT_BAD);
+    expect(methodVerdict('permerror')).toBe(VERDICT_BAD);
+  });
+
+  it('maps every other token — and absent — to neutral', () => {
+    for (const t of ['none', 'neutral', 'softfail', 'temperror', 'policy']) {
+      expect(methodVerdict(t)).toBe(VERDICT_NEUTRAL);
+    }
+    expect(methodVerdict(undefined)).toBe(VERDICT_NEUTRAL);
+    expect(methodVerdict(null)).toBe(VERDICT_NEUTRAL);
+  });
+});
+
+describe('hasAuthData', () => {
+  it('is false for null, undefined, and empty payloads', () => {
+    expect(hasAuthData(null)).toBe(false);
+    expect(hasAuthData(undefined)).toBe(false);
+    expect(hasAuthData({})).toBe(false);
+  });
+
+  it('is true when any method was evaluated', () => {
+    expect(hasAuthData({ spf: 'pass' })).toBe(true);
+    expect(hasAuthData({ dmarc: 'none' })).toBe(true);
+    expect(hasAuthData({ spf: 'pass', dkim: 'pass', dmarc: 'pass' })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of [`docs/0.10.x/inbound-auth-verification-plan.md`](https://github.com/cabalmail/cabal-infra/blob/stage/docs/0.10.x/inbound-auth-verification-plan.md): the React webmail displays the `auth_results` envelope field shipped in #595.

- **`utils/authResults.js`**: shared bucketing — `authState()` (ok / warning / not-verified, exactly the plan's rules: dmarc pass → ok; dmarc fail/permerror, or dmarc absent with spf+dkim both fail → warning; all else including absent/null → not-verified), `methodVerdict()` chip coloring, shared warning copy ("could not be authenticated as coming from its claimed sender" — deliberately not "dangerous").
- **Envelope row**: warning-state-only `shield-alert` icon (new glyph on the house 22×22 grid) in the existing `envelope-indicators` cluster, styled like `indicator-important` (`--ink-danger`); pass and not-verified show nothing. Wired at both call sites (folder list + search results).
- **Reading view**: per-method SPF/DKIM/DMARC chips in the header (all three states; muted "Not verified" for absent data; stable `min-height` so the header footprint doesn't shift). The line is a button opening the existing view-source modal on the Headers tab.
- Invariant: **absent/null/pre-field-cached envelopes never render as pass** — unit-tested.

## Verification

- `npm run test`: **307/307 tests, 32 files** (+15 new: bucketing states, absent-never-pass, partials; row icon shows for both warning triggers and not otherwise; reader chips/muted states). Note: run under Node 22 (CI's version) — Node 26 breaks jsdom `localStorage` repo-wide, pre-existing.
- `npm run build` and `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)