### PR TITLE
Add TF_LOG=DEBUG to infra plan step to diagnose refresh hang (TEMPORARY)

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -677,6 +677,16 @@ jobs:
       run: ../../.github/scripts/record-lambda-hashes.sh
     - name: plan-terraform
       id: plan-terraform
+      # TEMPORARY (diagnostic): TF_LOG=DEBUG surfaces the live AWS SDK
+      # HTTP request/retry lines so we can catch which refresh call wedges
+      # the plan - a multi-minute hang on
+      # module.admin.aws_s3_bucket_policy.admin_bucket that reproduces
+      # across runs. DEBUG (not TRACE) keeps request bodies out of the log
+      # but still shows the stuck endpoint call and any throttle/backoff
+      # loop. Revert once the culprit is identified; do not carry into
+      # steady-state CI (verbose, and includes signed-request metadata).
+      env:
+        TF_LOG: DEBUG
       run: ../../.github/scripts/plan-terraform.sh
 
   approval:


### PR DESCRIPTION
Single-commit change: adds **`TF_LOG=DEBUG`**, scoped to just the `plan-terraform` step in the infra `plan` job, to diagnose a reproducible multi-minute refresh hang on `module.admin.aws_s3_bucket_policy.admin_bucket`. `DEBUG` (not `TRACE`) surfaces the live AWS SDK HTTP request + retry/backoff lines — enough to tell a dead endpoint connection from a throttle loop — while keeping request bodies out of the log.

## ⚠️ Temporary diagnostic scaffolding — do not merge to prod as-is
This is throwaway debug logging (verbose; includes signed-request metadata). **Hold this PR** until the stage debug run identifies the stuck call, then I'll revert the commit on `stage` and this PR closes/empties out. It should not land in prod CI in steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)