### PR TITLE
Ship a native visionOS archive to TestFlight

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -153,20 +153,28 @@ jobs:
             | xcbeautify --renderer github-actions
 
   # -----------------------------------------------------------------------
-  # Build the app targets for the two product platforms. Unsigned — this
+  # Build the app targets for the three product platforms. Unsigned — this
   # job only verifies the code compiles and links; signing happens in the
-  # upload jobs below.
+  # upload jobs below. visionOS gets its own leg because the Cabalmail
+  # scheme's iOS and xros compilations diverge (`#if os(visionOS)` paths,
+  # per-SDK availability): an API that is compile-time unavailable on
+  # visionOS builds green for iOS and only breaks here.
   # -----------------------------------------------------------------------
   app-build:
-    name: Build ${{ matrix.scheme }}
+    name: Build ${{ matrix.scheme }} (${{ matrix.platform }})
     runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
         include:
           - scheme: Cabalmail
+            platform: iOS
             destination: 'generic/platform=iOS'
+          - scheme: Cabalmail
+            platform: visionOS
+            destination: 'generic/platform=visionOS'
           - scheme: CabalmailMac
+            platform: macOS
             destination: 'generic/platform=macOS'
     steps:
       - name: Checkout
@@ -197,9 +205,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: ~/Library/Developer/Xcode/DerivedData
-          key: dd-${{ runner.os }}-${{ matrix.scheme }}-${{ hashFiles('apple/project.yml', 'apple/CabalmailKit/Package.swift', 'apple/CabalmailKit/Package.resolved') }}
+          key: dd-${{ runner.os }}-${{ matrix.scheme }}-${{ matrix.platform }}-${{ hashFiles('apple/project.yml', 'apple/CabalmailKit/Package.swift', 'apple/CabalmailKit/Package.resolved') }}
           restore-keys: |
-            dd-${{ runner.os }}-${{ matrix.scheme }}-
+            dd-${{ runner.os }}-${{ matrix.scheme }}-${{ matrix.platform }}-
 
       - name: Build ${{ matrix.scheme }} (unsigned)
         working-directory: apple
@@ -223,15 +231,35 @@ jobs:
       run: echo "Approved"
 
   # -----------------------------------------------------------------------
-  # Signed archive + TestFlight upload for iOS/iPadOS/visionOS. Only runs
-  # on main or stage and only if the required secrets are configured.
+  # Signed archive + TestFlight upload for iOS/iPadOS and visionOS. Only
+  # runs on main or stage and only if the required secrets are configured.
+  # One matrix leg per App Store platform: the iOS archive covers
+  # iPhone/iPad (and used to be what Vision Pro installed, in compatibility
+  # mode); the visionOS leg ships the native xros build so the headset
+  # gets the layered AppIconVision stack, real windows, etc. Both legs
+  # sign with the same bundle ID, Apple Distribution certificate, and
+  # provisioning profile — modern App Store profiles list iOS and xrOS
+  # together. If the visionOS leg fails signing with a "doesn't include
+  # the xrOS platform" error, regenerate the App Store profile in the
+  # developer portal and refresh the IOS_APP_STORE_PROFILE secret.
   # -----------------------------------------------------------------------
   upload-ios:
-    name: Upload iOS to TestFlight
+    name: Upload ${{ matrix.platform }} to TestFlight
     needs: approval
     if: ${{ github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'stage') }}
     runs-on: macos-15
     environment: ${{ github.ref_name == 'main' && 'prod' || 'stage' }}
+    strategy:
+      # Never cancel a leg mid-upload because the other leg failed.
+      fail-fast: false
+      matrix:
+        include:
+          - platform: iOS
+            destination: 'generic/platform=iOS'
+            altool_type: ios
+          - platform: visionOS
+            destination: 'generic/platform=visionOS'
+            altool_type: visionos
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -394,7 +422,7 @@ jobs:
             -workspace Cabalmail.xcworkspace \
             -scheme Cabalmail \
             -configuration Release \
-            -destination 'generic/platform=iOS' \
+            -destination '${{ matrix.destination }}' \
             -archivePath "$RUNNER_TEMP/Cabalmail.xcarchive" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             IOS_APP_STORE_PROFILE_UUID="$IOS_APP_STORE_PROFILE_UUID" \
