### PR TITLE
Remove temporary TF_LOG=DEBUG from infra plan step

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -677,16 +677,6 @@ jobs:
       run: ../../.github/scripts/record-lambda-hashes.sh
     - name: plan-terraform
       id: plan-terraform
-      # TEMPORARY (diagnostic): TF_LOG=DEBUG surfaces the live AWS SDK
-      # HTTP request/retry lines so we can catch which refresh call wedges
-      # the plan - a multi-minute hang on
-      # module.admin.aws_s3_bucket_policy.admin_bucket that reproduces
-      # across runs. DEBUG (not TRACE) keeps request bodies out of the log
-      # but still shows the stuck endpoint call and any throttle/backoff
-      # loop. Revert once the culprit is identified; do not carry into
-      # steady-state CI (verbose, and includes signed-request metadata).
-      env:
-        TF_LOG: DEBUG
       run: ../../.github/scripts/plan-terraform.sh
 
   approval:


### PR DESCRIPTION
Removes the diagnostic `TF_LOG=DEBUG` added to the infra `plan` step in #604.

It served its purpose: the debug output showed the multi-minute plan "hang" was **EC2 `DescribeLaunchTemplates` throttling** (`RequestLimitExceeded`, HTTP 503) on `module.ecs.aws_launch_template.ecs` during refresh — a transient AWS-side event, not the S3 admin bucket that the frozen output line implicated, and not a provider or code change. The throttle has since cleared and a normal re-run planned and applied clean.

Dropping the verbose logging so steady-state CI stops emitting it (and the signed-request metadata it carries).

Single-commit change; reverts the `env: { TF_LOG: DEBUG }` block only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)