### PR TITLE
Make the floating tab bar's tray inert to touches on iPhone

### DIFF
--- a/apple/Cabalmail/Views/SignedInRootView.swift
+++ b/apple/Cabalmail/Views/SignedInRootView.swift
@@ -77,19 +77,28 @@ struct SignedInRootView: View {
     /// Those lists carry the full create/delete/request/revoke affordances, so
     /// there's a single list implementation per data type - the old dedicated
     /// management views were retired.
+    ///
+    /// Every tab wraps its content in `tabBarTrayShield()`: the floating bar
+    /// only draws the capsules, so without it, touches in the tray's margins
+    /// fall through to the rows visible behind the bar (see
+    /// `TabBarTrayShield.swift`).
     private var compactTabs: some View {
         TabView {
             Tab("Mail", systemImage: "tray") {
                 MailRootView()
+                    .tabBarTrayShield()
             }
             Tab("Addresses", systemImage: "at") {
                 AddressManagementTab()
+                    .tabBarTrayShield()
             }
             Tab("Folders", systemImage: "folder") {
                 FolderManagementTab()
+                    .tabBarTrayShield()
             }
             Tab("Settings", systemImage: "gear") {
                 SettingsView()
+                    .tabBarTrayShield()
             }
             // The search role detaches to the bottom-right, next to the tab bar.
             // On iOS 26 it adopts the morph (tab bar collapses to a dismiss
@@ -98,6 +107,7 @@ struct SignedInRootView: View {
             // `.searchable` inside `SearchView`.
             Tab(role: .search) {
                 SearchView()
+                    .tabBarTrayShield()
             }
         }
     }

--- a/apple/Cabalmail/Views/TabBarTrayShield.swift
+++ b/apple/Cabalmail/Views/TabBarTrayShield.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+#if !os(macOS)
+/// The compact-width floating tab bar (iOS 26 glass capsules) reserves a
+/// full-width tray at the bottom of the screen but only draws the capsules;
+/// the margins around them — the screen edges, the gap between the two
+/// capsules, and the strip below — are transparent AND touch-transparent.
+/// List rows showing through those margins scroll and open on touch, which
+/// reads as a misfire: the tray looks like chrome, so touches there should
+/// do nothing.
+///
+/// `tabBarTrayShield()` overlays a transparent UIKit view over the tab's
+/// content that claims (and drops) touches inside the reserved band while
+/// passing everything above it through. Rows behind the tray stay visible
+/// for context but are no longer interactive.
+///
+/// Applied per tab INSIDE the `TabView` — the tab bar is system chrome
+/// hosted above each tab's content, so the shield can never intercept the
+/// capsules or the search morph. An overlay on the `TabView` itself would
+/// sit above that chrome and deaden the bar.
+extension View {
+    func tabBarTrayShield() -> some View {
+        overlay { TrayShield().ignoresSafeArea() }
+    }
+}
+
+/// Full-screen transparent view whose hit test claims only the tab bar's
+/// reserved bottom band. UIKit-level rather than a SwiftUI gesture so it
+/// beats the list's scroll-view pan recognizer outright — the touch never
+/// reaches the collection view at all.
+private struct TrayShield: UIViewRepresentable {
+    func makeUIView(context: Context) -> TrayShieldUIView { TrayShieldUIView() }
+    func updateUIView(_ uiView: TrayShieldUIView, context: Context) {}
+}
+
+private final class TrayShieldUIView: UIView {
+    /// Claim points inside the tray band; pass everything else through.
+    ///
+    /// The band is read live from `safeAreaInsets`, so it tracks the bar's
+    /// actual reserved height across devices, orientations, and appearance
+    /// changes for free. The window comparison keeps the shield inert
+    /// wherever the bar is hidden (`MessageDetailView` hides it for the
+    /// reader): with no bar, this view's bottom inset collapses to the
+    /// window's own home-indicator inset and nothing may be blocked.
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        guard let window else { return false }
+        let band = safeAreaInsets.bottom
+        guard band > window.safeAreaInsets.bottom else { return false }
+        return point.y >= bounds.height - band
+    }
+}
+#endif

--- a/changelog.d/ios-tab-tray-touch-shield.fixed.md
+++ b/changelog.d/ios-tab-tray-touch-shield.fixed.md
@@ -1,0 +1,7 @@
+- **Inert tab-bar tray on iPhone.** The floating tab bar only draws its
+  capsules, so touches in the tray's margins (beside, between, and below
+  the capsules) fell through to the message list behind it — scrolling
+  the list or opening a message. The tray band now swallows those
+  touches; rows behind the bar stay visible for context but are no
+  longer interactive. The shield deactivates automatically wherever the
+  tab bar is hidden (e.g. the message reader).


### PR DESCRIPTION
The iOS 26 floating tab bar reserves a full-width tray at the bottom of the screen but only draws the capsules; touches in the tray's margins (beside, between, and below the capsules) fell through to the message list behind it — scrolling the list or opening a message. The rows remain **visible** through the tray for context, but should not be **interactive**.

## Approach

- **`TabBarTrayShield.swift`** — a transparent `UIViewRepresentable` overlaid on each tab's content whose `point(inside:)` claims only the tray band, measured live from `safeAreaInsets.bottom`. Claimed touches are swallowed at the UIKit hit-test level, so the list's scroll pan never sees them; everything above the band passes through untouched.
- **Applied per tab inside the `TabView`** (all five tabs, including search) — the tab bar is system chrome hosted *above* each tab's content, so the shield can't intercept the capsules or the search morph. An overlay on the `TabView` itself would deaden the bar.
- **Auto-inert when the bar hides**: `MessageDetailView` hides the tab bar for the reader; there the view's bottom inset collapses to the window's own home-indicator inset and the shield claims nothing.
- Guarded `#if !os(macOS)` since `Cabalmail/Views` also compiles into `CabalmailMac`.

## Verification

- `scripts/build-apple.sh`: swiftlint --strict, macOS and iOS builds all pass.
- Local visionOS leg fails on pre-existing `MailRootView.swift:589` (`sharedBackgroundVisibility` unavailable in the local Xcode 26.6 visionOS SDK) — already on stage tip `ee755b00`, where CI's visionOS leg is green, so it's a local SDK quirk unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)