### PR TITLE
Replace append_sent os._exit with INIT-time IMAP resolution + EBUSY shim

### DIFF
--- a/changelog.d/append-sent-wedged-resolver.fixed.md
+++ b/changelog.d/append-sent-wedged-resolver.fixed.md
@@ -1,10 +1,12 @@
-- **Sent-copy delivery no longer trapped by a wedged sandbox resolver.** When
-  the `append_sent` consumer's Lambda execution environment hit a sticky
-  `getaddrinfo` `EBUSY`, every invocation in that container failed identically
-  and SQS pinned redelivery (batch size 1) to the same warm container, so the
-  Sent copy retried until the DLQ instead of being written — even though a
-  fresh container resolves the IMAP host fine. The consumer now crashes the
-  process on that specific failure so Lambda retires the poisoned container and
-  the next redelivery cold-starts a healthy one. SMTP delivery was never
-  affected (it does not touch IMAP), and the planned-IMAP-roll retry path
-  (`MaintenanceError`) is unchanged.
+- **Sent-copy delivery no longer trapped by a wedged sandbox resolver.** The
+  `append_sent` consumer's Lambda container can wedge such that DNS resolution
+  of the IMAP host fails with `EBUSY` for the container's entire life, and
+  because the SQS event source (batch size 1) pins redelivery to the same warm
+  container, the Sent copy retried until the DLQ instead of being written.
+  Only this consumer was exposed — interactive endpoints ride client retries
+  onto other containers. The consumer now resolves the IMAP host once at INIT
+  (so a container wedged from birth fails INIT and is replaced by Lambda) and
+  falls back to that cached address if the resolver wedges later, keeping TLS
+  certificate validation against the hostname. SMTP delivery was never
+  affected, and no Sent copy was lost — undelivered copies wait in the queue
+  or DLQ with the raw message staged in S3.