@@ -412,7 +440,7 @@ jobs:
           # needs the `provisioningProfiles` dict to map each bundle ID to
           # a profile; the archive's embedded profile alone isn't always
           # consulted during export.
-          PLIST="$RUNNER_TEMP/ExportOptions-iOS.plist"
+          PLIST="$RUNNER_TEMP/ExportOptions-${{ matrix.altool_type }}.plist"
           cat > "$PLIST" <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -440,7 +468,7 @@ jobs:
           EOF
           xcodebuild -exportArchive \
             -archivePath "$RUNNER_TEMP/Cabalmail.xcarchive" \
-            -exportPath "$RUNNER_TEMP/export-ios" \
+            -exportPath "$RUNNER_TEMP/export-${{ matrix.altool_type }}" \
             -exportOptionsPlist "$PLIST" \
             | xcbeautify --renderer github-actions
 
@@ -451,14 +479,14 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           set -euo pipefail
-          IPA=$(ls "$RUNNER_TEMP/export-ios"/*.ipa | head -n1)
+          IPA=$(ls "$RUNNER_TEMP/export-${{ matrix.altool_type }}"/*.ipa | head -n1)
           echo "Uploading $IPA"
-          LOG="$RUNNER_TEMP/altool-ios.log"
+          LOG="$RUNNER_TEMP/altool-${{ matrix.altool_type }}.log"
           # altool returns 0 even on validation failure in some releases, so
           # we also grep for its failure banners and fail the step ourselves.
           xcrun altool --upload-app \
             -f "$IPA" \
-            --type ios \
+            --type ${{ matrix.altool_type }} \
             --apiKey "$ASC_KEY_ID" \
             --apiIssuer "$ASC_ISSUER_ID" 2>&1 | tee "$LOG"
           # altool's exit code is unreliable (0 on some validation failures),
@@ -478,7 +506,7 @@ jobs:
           fi
           echo "::notice::altool upload completed cleanly."
           {
-            echo "### iOS TestFlight upload"
+            echo "### ${{ matrix.platform }} TestFlight upload"
             echo ""
             echo "- Workflow run: \`${{ github.run_number }}\`"
             echo "- Environment: \`${{ github.ref_name == 'main' && 'prod' || 'stage' }}\`"
@@ -489,7 +517,10 @@ jobs:
         # Prod releases only - the stage track is the developer's own and
         # ships no notes. Best-effort: the binary is already uploaded, so the
         # script warns and exits 0 on any failure rather than failing release.
-        if: steps.check.outputs.enabled == 'true' && github.ref_name == 'main'
+        # iOS leg only: the script matches builds by CFBundleVersion, and the
+        # legs stamp different timestamps — one notes pass per release is
+        # enough until the script grows platform awareness.
+        if: steps.check.outputs.enabled == 'true' && github.ref_name == 'main' && matrix.platform == 'iOS'
         env:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -570,8 +570,16 @@ extension MailRootView {
             // On OS 26's liquid glass, a bare toolbar item gets wrapped in a
             // glass capsule, which makes the decorative mark read as a button.
             // Detach it from the shared glass background where the API exists;
-            // earlier systems render toolbar images plain anyway.
-            if #available(iOS 26.0, visionOS 26.0, *) {
+            // earlier systems render toolbar images plain anyway. The SDK
+            // marks `sharedBackgroundVisibility` explicitly unavailable on
+            // visionOS (a runtime `#available` check can't gate a symbol the
+            // compiler rejects), so the visionOS build takes the plain path.
+            #if os(visionOS)
+            ToolbarItem(placement: .topBarLeading) {
+                CabalmailMark(size: isWideSidebar ? 102 : 132)
+            }
+            #else
+            if #available(iOS 26.0, *) {
                 ToolbarItem(placement: .topBarLeading) {
                     CabalmailMark(size: isWideSidebar ? 102 : 132)
                 }
@@ -581,6 +589,7 @@ extension MailRootView {
                     CabalmailMark(size: isWideSidebar ? 102 : 132)
                 }
             }
+            #endif
         }
         #endif
     }

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -52,8 +52,13 @@ targets:
       properties:
         CFBundleDisplayName: Cabalmail
         # Required by App Store validation for apps built against
-        # iOS 11+ SDKs that ship icons in an asset catalog.
-        CFBundleIconName: AppIcon
+        # iOS 11+ SDKs that ship icons in an asset catalog. Routed through
+        # the build setting so it tracks the per-SDK override below —
+        # `AppIcon` on iOS/iPadOS, `AppIconVision` on visionOS. A literal
+        # `AppIcon` here points visionOS at an icon that isn't in its
+        # compiled catalog (actool compiles only the xros primary icon),
+        # so the device falls back to a flat squircle in the icon well.
+        CFBundleIconName: "$(ASSETCATALOG_COMPILER_APPICON_NAME)"
         # App uses only standard HTTPS/TLS; exempt from export compliance
         # questions on every TestFlight upload.
         ITSAppUsesNonExemptEncryption: false

--- a/changelog.d/visionos-native-icon.fixed.md
+++ b/changelog.d/visionos-native-icon.fixed.md
@@ -1,0 +1,8 @@
+- **Native visionOS build and icon restored.** The visionOS target had not
+  compiled since the sidebar-branding change (`sharedBackgroundVisibility` is
+  compile-time unavailable on visionOS, which a runtime `#available` check
+  cannot gate), and the hardcoded `CFBundleIconName: AppIcon` pointed visionOS
+  at the flat iOS icon instead of the layered `AppIconVision` stack. The
+  toolbar mark now takes the plain path on visionOS, and `CFBundleIconName`
+  is routed through `ASSETCATALOG_COMPILER_APPICON_NAME` so each platform
+  resolves its own icon.

--- a/changelog.d/visionos-testflight.added.md
+++ b/changelog.d/visionos-testflight.added.md
@@ -1,0 +1,6 @@
+- **Native visionOS build in CI.** `apple.yml` now compiles the Cabalmail
+  scheme for visionOS in the unsigned build gate (catching xros-only compile
+  breaks that an iOS build misses) and ships a native visionOS archive to
+  TestFlight alongside the iOS one, so the Vision Pro can install the real
+  app — layered parallax icon and all — instead of the iPad build in
+  compatibility mode.


### PR DESCRIPTION
Follow-up to #615. **Stacked on that branch** — the visionOS legs added here only pass once #615's compile fix is in; merge #615 first and this PR's diff collapses to the two commits it adds.

## Changes to `apple.yml`

1. **`app-build` gains a visionOS leg** (unsigned compile gate). iOS and xros compilations of the Cabalmail scheme diverge (`#if os(visionOS)`, per-SDK availability), so a visionOS-only compile break sails through the iOS build — this leg would have caught the Jul 3 `sharedBackgroundVisibility` break the day it landed. DerivedData cache key now includes the platform so the two Cabalmail legs don't share stale caches.

2. **`upload-ios` becomes a two-leg matrix (iOS, visionOS)** — same secrets, certificate, bundle ID, and provisioning profile; the legs differ only in `-destination` and `altool --type`. `fail-fast: false` so a failure in one leg never cancels the other mid-upload. TestFlight "What to Test" notes stay on the iOS leg only (the script matches builds by `CFBundleVersion`, and the legs stamp independent timestamps).

## One-time manual steps that may be needed on first run

- **App Store Connect**: if the visionOS upload is rejected for a missing platform, add *Apple Vision Pro* to the Cabalmail app record (App Store Connect → Cabalmail → Add Platform), then re-run the job.
- **Provisioning profile**: both legs sign with `IOS_APP_STORE_PROFILE`. Modern App Store distribution profiles list iOS and xrOS together; if the archive step fails with "profile doesn't include the xrOS platform", regenerate the profile in the developer portal and refresh the secret (same name, new value).

## Verification

- The equivalent `generic/platform=visionOS` archive path builds locally on this branch (verified in #615).
- `actionlint`: finding count unchanged (5 pre-existing shellcheck notes).
- No new secrets; environment gating, approval job, and the macOS job untouched.

After this merges and `stage` builds, the Vision Pro's TestFlight will offer the **native** app — that's when the layered icon (and honest visionOS windows) replace the compat-mode iPad app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)