### PR TITLE
Retire poisoned append_sent container on getaddrinfo EBUSY

### DIFF
--- a/changelog.d/append-sent-wedged-resolver.fixed.md
+++ b/changelog.d/append-sent-wedged-resolver.fixed.md
@@ -1,0 +1,10 @@
+- **Sent-copy delivery no longer trapped by a wedged sandbox resolver.** When
+  the `append_sent` consumer's Lambda execution environment hit a sticky
+  `getaddrinfo` `EBUSY`, every invocation in that container failed identically
+  and SQS pinned redelivery (batch size 1) to the same warm container, so the
+  Sent copy retried until the DLQ instead of being written — even though a
+  fresh container resolves the IMAP host fine. The consumer now crashes the
+  process on that specific failure so Lambda retires the poisoned container and
+  the next redelivery cold-starts a healthy one. SMTP delivery was never
+  affected (it does not touch IMAP), and the planned-IMAP-roll retry path
+  (`MaintenanceError`) is unchanged.

--- a/lambda/api/append_sent/function.py
+++ b/lambda/api/append_sent/function.py
@@ -10,7 +10,9 @@ serving. After the queue's maxReceiveCount the record lands in the DLQ.
 
 The event source mapping uses batch_size 1 so a single failing job retries on
 its own rather than dragging a whole batch with it.'''
+import errno
 import json
+import os
 from botocore.exceptions import ClientError # pylint: disable=import-error
 from helper import get_imap_client # pylint: disable=import-error
 from helper import get_object # pylint: disable=import-error
@@ -45,9 +47,25 @@ def _process(job):
 
     # Connect to INBOX (always present); create/select Sent ourselves so a fresh
     # mailbox without a Sent folder still works. get_imap_client raises during a
-    # planned IMAP roll, which is exactly when we WANT the job to retry, so it is
-    # deliberately not guarded here.
-    client = get_imap_client(None, user, 'INBOX')
+    # planned IMAP roll (MaintenanceError, not an OSError), which is exactly when
+    # we WANT the job to retry, so that path is deliberately not guarded here.
+    try:
+        client = get_imap_client(None, user, 'INBOX')
+    except OSError as err:
+        if err.errno == errno.EBUSY:
+            # The sandbox resolver can wedge such that getaddrinfo fails with
+            # EBUSY, and it sticks to this execution environment: every
+            # invocation here fails identically. Because SQS pins redelivery
+            # (batch_size 1) to the same warm container, the job would be
+            # trapped retrying forever until the DLQ, even though a fresh
+            # container resolves fine (interactive lambdas dodge this by
+            # retrying onto a different container). Crash the process so Lambda
+            # retires the poisoned container; SQS redelivers to a cold-started
+            # one. os._exit skips atexit/flush, so emit the log line first.
+            print('[append-sent] getaddrinfo EBUSY: resolver wedged in this '
+                  f'container, retiring it so redelivery lands fresh: {err}')
+            os._exit(1)  # pylint: disable=protected-access
+        raise
     try:
         try:
             client.create_folder('Sent')


### PR DESCRIPTION
## Problem

A user's sent message was delivered fine (SMTP succeeded, recipient replied) but never appeared in Sent. Root cause: the decoupled `append_sent` SQS consumer, which writes the Sent copy, was failing on **every** retry with:

```
OSError: [Errno 16] Device or resource busy   # EBUSY, at socket.getaddrinfo
```

Diagnosis from prod logs:

- The `EBUSY` from `getaddrinfo` is **sticky per execution environment** — every invocation in a given container fails identically (observed 8/8 on the original container, then 4/4 on a fresh one after a config-recycle: 12 consecutive across two containers).
- **Interactive IMAP lambdas stayed healthy throughout** (`list_folders`, `list_envelopes` succeeded during the same window, same `IMAP_HOST`, same `open_imap_client` code) — they dodge it because each request can land on a different container and callers retry.
- **`append_sent` is a trap**: the SQS event source uses `batch_size 1`, so redelivery is pinned to the same warm (poisoned) container. The job can never escape on its own and churns until the DLQ.

The message content is never at risk — the SQS body is only a pointer; the raw copy sits in S3 (`sent-pending/<user>/<uuid>`) and is deleted only on a successful append.

## Fix

Catch the `EBUSY` case at connect and `os._exit(1)` after logging, so Lambda **retires the poisoned container**. The next SQS redelivery cold-starts a fresh environment, which resolves the IMAP host fine, and the append succeeds. Since in-process retry is useless here (same container = same failure), forcing container replacement is the only thing that actually breaks the trap.

Scoped deliberately:

- Only `errno.EBUSY` triggers the crash. The planned-IMAP-roll path raises `MaintenanceError` (subclasses `Exception`, not `OSError`) **before** the connect, so it keeps its existing raise-and-retry behavior.
- Genuine DNS-not-found surfaces as `socket.gaierror` with a different errno, so a real outage still retries rather than crash-looping.

## Testing

- `pylint --rcfile .pylintrc append_sent/function.py` → 10.00/10.
- No behavior change on the happy path or the maintenance-roll path; the new branch only fires on `getaddrinfo`/`EBUSY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)