--- a/lambda/api/append_sent/function.py
+++ b/lambda/api/append_sent/function.py
@@ -12,11 +12,74 @@ The event source mapping uses batch_size 1 so a single failing job retries on
 its own rather than dragging a whole batch with it.'''
 import errno
 import json
-import os
+import socket
 from botocore.exceptions import ClientError # pylint: disable=import-error
+from helper import IMAP_HOST # pylint: disable=import-error
 from helper import get_imap_client # pylint: disable=import-error
 from helper import get_object # pylint: disable=import-error
 from helper import delete_object # pylint: disable=import-error
+
+# --- Wedged-resolver armor --------------------------------------------------
+# The Lambda sandbox resolver can wedge such that getaddrinfo for IMAP_HOST
+# fails with EBUSY for the container's entire life, while other names (S3,
+# SQS) keep resolving in the same invocation. Only this consumer is exposed:
+# interactive lambdas ride client retries onto other containers, but the SQS
+# event source (batch_size 1) pins redelivery to the same warm container, so a
+# wedged container traps the job until the DLQ. Crashing mid-invocation does
+# not help -- os._exit(1) was tried and the environment was reused anyway.
+# Two defenses:
+#
+# 1. Resolve IMAP_HOST once at import time (bottom of this block). On a
+#    container wedged from birth this raises during INIT, and a failed INIT
+#    makes Lambda discard the environment and provision a fresh sandbox for
+#    the next delivery -- the retirement a mid-invocation crash cannot achieve.
+# 2. Shim socket.getaddrinfo for IMAP_HOST only: try the live resolver first
+#    (freshness), fall back to the INIT-time answer on EBUSY (a wedge that
+#    develops after INIT). The shim answers with address tuples, so the TLS
+#    layer still validates the certificate against the hostname.
+#
+# The NLB behind IMAP_HOST keeps its per-AZ addresses for its lifetime, so the
+# cached answer only goes stale if the NLB is replaced while this container is
+# warm AND the resolver is wedged at that moment; in that double failure the
+# connect fails and SQS retry/DLQ behaves exactly as it did before the shim.
+
+_real_getaddrinfo = socket.getaddrinfo
+
+
+def _rewrite_port(addrinfo, port):
+    '''Returns addrinfo tuples with the sockaddr port replaced. The cached
+    answer is keyed only by host, so serve whatever port the caller asked for
+    (in practice always 993).'''
+    return [
+        (family, type_, proto, cname, (sockaddr[0], port) + sockaddr[2:])
+        for family, type_, proto, cname, sockaddr in addrinfo
+    ]
+
+
+def _imap_getaddrinfo(host, port, *args, **kwargs):
+    '''socket.getaddrinfo with an EBUSY fallback for IMAP_HOST. Installed
+    module-wide below; socket.create_connection resolves getaddrinfo through
+    the socket module's namespace at call time, so imapclient's connect goes
+    through here.'''
+    if host != IMAP_HOST:
+        return _real_getaddrinfo(host, port, *args, **kwargs)
+    try:
+        fresh = _real_getaddrinfo(host, port, *args, **kwargs)
+        _last_good['addrinfo'] = fresh
+        return fresh
+    except OSError as err:
+        if err.errno != errno.EBUSY:
+            raise
+        print(f'[append-sent] getaddrinfo EBUSY for {IMAP_HOST}; '
+              'serving the address cached at INIT')
+        return _rewrite_port(_last_good['addrinfo'], port)
+
+
+# Deliberately at module scope: INIT is the one place a wedged-from-birth
+# container can fail in a way that makes Lambda replace it.
+_last_good = {'addrinfo': _real_getaddrinfo(IMAP_HOST, 993, 0, socket.SOCK_STREAM)}
+socket.getaddrinfo = _imap_getaddrinfo
+# -----------------------------------------------------------------------------
 
 
 def handler(event, _context):
@@ -47,25 +110,10 @@ def _process(job):
 
     # Connect to INBOX (always present); create/select Sent ourselves so a fresh
     # mailbox without a Sent folder still works. get_imap_client raises during a
-    # planned IMAP roll (MaintenanceError, not an OSError), which is exactly when
-    # we WANT the job to retry, so that path is deliberately not guarded here.
-    try:
-        client = get_imap_client(None, user, 'INBOX')
-    except OSError as err:
-        if err.errno == errno.EBUSY:
-            # The sandbox resolver can wedge such that getaddrinfo fails with
-            # EBUSY, and it sticks to this execution environment: every
-            # invocation here fails identically. Because SQS pins redelivery
-            # (batch_size 1) to the same warm container, the job would be
-            # trapped retrying forever until the DLQ, even though a fresh
-            # container resolves fine (interactive lambdas dodge this by
-            # retrying onto a different container). Crash the process so Lambda
-            # retires the poisoned container; SQS redelivers to a cold-started
-            # one. os._exit skips atexit/flush, so emit the log line first.
-            print('[append-sent] getaddrinfo EBUSY: resolver wedged in this '
-                  f'container, retiring it so redelivery lands fresh: {err}')
-            os._exit(1)  # pylint: disable=protected-access
-        raise
+    # planned IMAP roll, which is exactly when we WANT the job to retry, so it is
+    # deliberately not guarded here. A wedged-resolver EBUSY is handled by the
+    # getaddrinfo shim at the top of this module, not here.
+    client = get_imap_client(None, user, 'INBOX')
     try:
         try:
             client.create_folder('Sent')


### PR DESCRIPTION
## Stage disproved #620

The `os._exit(1)` approach does not work. Stage evidence after a test send:

```
16:00:29  c98a9347  INIT_START           ← one cold start
16:00:30  c98a9347  EBUSY → os._exit(1)
16:02:30  c98a9347  EBUSY → os._exit(1)  ← same container, no new INIT
16:04:30  c98a9347  EBUSY → os._exit(1)  ← same container again
```

Lambda reuses the execution environment after a mid-invocation crash, so a wedged container still traps the SQS job. This PR reverts that mechanism and replaces it.

## What five days of logs established

- **Recurring, not a one-off**: a ~21-minute EBUSY retry loop on 07-05 ended in the stage DLQ; today's test repeated the pattern. Prod hit it independently on 07-09.
- **Exclusive to `append_sent`**: zero `EBUSY` events across every interactive IMAP lambda (`list_folders`, `list_envelopes`, `fetch_message`, `send`, `save_draft`, `move_messages`, `set_flag`) in the same 5-day window, at far higher volume, on the identical `getaddrinfo` path. Interactive callers retry onto other containers; the SQS event source (`batch_size 1`) pins redelivery to the warm wedged one.
- **The wedge is per-name, not a dead resolver**: in the same failing invocation, `get_object` (S3) resolves fine moments before `IMAP_HOST` fails with `EBUSY`.
- **Wedged from birth**: a fresh container failed its first invocation one second after `INIT_START`.

## The fix (two layers)

1. **Resolve `IMAP_HOST` once at module scope.** A container wedged from birth now fails INIT — and a failed INIT is the one crash Lambda answers by *discarding* the environment, so the next SQS redelivery cold-starts a genuinely fresh sandbox. This is the container retirement `os._exit` could not deliver.
2. **Shim `socket.getaddrinfo` for `IMAP_HOST` only**: live resolution first (freshness), fall back to the INIT-cached address tuples on `EBUSY` (a wedge that develops after INIT). `socket.create_connection` looks `getaddrinfo` up through the socket module namespace at call time, so imapclient's connect observes the shim while **TLS still validates the certificate against the hostname** (the shim answers with address tuples; the hostname never changes).

Staleness bound: the NLB's per-AZ addresses are stable for its lifetime, so the cached answer only goes stale if the NLB is replaced while this container is warm **and** the resolver is wedged at that moment — that double failure degrades to the pre-shim retry/DLQ behavior, never a wrong connection.

## Deliberately not included

- **Memory-tier change (512→128 to match the interactive fleet)**: observed `Max Memory Used` is 110–114 MB just booting the runtime with a 1.2 KB message — 128 MB would flirt with OOM on real messages (≤~10 MB via API Gateway, ×2–3 in-memory copies during append), and 256 MB wouldn't test the fleet hypothesis. The shim's fallback log line (`getaddrinfo EBUSY for <host>; serving the address cached at INIT`) is the recurrence signal instead.

## Verification

- Shim mechanics tested standalone: EBUSY fallback, port rewrite, non-IMAP passthrough, non-EBUSY errors re-raise, and — the key integration property — `socket.create_connection` dialing the cached address under a simulated wedge.
- `pylint --rcfile .pylintrc append_sent/function.py` → 10.00/10.
- Changelog fragment from #620 rewritten to describe only what ships (the `os._exit` blind alley is dropped per the fragments convention).

## Post-merge punch list

- Stage DLQ holds **2 messages** (07-05 casualty + today's test) → redrive `cabal-append-sent-dlq` → `cabal-append-sent` after this deploys.
- Prod: same redrive for the original stuck message once this promotes (its raw copy is staged in S3 and backed up locally; nothing is lost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)