### PR TITLE
Restore the native visionOS build and its layered app icon

### DIFF
--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -570,8 +570,16 @@ extension MailRootView {
             // On OS 26's liquid glass, a bare toolbar item gets wrapped in a
             // glass capsule, which makes the decorative mark read as a button.
             // Detach it from the shared glass background where the API exists;
-            // earlier systems render toolbar images plain anyway.
-            if #available(iOS 26.0, visionOS 26.0, *) {
+            // earlier systems render toolbar images plain anyway. The SDK
+            // marks `sharedBackgroundVisibility` explicitly unavailable on
+            // visionOS (a runtime `#available` check can't gate a symbol the
+            // compiler rejects), so the visionOS build takes the plain path.
+            #if os(visionOS)
+            ToolbarItem(placement: .topBarLeading) {
+                CabalmailMark(size: isWideSidebar ? 102 : 132)
+            }
+            #else
+            if #available(iOS 26.0, *) {
                 ToolbarItem(placement: .topBarLeading) {
                     CabalmailMark(size: isWideSidebar ? 102 : 132)
                 }
@@ -581,6 +589,7 @@ extension MailRootView {
                     CabalmailMark(size: isWideSidebar ? 102 : 132)
                 }
             }
+            #endif
         }
         #endif
     }

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -52,8 +52,13 @@ targets:
       properties:
         CFBundleDisplayName: Cabalmail
         # Required by App Store validation for apps built against
-        # iOS 11+ SDKs that ship icons in an asset catalog.
-        CFBundleIconName: AppIcon
+        # iOS 11+ SDKs that ship icons in an asset catalog. Routed through
+        # the build setting so it tracks the per-SDK override below —
+        # `AppIcon` on iOS/iPadOS, `AppIconVision` on visionOS. A literal
+        # `AppIcon` here points visionOS at an icon that isn't in its
+        # compiled catalog (actool compiles only the xros primary icon),
+        # so the device falls back to a flat squircle in the icon well.
+        CFBundleIconName: "$(ASSETCATALOG_COMPILER_APPICON_NAME)"
         # App uses only standard HTTPS/TLS; exempt from export compliance
         # questions on every TestFlight upload.
         ITSAppUsesNonExemptEncryption: false

--- a/changelog.d/visionos-native-icon.fixed.md
+++ b/changelog.d/visionos-native-icon.fixed.md
@@ -1,0 +1,8 @@
+- **Native visionOS build and icon restored.** The visionOS target had not
+  compiled since the sidebar-branding change (`sharedBackgroundVisibility` is
+  compile-time unavailable on visionOS, which a runtime `#available` check
+  cannot gate), and the hardcoded `CFBundleIconName: AppIcon` pointed visionOS
+  at the flat iOS icon instead of the layered `AppIconVision` stack. The
+  toolbar mark now takes the plain path on visionOS, and `CFBundleIconName`
+  is routed through `ASSETCATALOG_COMPILER_APPICON_NAME` so each platform
+  resolves its own icon.


### PR DESCRIPTION
## Why the Vision Pro shows a flat, squared-off icon

Today's TestFlight build renders the new mark correctly on Mac/iPad/iPhone but flat-in-a-well on visionOS. Three stacked causes:

1. **TestFlight only carries the iOS archive** (`apple.yml` archives `generic/platform=iOS` only), so the Vision Pro install is the iPad app in compatibility mode — which *by design* renders the flat iOS icon on a dark disc and never consults `AppIconVision`.
2. **The native visionOS target didn't compile** since Jul 3: `.sharedBackgroundVisibility` on the sidebar mark is compile-time unavailable on visionOS; the `if #available(iOS 26.0, visionOS 26.0, *)` runtime check can't gate a symbol the compiler rejects.
3. **`CFBundleIconName` was hardcoded to `AppIcon`** for every platform, while actool compiles only `AppIconVision` into the xros catalog — a native build's plist pointed at an icon absent from its own `Assets.car`.

## Changes

- `MailRootView.swift`: visionOS takes the plain `ToolbarItem` path via `#if os(visionOS)`; iOS keeps the liquid-glass detach.
- `project.yml`: `CFBundleIconName` routed through `$(ASSETCATALOG_COMPILER_APPICON_NAME)` (same idiom as `MARKETING_VERSION`), so iOS resolves `AppIcon` and visionOS resolves `AppIconVision`.
- Changelog fragment.

## Verification

- `xcodebuild` succeeds for `generic/platform=visionOS` (previously 1 error) and `generic/platform=iOS`.
- Built xros `Info.plist`: `CFBundleIconName = AppIconVision`, `CFBundlePrimaryIcon = AppIconVision`; xros `Assets.car` contains the three-layer stack.
- Built iphoneos `Info.plist`: `CFBundleIconName = AppIcon`; flat icon set present in its `Assets.car`.
- `swiftlint` clean.

## Seeing it on the device

The layered icon appears only for a **native** install: side-load via the visionOS device-deploy runbook (build → `devicectl install`). The TestFlight path stays compat-mode until a visionOS archive is added to CI (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)