### PR TITLE
Don't fail TestFlight upload on altool's recovered retries

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -461,14 +461,20 @@ jobs:
             --type ios \
             --apiKey "$ASC_KEY_ID" \
             --apiIssuer "$ASC_ISSUER_ID" 2>&1 | tee "$LOG"
-          # altool writes timestamped "ERROR:" lines and returns 0 anyway in
-          # some releases, so we scan the log and fail the step ourselves if
-          # any error marker appears. The pattern matches anywhere in the
-          # line since altool prefixes errors with a timestamp.
-          if grep -qE '(UPLOAD FAILED|ERROR: |iris-code : STATE_ERROR)' "$LOG"; then
-            ERRORS=$(grep -cE '(UPLOAD FAILED|ERROR: )' "$LOG")
-            echo "::error::altool reported $ERRORS error line(s) despite exit code 0. Review the log above."
+          # altool's exit code is unreliable (0 on some validation failures),
+          # and its "ERROR:" lines are unreliable the other way: a transient
+          # chunk failure logs "ERROR: ... WILL RETRY PART n ..." and then
+          # recovers (this false-failed a real upload once - the log ended
+          # "UPLOAD SUCCEEDED with no errors"). Trust the final verdict
+          # banner instead: pass iff altool printed UPLOAD SUCCEEDED and no
+          # failure banner; recovered retries only warn.
+          if grep -qE '(UPLOAD FAILED|iris-code : STATE_ERROR)' "$LOG" \
+             || ! grep -q 'UPLOAD SUCCEEDED' "$LOG"; then
+            echo "::error::altool did not report a clean UPLOAD SUCCEEDED despite exit code 0. Review the log above."
             exit 1
+          fi
+          if grep -q 'ERROR: ' "$LOG"; then
+            echo "::warning::altool logged transient error(s) but recovered - final verdict was UPLOAD SUCCEEDED."
           fi
           echo "::notice::altool upload completed cleanly."
           {
@@ -739,14 +745,19 @@ jobs:
             --type osx \
             --apiKey "$ASC_KEY_ID" \
             --apiIssuer "$ASC_ISSUER_ID" 2>&1 | tee "$LOG"
-          # altool writes timestamped "ERROR:" lines and returns 0 anyway in
-          # some releases, so we scan the log and fail the step ourselves if
-          # any error marker appears. The pattern matches anywhere in the
-          # line since altool prefixes errors with a timestamp.
-          if grep -qE '(UPLOAD FAILED|ERROR: |iris-code : STATE_ERROR)' "$LOG"; then
-            ERRORS=$(grep -cE '(UPLOAD FAILED|ERROR: )' "$LOG")
-            echo "::error::altool reported $ERRORS error line(s) despite exit code 0. Review the log above."
+          # altool's exit code is unreliable (0 on some validation failures),
+          # and its "ERROR:" lines are unreliable the other way: a transient
+          # chunk failure logs "ERROR: ... WILL RETRY PART n ..." and then
+          # recovers. Trust the final verdict banner instead: pass iff altool
+          # printed UPLOAD SUCCEEDED and no failure banner; recovered retries
+          # only warn. (Mirrors the iOS upload step.)
+          if grep -qE '(UPLOAD FAILED|iris-code : STATE_ERROR)' "$LOG" \
+             || ! grep -q 'UPLOAD SUCCEEDED' "$LOG"; then
+            echo "::error::altool did not report a clean UPLOAD SUCCEEDED despite exit code 0. Review the log above."
             exit 1
+          fi
+          if grep -q 'ERROR: ' "$LOG"; then
+            echo "::warning::altool logged transient error(s) but recovered - final verdict was UPLOAD SUCCEEDED."
           fi
           echo "::notice::altool upload completed cleanly."
 

--- a/changelog.d/altool-retry-false-positive.fixed.md
+++ b/changelog.d/altool-retry-false-positive.fixed.md
@@ -1,0 +1,8 @@
+- **TestFlight upload no longer fails on recovered network retries.** The
+  iOS/macOS upload steps guarded against altool's unreliable exit code by
+  failing on any `ERROR:` log line, which false-failed a successful upload
+  when a transient "connection was lost" chunk error was retried and the
+  final banner read `UPLOAD SUCCEEDED`. The guard now trusts altool's final
+  verdict: pass only on `UPLOAD SUCCEEDED` with no failure banner, warn on
+  recovered retries, and still fail on `UPLOAD FAILED`, `STATE_ERROR`, or a
+  missing verdict.


### PR DESCRIPTION
## Summary

[Run 28954604753](https://github.com/cabalmail/cabal-infra/actions/runs/28954604753) (the PR #611 merge to stage) failed **Upload iOS to TestFlight** even though the upload succeeded. The log shows a transient chunk failure that altool retried and recovered from:

```
ERROR: [ContentDelivery.Uploader...] WILL RETRY PART 1. Failed with error: ... "The network connection was lost."
...
UPLOAD SUCCEEDED with no errors
Delivery UUID: ae1427cf-99d0-4f76-b333-4ce677d8f0dc
```

The step's guard — added because altool sometimes exits 0 on real validation failures — greps for any `ERROR: ` line, so a *recovered* retry false-failed the job. No delivery was lost (the build reached App Store Connect; the only skipped step was the prod-only "What to Test" notes).

## Fix

In both the iOS and macOS upload steps, trust altool's **final verdict banner** instead of individual error lines:

- **Pass** iff the log contains `UPLOAD SUCCEEDED` and no `UPLOAD FAILED` / `iris-code : STATE_ERROR`.
- **Warn** (`::warning::`) when recovered retry errors are present alongside the success banner.
- **Fail** on a failure banner, a STATE_ERROR, or a missing verdict entirely — so the original exit-code-0-on-validation-failure case is still caught.

## Validation

Exercised the new guard against five log shapes: the actual failing run's log (pass + warning), a validation failure (fail), errors with no verdict banner (fail), clean success (pass), and STATE_ERROR alongside a success banner (fail). `actionlint`/YAML clean — remaining shellcheck infos on those steps are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)