### PR TITLE
Carry original attachments into Apple-client forwards

### DIFF
--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -53,6 +53,16 @@ final class AppState {
     /// via mailto leave the seed parked here until `MessageListView`
     /// first appears.
     var pendingComposeSeed: Draft?
+    /// Forwarded-message attachments awaiting pickup by the compose
+    /// surface, keyed by seed draft id. The forward action stashes the
+    /// original message's decoded attachments here — they're too big to
+    /// ride the Codable `Draft` through `openWindow` — and `ComposeView`
+    /// consumes them in its `.task`. In-memory only: like hand-picked
+    /// compose attachments, they don't survive a relaunch or a resumed
+    /// draft. `@ObservationIgnored` because no view renders this
+    /// directly; it's a one-shot handoff, and consuming it during view
+    /// setup must not invalidate anyone's body.
+    @ObservationIgnored var pendingComposeAttachments: [UUID: [Attachment]] = [:]
     /// Reply / reply-all / forward intent counters bumped from the macOS
     /// menu bar so the shortcut fires regardless of which scene holds
     /// AppKit first-responder focus. The currently-presented
@@ -577,6 +587,20 @@ extension AppState {
     func consumePendingComposeSeed() -> Draft? {
         defer { pendingComposeSeed = nil }
         return pendingComposeSeed
+    }
+
+    /// Stash the original message's attachments for a forward seed. The
+    /// compose surface picks them up via `consumeComposeAttachments(for:)`.
+    func stashComposeAttachments(_ attachments: [Attachment], for draftId: UUID) {
+        pendingComposeAttachments[draftId] = attachments
+    }
+
+    /// Reads and clears the stashed attachments for one compose seed.
+    /// Pop-once, so a system-restored compose scene (whose stashed bytes
+    /// are gone) degrades to composing without them rather than stalling.
+    func consumeComposeAttachments(for draftId: UUID) -> [Attachment] {
+        defer { pendingComposeAttachments[draftId] = nil }
+        return pendingComposeAttachments[draftId] ?? []
     }
 
     /// Kick off a one-shot contacts authorization request,

--- a/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
@@ -26,6 +26,21 @@ extension ComposeViewModel {
         attachments.removeAll { $0.id == id }
     }
 
+    /// Seed the composer with the forwarded message's attachments. Called
+    /// by `ComposeView` on appearance with the bytes the forward action
+    /// stashed on `AppState` (see `MessageDetailView.beginCompose`). The
+    /// seeded rows are ordinary `ComposeAttachment`s from here on — the
+    /// user can remove them, and send stages them like hand-picked files.
+    func seedForwardedAttachments(_ forwarded: [Attachment]) {
+        for attachment in forwarded {
+            addAttachment(
+                filename: attachment.filename,
+                mimeType: attachment.mimeType,
+                data: attachment.data
+            )
+        }
+    }
+
     // MARK: - Internals
 
     /// Resolves the current `fromAddress` string into a parsed

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -67,6 +67,15 @@ struct ComposeView: View {
             #endif
             .toolbar { toolbarContent }
             .task {
+                // Pick up forwarded attachments stashed by the forward
+                // action. They hand off out-of-band because the seed
+                // `Draft` travels through `openWindow` as a Codable
+                // value. Pop-once: a system-restored compose scene finds
+                // nothing and simply composes without them.
+                let forwarded = appState.consumeComposeAttachments(for: model.draftId)
+                if !forwarded.isEmpty {
+                    model.seedForwardedAttachments(forwarded)
+                }
                 await model.start()
                 // Snapshot contacts once per compose surface. The list is
                 // bounded by the user's address book; the per-keystroke

--- a/apple/Cabalmail/Views/MessageDetailView+Compose.swift
+++ b/apple/Cabalmail/Views/MessageDetailView+Compose.swift
@@ -42,8 +42,38 @@ extension MessageDetailView {
                 mode: mode,
                 userAddresses: addresses
             )
+            if mode == .forward {
+                stashForwardAttachments(for: seed)
+            }
             presentCompose(seed: seed)
         }
+    }
+
+    /// Forwarding includes the original message's attachments. The detail
+    /// view model decoded them to temp files during the MIME parse, so
+    /// re-read the bytes and stash them on `AppState` keyed by the seed
+    /// id — they can't ride the Codable `Draft` through `openWindow`, and
+    /// `ComposeView` consumes the stash on appearance. Inline `cid:`
+    /// images stay behind: they live in the quoted body, not the
+    /// attachment strip, matching the React composer's scope.
+    private func stashForwardAttachments(for seed: Draft) {
+        guard let source = model?.attachments, !source.isEmpty else { return }
+        let loaded: [Attachment] = source.compactMap { attachment in
+            guard let data = try? Data(contentsOf: attachment.fileURL) else { return nil }
+            return Attachment(
+                filename: attachment.filename,
+                mimeType: attachment.mimeType,
+                data: data
+            )
+        }
+        if loaded.count < source.count {
+            appState.showToast(Toast(
+                kind: .warning,
+                message: "Some attachments couldn't be carried into the forward."
+            ))
+        }
+        guard !loaded.isEmpty else { return }
+        appState.stashComposeAttachments(loaded, for: seed.id)
     }
 
     /// Opens compose resuming the open Drafts-folder message: recipients,

--- a/changelog.d/apple-forward-includes-attachments.added.md
+++ b/changelog.d/apple-forward-includes-attachments.added.md
@@ -1,0 +1,4 @@
+- **Forwarding carries attachments in the Apple clients.** Forwarding a
+  message on iOS, iPadOS, macOS, and visionOS now brings the original
+  message's attachments into the compose window as removable rows; they
+  upload and send exactly like hand-picked files.


### PR DESCRIPTION
## Summary

Companion to #625: forwarding a message in the Apple clients (iOS, iPadOS, macOS, visionOS) now carries the original message's attachments into the compose window as ordinary removable attachment rows.

## How it works

The Apple side is simpler than React — no extra network round-trips. `MessageDetailViewModel` already decodes every attachment to a temp file during the client-side MIME parse, so:

- `beginCompose(.forward)` re-reads those bytes into Kit `Attachment`s and stashes them on `AppState` keyed by the seed draft id (mirroring the existing `pendingComposeSeed` mailto: handoff). Out-of-band because the seed `Draft` travels through `openWindow` as a Codable value on the window-scene platforms, and multi-MB `Data` shouldn't ride scene state.
- `ComposeView` pops the stash in its `.task` — one pickup point covering both the iPhone sheet path and the macOS/iPad/visionOS window path — and seeds them via the existing `addAttachment` plumbing. From there they're indistinguishable from hand-picked files: removable rows, 20 MB soft warning, presigned-S3 staging on send.
- Pop-once semantics: a system-restored compose scene finds an empty stash and composes without them (same lifecycle as hand-picked attachments, which are in-memory only).
- If a temp file can't be re-read, the forward proceeds with a warning toast rather than blocking.
- Inline `cid:` images stay in the quoted body, not the attachment strip — same scope as the React composer.

No CabalmailKit or server changes.

## Testing

- `scripts/build-apple.sh lint` (swiftlint --strict) clean
- `scripts/build-apple.sh ios` and `scripts/build-apple.sh macos` both build successfully
- No Kit changes, so `swift test` coverage is unaffected; the app targets have no automated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)