### PR TITLE
Include original attachments when forwarding a message

### DIFF
--- a/changelog.d/forward-includes-attachments.added.md
+++ b/changelog.d/forward-includes-attachments.added.md
@@ -1,0 +1,3 @@
+- **Forwarding carries attachments.** Forwarding a message in the web client
+  now brings the original message's attachments into the compose window as
+  removable chips; they upload and send exactly like hand-picked files.

--- a/react/admin/src/ApiClient.js
+++ b/react/admin/src/ApiClient.js
@@ -511,6 +511,16 @@ export default class ApiClient {
     });
   }
 
+  // Download attachment bytes from a presigned S3 GET URL (as minted by
+  // /fetch_attachment) into a Blob. No Authorization header — the signed
+  // URL carries its own credentials.
+  downloadAttachment(signedUrl) {
+    return axios.get(signedUrl, {
+      responseType: 'blob',
+      timeout: ONE_SECOND * 90,
+    });
+  }
+
   getAttachment(a, folder, id, seen) {
     const response = axios.get('/fetch_attachment',
       {

--- a/react/admin/src/Email/ComposeOverlay/ComposeOverlay.css
+++ b/react/admin/src/Email/ComposeOverlay/ComposeOverlay.css
@@ -547,6 +547,13 @@
   max-width: 240px;
 }
 
+/* Forwarded attachments whose bytes are still downloading. The chip keeps
+   its final footprint — only the tone changes — so nothing shifts when the
+   Blob lands. */
+.compose-attachment-chip--pending {
+  opacity: 0.55;
+}
+
 .compose-attachment-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/react/admin/src/Email/ComposeOverlay/ComposeOverlay.test.jsx
+++ b/react/admin/src/Email/ComposeOverlay/ComposeOverlay.test.jsx
@@ -10,12 +10,16 @@ const mockGetAddresses = vi.fn().mockResolvedValue({
 const mockSendMessage = vi.fn().mockResolvedValue({});
 const mockGetAttachmentUploadUrls = vi.fn();
 const mockUploadAttachmentToS3 = vi.fn().mockResolvedValue({});
+const mockGetAttachment = vi.fn();
+const mockDownloadAttachment = vi.fn();
 
 const mockApi = {
   getAddresses: mockGetAddresses,
   sendMessage: mockSendMessage,
   getAttachmentUploadUrls: mockGetAttachmentUploadUrls,
   uploadAttachmentToS3: mockUploadAttachmentToS3,
+  getAttachment: mockGetAttachment,
+  downloadAttachment: mockDownloadAttachment,
   newAddress: vi.fn().mockResolvedValue({ data: { address: 'new@test.com' } }),
 };
 
@@ -306,6 +310,123 @@ describe('ComposeOverlay', () => {
     } finally {
       unmount();
     }
+  });
+
+  describe('forwarded attachments', () => {
+    const FWD_ENVELOPE = { from: ['sender@example.com'], to: ['me@test.com'], cc: [], subject: 'Test' };
+    const FWD_SOURCE = {
+      folder: 'INBOX',
+      id: 42,
+      seen: true,
+      attachments: [{ name: 'report.pdf', type: 'application/pdf', size: 5, id: 2 }],
+    };
+
+    function renderForward(source = FWD_SOURCE) {
+      return renderCompose({
+        type: 'forward',
+        envelope: FWD_ENVELOPE,
+        recipient: 'me@test.com',
+        subject: 'Fwd: Test',
+        forward_attachments: source,
+      });
+    }
+
+    it('carries the original attachments into the compose window and sends them', async () => {
+      const blob = new Blob(['12345'], { type: 'application/pdf' });
+      mockGetAttachment.mockResolvedValueOnce({ data: { url: 'https://s3/get' } });
+      mockDownloadAttachment.mockResolvedValueOnce({ data: blob });
+      mockGetAttachmentUploadUrls.mockResolvedValueOnce({
+        data: { uploads: [{ key: 'outbound/cog-user/uuid/report.pdf', url: 'https://s3/put' }] }
+      });
+      const { unmount } = renderForward();
+      try {
+        // Chip appears immediately (pending), then resolves once the Blob lands.
+        expect(screen.getByText('report.pdf')).toBeInTheDocument();
+        expect(screen.getByText('loading…')).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.queryByText('loading…')).not.toBeInTheDocument();
+        });
+        expect(mockGetAttachment).toHaveBeenCalledWith(
+          FWD_SOURCE.attachments[0], 'INBOX', 42, true
+        );
+        expect(mockDownloadAttachment).toHaveBeenCalledWith('https://s3/get');
+
+        // Complete the form and send — the forwarded Blob goes up like a
+        // hand-picked file.
+        fireEvent.click(screen.getByLabelText('From'));
+        fireEvent.click(await screen.findByRole('option', { name: /user@test\.com/ }));
+        const toInput = screen.getByLabelText('Recipients');
+        fireEvent.change(toInput, { target: { value: 'dest@test.com' } });
+        fireEvent.keyDown(toInput, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+        await waitFor(() => {
+          expect(mockUploadAttachmentToS3).toHaveBeenCalledWith('https://s3/put', blob);
+        });
+        await waitFor(() => {
+          expect(mockSendMessage).toHaveBeenCalled();
+        });
+        const wireAttachments = mockSendMessage.mock.calls[0][10];
+        expect(wireAttachments).toEqual([{
+          filename: 'report.pdf',
+          mime_type: 'application/pdf',
+          s3_key: 'outbound/cog-user/uuid/report.pdf',
+        }]);
+      } finally {
+        unmount();
+      }
+    });
+
+    it('blocks Send while a forwarded attachment is still downloading', async () => {
+      mockGetAttachment.mockReturnValueOnce(new Promise(() => {})); // never resolves
+      const { unmount } = renderForward();
+      try {
+        await waitFor(() => {
+          expect(mockGetAddresses).toHaveBeenCalled();
+        });
+        fireEvent.click(screen.getByLabelText('From'));
+        fireEvent.click(await screen.findByRole('option', { name: /user@test\.com/ }));
+        const toInput = screen.getByLabelText('Recipients');
+        fireEvent.change(toInput, { target: { value: 'dest@test.com' } });
+        fireEvent.keyDown(toInput, { key: 'Enter' });
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+        expect(setMessage).toHaveBeenCalledWith(
+          'Attachments are still loading — please wait a moment.', true
+        );
+        expect(mockSendMessage).not.toHaveBeenCalled();
+      } finally {
+        unmount();
+      }
+    });
+
+    it('drops the chip and warns when a forwarded attachment fails to download', async () => {
+      mockGetAttachment.mockRejectedValueOnce(new Error('boom'));
+      const { unmount } = renderForward();
+      try {
+        expect(screen.getByText('report.pdf')).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.queryByText('report.pdf')).not.toBeInTheDocument();
+        });
+        expect(setMessage).toHaveBeenCalledWith(
+          'Couldn\'t carry over attachment "report.pdf" from the original message.', true
+        );
+      } finally {
+        unmount();
+      }
+    });
+
+    it('allows removing a forwarded attachment before it finishes downloading', async () => {
+      mockGetAttachment.mockReturnValueOnce(new Promise(() => {}));
+      const { unmount } = renderForward();
+      try {
+        expect(screen.getByText('report.pdf')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Remove attachment report.pdf' }));
+        expect(screen.queryByText('report.pdf')).not.toBeInTheDocument();
+        await act(async () => { await Promise.resolve(); });
+      } finally {
+        unmount();
+      }
+    });
   });
 
   it('shows a warning when total attachment size exceeds 20 MB', async () => {

--- a/react/admin/src/Email/ComposeOverlay/index.jsx
+++ b/react/admin/src/Email/ComposeOverlay/index.jsx
@@ -149,6 +149,7 @@ function ComposeOverlay({
   subject: propSubject,
   type,
   other_headers,
+  forward_attachments,
   smtp_host,
   domains: propDomains,
   stackIndex = 0,
@@ -290,6 +291,43 @@ function ComposeOverlay({
       default:
         break;
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Forwarding includes the original message's attachments. Seed a chip per
+  // attachment right away (marked pending, from the metadata the reader had
+  // already loaded), then fetch each one's bytes — /fetch_attachment mints a
+  // presigned GET URL — and swap the Blob in. A chip can be removed while
+  // still pending; the late-arriving Blob then finds no row and is dropped.
+  useEffect(() => {
+    if (type !== 'forward') return;
+    const src = forward_attachments;
+    if (!src || !Array.isArray(src.attachments) || src.attachments.length === 0) return;
+    const seeded = src.attachments.map((a) => ({
+      id: `fwd-${src.id}-${a.id}`,
+      filename: a.name,
+      mimeType: a.type || 'application/octet-stream',
+      file: null,
+      size: a.size || 0,
+      pending: true,
+    }));
+    setAttachments(prev => [...prev, ...seeded]);
+    src.attachments.forEach((a, i) => {
+      api.getAttachment(a, src.folder, src.id, src.seen)
+        .then((data) => api.downloadAttachment(data.data.url))
+        .then((resp) => {
+          setAttachments(prev => prev.map(x => (x.id === seeded[i].id
+            ? {
+              ...x, file: resp.data, size: resp.data.size || x.size, pending: false,
+            }
+            : x)));
+        })
+        .catch((err) => {
+          console.log(err);
+          setAttachments(prev => prev.filter(x => x.id !== seeded[i].id));
+          setMessage(`Couldn't carry over attachment "${a.name}" from the original message.`, true);
+        });
+    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -489,6 +527,10 @@ function ComposeOverlay({
     }
     if (addresses.indexOf(address) === -1) {
       setMessage("Please select an address from which to send.", true);
+      return;
+    }
+    if (attachments.some(a => a.pending)) {
+      setMessage("Attachments are still loading — please wait a moment.", true);
       return;
     }
     setSending(true);
@@ -833,10 +875,15 @@ function ComposeOverlay({
           <>
             <ul className="compose-attachments" aria-label="Attachments">
               {attachments.map((a) => (
-                <li key={a.id} className="compose-attachment-chip">
+                <li
+                  key={a.id}
+                  className={`compose-attachment-chip${a.pending ? ' compose-attachment-chip--pending' : ''}`}
+                >
                   <Paperclip size={12} aria-hidden="true" />
                   <span className="compose-attachment-name" title={a.filename}>{a.filename}</span>
-                  <span className="compose-attachment-size">{formatBytes(a.size)}</span>
+                  <span className="compose-attachment-size">
+                    {a.pending ? 'loading…' : formatBytes(a.size)}
+                  </span>
                   <button
                     type="button"
                     className="compose-attachment-remove"

--- a/react/admin/src/Email/MessageOverlay/index.jsx
+++ b/react/admin/src/Email/MessageOverlay/index.jsx
@@ -220,8 +220,13 @@ function MessageOverlay({
 
   const forward = useCallback(() => {
     const [r, b, e, h] = createPayload();
-    forwardProp(r, b, e, h);
-  }, [createPayload, forwardProp]);
+    // Forwarding carries the original attachments along. The compose window
+    // needs the source coordinates (folder / uid / seen) plus the metadata
+    // already loaded here to fetch the bytes itself.
+    forwardProp(r, b, e, h, {
+      folder, id: envelopeId, seen, attachments,
+    });
+  }, [createPayload, forwardProp, folder, envelopeId, seen, attachments]);
 
   const downloadAttachment = useCallback((id) => {
     const a = attachments.find((att) => att.id === id);

--- a/react/admin/src/Email/index.jsx
+++ b/react/admin/src/Email/index.jsx
@@ -202,7 +202,7 @@ function Email({
     });
   }, [openCompose]);
 
-  const launchComposer = useCallback((recipient, body, env, other_headers, type) => {
+  const launchComposer = useCallback((recipient, body, env, other_headers, type, source) => {
     const prefix = type === "forward" ? "Fwd: " : "Re: ";
     const subject = prefix + env.subject.replace(/^(re:?\s|fwd?:?\s)?/i, "");
     const extended_body = prepBody(body, env);
@@ -212,7 +212,10 @@ function Email({
       recipient: recipient,
       body: extended_body,
       type: type,
-      other_headers: other_headers
+      other_headers: other_headers,
+      // Forward only: `{folder, id, seen, attachments}` of the original
+      // message, so the compose window can carry its attachments over.
+      forward_attachments: source
     });
   }, [openCompose]);
 
@@ -224,8 +227,8 @@ function Email({
     launchComposer(recipient, body, env, other_headers, "replyAll");
   }, [launchComposer]);
 
-  const forward = useCallback((recipient, body, env, other_headers) => {
-    launchComposer(recipient, body, env, other_headers, "forward");
+  const forward = useCallback((recipient, body, env, other_headers, source) => {
+    launchComposer(recipient, body, env, other_headers, "forward", source);
   }, [launchComposer]);
 
   // Register keyboard-shortcut handlers with App-level hook.
@@ -433,6 +436,7 @@ function Email({
               subject={w.subject}
               type={w.type}
               other_headers={w.other_headers}
+              forward_attachments={w.forward_attachments}
               composeFromAddress={composeFromAddress}
               setComposeFromAddress={setComposeFromAddress}
               layout={layout}


### PR DESCRIPTION
## Summary

Forwarding a message in the web client now carries the original message's attachments into the compose window, where they appear as the usual removable chips.

## How it works

- `MessageOverlay` already loads the attachment metadata for display; on Forward it now passes that list plus the source coordinates (`folder`/`uid`/`seen`) through to the compose window.
- `ComposeOverlay` seeds a chip per attachment immediately (dimmed, `loading…`), fetches each one's bytes via the existing `/fetch_attachment` presigned GET URL into a Blob, and swaps it in. The chip keeps its final footprint — only the tone changes.
- From there the existing send path applies unchanged: presigned S3 PUT upload, `s3_key` references to `/send`, and the remove button to drop any attachment before sending.
- Send is blocked with a toast while any attachment is still downloading; a failed download drops its chip and warns.

No Lambda or Terraform changes — the cache bucket's CORS rule already allows GET from the admin origin (used by View source).

## Testing

- 4 new Vitest cases: happy path through to `/send` wire format, send blocked while pending, failed download drops chip + warns, pending chip removable.
- `ComposeOverlay` (17) and `MessageOverlay` (34) suites pass; `eslint` clean on changed files. (Unrelated suites fail locally under Node 24's experimental `localStorage` global — also fail on a clean tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)