### PR TITLE
Publish CAA records authorizing ACM and Let's Encrypt

### DIFF
--- a/changelog.d/caa-records.added.md
+++ b/changelog.d/caa-records.added.md
@@ -1,0 +1,6 @@
+- **CAA records authorizing our certificate authorities.** A new
+  `terraform/infra/modules/caa` module publishes CAA records that lock
+  certificate issuance to the CAs Cabalmail actually uses: ACM plus Let's
+  Encrypt on the control domain, ACM only on the mail domains (Let's Encrypt is
+  used only on the control domain). Each record carries an `iodef` violation
+  contact set to `TF_VAR_EMAIL`. See [docs/caa.md](docs/caa.md).

--- a/docs/caa.md
+++ b/docs/caa.md
@@ -1,0 +1,88 @@
+# CAA records
+
+[Certification Authority Authorization](https://www.rfc-editor.org/rfc/rfc8659) (CAA)
+records tell certificate authorities which of them, if any, may issue a
+certificate for a domain. A CA is required to check CAA before issuing, so a
+published CAA record is a cheap, standards-backed lock against mis-issuance: no
+CA outside the authorized set can mint a certificate for your names, even if it
+is tricked into trying.
+
+Cabalmail publishes CAA in Terraform (`terraform/infra/modules/caa`), so the
+policy is version-controlled and applied alongside the certificates it governs.
+The records are read at plan time from the same zone IDs the certificate modules
+use, so they cannot drift away from where certificates are actually issued.
+
+## What is authorized
+
+Every TLS certificate Cabalmail issues is a wildcard for the control domain,
+`*.<control_domain>`, from one of two CAs:
+
+- **ACM** (`modules/cert`) - the certificate on the load balancer and
+  CloudFront, DNS-validated in the control-domain zone.
+- **Let's Encrypt** (`modules/certbot_renewal`) - the certificate the mail
+  tiers present for IMAPS and SMTP submission, renewed by the certbot Lambda
+  over DNS-01.
+
+Because both are wildcards, each authorized CA is granted `issue` (exact names)
+and `issuewild` (wildcards).
+
+| Zone | Authorized CAs | Why |
+|------|----------------|-----|
+| Control domain | ACM + Let's Encrypt | Both certificates live here. |
+| Each mail domain | ACM only | See below. |
+
+**ACM is authorized by four identifiers** - `amazon.com`, `amazontrust.com`,
+`awstrust.com`, and `amazonaws.com`. ACM's issuing intermediates vary by region
+and by the AWS service consuming the certificate, so all four are authorized to
+avoid a surprise validation failure. This follows
+[AWS's CAA guidance](https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html).
+
+**Let's Encrypt is authorized on the control domain only.** It is not an
+oversight that the mail domains omit `letsencrypt.org`: certbot is hardwired to
+`CONTROL_DOMAIN`, and the mail services present control-domain hostnames
+(`imap.<control_domain>`, `smtp-out.<control_domain>`), so a mail apex never
+terminates a Let's Encrypt certificate. Mail domains keep ACM authorized because
+ACM is the AWS-native path should a mail domain ever be fronted by an AWS
+service.
+
+A single record at the control-domain apex governs every infrastructure
+subdomain: a CA validating `*.<control_domain>` walks up the DNS tree, finds the
+apex record, and stops. Mail domains are addressing-only (MX/SPF/DKIM/DMARC) and
+carry no certificates today; their CAA is defense-in-depth so that no CA may
+issue for them without a deliberate policy change here.
+
+## Violation reporting (iodef)
+
+Each record carries an `iodef` property pointing at the Let's Encrypt contact
+email (`TF_VAR_EMAIL`). A conformant CA that receives a request violating the
+policy can report it to that address. Treat any such report as a signal worth
+investigating.
+
+## Authorizing a new CA
+
+To let another CA issue for a domain - for example, adding DigiCert or Entrust
+for a [BIMI](https://bimigroup.org/) Verified Mark Certificate on a mail domain -
+edit `terraform/infra/modules/caa/main.tf`:
+
+- Add the CA's identifier to `local.acm_issuers` (badly named for a
+  mail-domain-wide addition; rename to taste) or build the record list it
+  belongs in.
+- For a control-domain-only CA, add it to `local.control_issuers`.
+
+Apply through the normal infra pipeline. Removing a CA is the same edit in
+reverse; existing certificates keep working, but that CA can no longer renew or
+re-issue.
+
+## Verifying
+
+CAA records are signed automatically when the zone has DNSSEC enabled; no extra
+steps. After an apply, confirm what resolvers see:
+
+```
+dig +short CAA <control_domain>
+dig +short CAA <mail_domain>
+```
+
+You should see the `issue`/`issuewild` lines for the authorized CAs and the
+`iodef` line. Allow for the record TTL (one hour by default) before expecting a
+change to be visible everywhere.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,6 +22,10 @@ Setting `TF_VAR_MONITORING` to `true` in a GitHub environment adds [monitoring](
 
 DNSSEC signing for the control-domain and mail-apex zones is opt-in per environment (`TF_VAR_DNSSEC_ENABLED`). Enabling, disabling, and KSK rotation all involve registrar DS-record steps whose ordering matters - a DS record published against an unsigned zone is an outage. See [DNSSEC](./dnssec.md) for the runbooks before touching any of it.
 
+# CAA records
+
+CAA records lock certificate issuance for your domains to only the CAs Cabalmail uses: ACM plus Let's Encrypt on the control domain, ACM only on the mail domains. They are published from Terraform (`terraform/infra/modules/caa`) and signed automatically where DNSSEC is on. See [CAA records](./caa.md) for what is authorized, the `iodef` violation-report contact, and how to authorize an additional CA (for example a DigiCert or Entrust mark certificate for BIMI).
+
 # NLB access logs
 
 The mail NLB writes TLS-connection access logs (the IMAPS listener; SMTP listeners are TCP passthrough and produce none) to a dedicated, versioned, 180-day-lifecycled S3 bucket. See [NLB access logs](./nlb-access-logs.md) for what the logs do and do not cover and for the Athena setup to query them.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -137,6 +137,10 @@ If you enabled backups (`TF_VAR_BACKUP=true`), one step cannot be automated: cro
 
 DNSSEC signing for your zones is off by default (`TF_VAR_DNSSEC_ENABLED`). Enabling it involves a registrar DS-record step whose ordering matters; read [DNSSEC](./dnssec.md) first. The cicd policy in [the AWS setup guide](./aws.md) marks which permissions DNSSEC needs.
 
+## CAA records
+
+CAA records authorizing only the CAs Cabalmail uses (ACM and Let's Encrypt on the control domain, ACM only on the mail domains) are published automatically from Terraform. The `iodef` violation-report contact is set to `TF_VAR_EMAIL`. See [CAA records](./caa.md) for what is authorized, why Let's Encrypt is control-domain only, and how to authorize an additional CA (e.g. for a BIMI mark certificate).
+
 ## Port 25 Block (What to do with the `relay_ips` output)
 
 The output contains the IP address of each of your outgoing mail relays. (More specifically, it's the elastic IP addresses used for egress on the NAT instances.) In order to send mail reliably, you must get AWS to allow outbound traffic on port 25. There is no API for this, so the process cannot be automated. Instead, you must fill out [this form](https://console.aws.amazon.com/support/contacts?#/rdns-limits).

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -148,6 +148,17 @@ module "cert" {
   zone_id        = data.terraform_remote_state.zone.outputs.control_domain_zone_id
 }
 
+# Publishes CAA records authorizing only the CAs we use: ACM + Let's Encrypt on
+# the control domain, ACM only on the mail domains (Let's Encrypt is used only
+# on the control domain). See modules/caa and docs/caa.md.
+module "caa" {
+  source                 = "./modules/caa"
+  control_domain         = var.control_domain
+  control_domain_zone_id = data.terraform_remote_state.zone.outputs.control_domain_zone_id
+  mail_domains           = [for d in module.domains.domains : { domain = d.domain, zone_id = d.zone_id }]
+  iodef_email            = var.email
+}
+
 # Public front door site at www.<control_domain>. Hosts the home page
 # and the privacy/terms pages referenced by carrier registrations.
 # See docs/front-door.md.

--- a/terraform/infra/modules/caa/README.md
+++ b/terraform/infra/modules/caa/README.md
@@ -1,0 +1,58 @@
+<!-- BEGIN_TF_DOCS -->
+# Cabalmail
+<div style="width: 10em; float:left; height: 100%; padding-right: 1em;"><img src="/docs/logo.png" width="100" />
+<p><a href="/README.md">Main documentation</a></p>
+</div><div style="padding-left: 11em;">
+
+Publishes CAA records that authorize only the certificate authorities we
+actually use, so no other CA may issue a certificate for our domains.
+
+Both TLS certificates we issue target `*.<control_domain>`: the ACM
+certificate (`modules/cert`) and the Let's Encrypt certificate
+(`modules/certbot_renewal`). Because those are wildcards, every issuer is
+authorized for both `issue` and `issuewild`.
+
+- Control domain: ACM + Let's Encrypt. ACM rotates its issuing
+  intermediates by region and service, so all four Amazon CA identifiers are
+  authorized to avoid a surprise validation failure.
+- Mail domains: ACM only. Let's Encrypt is architecturally control-domain
+  only - certbot is hardwired to `CONTROL_DOMAIN` and the mail services
+  present control-domain hostnames, so a mail apex never terminates a
+  Let's Encrypt certificate. ACM stays authorized as the AWS-native path in
+  case a mail domain is ever fronted by an AWS service.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_control_domain"></a> [control\_domain](#input\_control\_domain) | Root domain for infrastructure. CAA authorizing ACM and Let's Encrypt is published at its apex. | `string` | n/a | yes |
+| <a name="input_control_domain_zone_id"></a> [control\_domain\_zone\_id](#input\_control\_domain\_zone\_id) | Route 53 Zone ID for the control domain (owned by the bootstrap terraform/dns stack). | `string` | n/a | yes |
+| <a name="input_mail_domains"></a> [mail\_domains](#input\_mail\_domains) | Mail domains and their Route 53 zone IDs (module.domains.domains). Each gets an ACM-only CAA record; the control domain is skipped here as it is covered by control\_domain\_zone\_id. | `list(object({ domain = string, zone_id = string }))` | n/a | yes |
+| <a name="input_iodef_email"></a> [iodef\_email](#input\_iodef\_email) | Contact address for the CAA iodef property, where a CA reports requests that violate the policy. The root stack sets this to the Let's Encrypt contact email (var.email). | `string` | n/a | yes |
+| <a name="input_ttl"></a> [ttl](#input\_ttl) | TTL in seconds for the CAA records. | `number` | `3600` | no |
+## Modules
+
+No modules.
+## Outputs
+
+No outputs.
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_record.control](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.mail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+
+</div>
+<!-- END_TF_DOCS -->

--- a/terraform/infra/modules/caa/main.tf
+++ b/terraform/infra/modules/caa/main.tf
@@ -1,0 +1,76 @@
+/**
+* Publishes CAA records that authorize only the certificate authorities we
+* actually use, so no other CA may issue a certificate for our domains.
+*
+* Both TLS certificates we issue target `*.<control_domain>`: the ACM
+* certificate (`modules/cert`) and the Let's Encrypt certificate
+* (`modules/certbot_renewal`). Because those are wildcards, every issuer is
+* authorized for both `issue` and `issuewild`.
+*
+* - Control domain: ACM + Let's Encrypt. ACM rotates its issuing
+*   intermediates by region and service, so all four Amazon CA identifiers are
+*   authorized to avoid a surprise validation failure.
+* - Mail domains: ACM only. Let's Encrypt is architecturally control-domain
+*   only - certbot is hardwired to `CONTROL_DOMAIN` and the mail services
+*   present control-domain hostnames, so a mail apex never terminates a
+*   Let's Encrypt certificate. ACM stays authorized as the AWS-native path in
+*   case a mail domain is ever fronted by an AWS service.
+*
+* A single CAA record at the control-domain apex governs every infrastructure
+* subdomain: a CA validating `*.<control_domain>` climbs to that apex, finds
+* the record, and stops. The control domain's record lives in the bootstrap
+* `terraform/dns` zone but is written here (as `modules/cert` already does for
+* ACM validation) to keep the "who may issue for us" policy in one place.
+*/
+
+locals {
+  # ACM's issuing intermediates vary by region and service; authorize all four
+  # Amazon identifiers. See https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html
+  acm_issuers = ["amazon.com", "amazontrust.com", "awstrust.com", "amazonaws.com"]
+  le_issuer   = "letsencrypt.org"
+
+  # A CA that receives a request violating this policy can report it here.
+  iodef_record = "0 iodef \"mailto:${var.iodef_email}\""
+
+  # Control domain: ACM + Let's Encrypt, wildcard and non-wildcard.
+  control_issuers = concat(local.acm_issuers, [local.le_issuer])
+  control_records = concat(
+    [for ca in local.control_issuers : "0 issue \"${ca}\""],
+    [for ca in local.control_issuers : "0 issuewild \"${ca}\""],
+    [local.iodef_record],
+  )
+
+  # Mail domains: ACM only.
+  mail_records = concat(
+    [for ca in local.acm_issuers : "0 issue \"${ca}\""],
+    [for ca in local.acm_issuers : "0 issuewild \"${ca}\""],
+    [local.iodef_record],
+  )
+
+  # Mail-domain zones that get their own CAA. The control domain is excluded:
+  # its record is managed against the bootstrap zone below, and
+  # `module.domains.domains` surfaces the control domain in this list when it
+  # doubles as a mail domain (which would otherwise collide on the same zone
+  # and name).
+  mail_zones = {
+    for d in var.mail_domains : d.domain => d.zone_id if d.domain != var.control_domain
+  }
+}
+
+resource "aws_route53_record" "control" {
+  zone_id = var.control_domain_zone_id
+  name    = var.control_domain
+  type    = "CAA"
+  ttl     = var.ttl
+  records = local.control_records
+}
+
+resource "aws_route53_record" "mail" {
+  for_each = local.mail_zones
+
+  zone_id = each.value
+  name    = each.key
+  type    = "CAA"
+  ttl     = var.ttl
+  records = local.mail_records
+}

--- a/terraform/infra/modules/caa/variables.tf
+++ b/terraform/infra/modules/caa/variables.tf
@@ -1,0 +1,28 @@
+variable "control_domain" {
+  type        = string
+  description = "Root domain for infrastructure. CAA authorizing ACM and Let's Encrypt is published at its apex."
+}
+
+variable "control_domain_zone_id" {
+  type        = string
+  description = "Route 53 Zone ID for the control domain (owned by the bootstrap terraform/dns stack)."
+}
+
+variable "mail_domains" {
+  type = list(object({
+    domain  = string
+    zone_id = string
+  }))
+  description = "Mail domains and their Route 53 zone IDs (module.domains.domains). Each gets an ACM-only CAA record; the control domain is skipped here as it is covered by control_domain_zone_id."
+}
+
+variable "iodef_email" {
+  type        = string
+  description = "Contact address for the CAA iodef property, where a CA reports requests that violate the policy. The root stack sets this to the Let's Encrypt contact email (var.email)."
+}
+
+variable "ttl" {
+  type        = number
+  default     = 3600
+  description = "TTL in seconds for the CAA records."
+}

--- a/terraform/infra/modules/caa/versions.tf
+++ b/terraform/infra/modules/caa/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.32"
+    }
+  }
+
+  required_version = ">= 1.1.2"
+}


### PR DESCRIPTION
## What

Adds a `terraform/infra/modules/caa` module that publishes [CAA](https://www.rfc-editor.org/rfc/rfc8659) records locking certificate issuance to only the CAs Cabalmail actually uses.

Both TLS certificates we issue target `*.<control_domain>` — ACM (`modules/cert`, on the NLB/CloudFront) and Let's Encrypt (`modules/certbot_renewal`, on the mail tiers) — so each authorized CA is granted both `issue` and `issuewild`.

| Zone | Authorized CAs | Rationale |
|------|----------------|-----------|
| Control domain | ACM (`amazon.com`, `amazontrust.com`, `awstrust.com`, `amazonaws.com`) + `letsencrypt.org` | Both certificates live here. All four Amazon IDs because ACM's issuing intermediates vary by region/service. |
| Each mail domain | ACM only | **Verified:** Let's Encrypt is architecturally control-domain only — certbot is hardwired to `CONTROL_DOMAIN` and the mail services present control-domain hostnames, so a mail apex never terminates an LE cert. ACM stays authorized as the AWS-native path. |

Each record carries an `iodef` violation-report contact set to the Let's Encrypt contact email (`var.email`).

## Why this shape

- **One record at the control-domain apex** governs every infra subdomain: a CA validating `*.<control_domain>` climbs to the apex, finds the record, and stops.
- The control-domain record lives in the bootstrap `terraform/dns` zone but is written from the infra stack, mirroring how `modules/cert` already writes ACM validation records there — keeping all "who may issue for us" policy in one file in the regularly-applied stack.
- Mail domains carry no certs today; their CAA is defense-in-depth. Adding a CA later (e.g. DigiCert/Entrust for a BIMI mark certificate) is a one-line edit in `modules/caa`.

## Files

- `terraform/infra/modules/caa/` — new module (`main.tf`, `variables.tf`, `versions.tf`, `README.md`)
- `terraform/infra/main.tf` — wire `module "caa"` next to `module "cert"`
- `docs/caa.md` — operator reference; linked from `docs/operations.md` and `docs/setup.md`
- `changelog.d/caa-records.added.md`

## Verification

Terraform isn't installed on this box, so `validate`/`plan` runs in CI. After apply:

```
dig +short CAA <control_domain>   # issue/issuewild for ACM + Let's Encrypt, iodef
dig +short CAA <mail_domain>      # issue/issuewild for ACM only, iodef
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)