### PR TITLE
Route CAA iodef reports through the DMARC pipeline to the admin site

### DIFF
--- a/changelog.d/caa-records.added.md
+++ b/changelog.d/caa-records.added.md
@@ -3,4 +3,5 @@
   certificate issuance to the CAs Cabalmail actually uses: ACM plus Let's
   Encrypt on the control domain, ACM only on the mail domains (Let's Encrypt is
   used only on the control domain). Each record carries an `iodef` violation
-  contact set to `TF_VAR_EMAIL`. See [docs/caa.md](docs/caa.md).
+  contact pointing at the system-managed `caa-reports@mail-admin.` address.
+  See [docs/caa.md](docs/caa.md).

--- a/changelog.d/caa-report-ingestion.added.md
+++ b/changelog.d/caa-report-ingestion.added.md
@@ -1,0 +1,9 @@
+- **CAA violation reports on the admin site.** The CAA `iodef` contact is a
+  new system-managed address, `caa-reports@mail-admin.<first mail domain>`,
+  delivered to the same mailbox as DMARC reports. The `process_dmarc` Lambda
+  ingests these messages into a new `cabal-caa-reports` table (raw message
+  archived to S3), and a new admin-only CAA view lists them, following the
+  DMARC-report pattern. The view is expected to stay empty: a CA sends an
+  iodef report only when it refuses a certificate request that violates the
+  CAA policy, so any row is a mis-issuance attempt (or deliberate test) worth
+  investigating.

--- a/docs/caa.md
+++ b/docs/caa.md
@@ -105,14 +105,80 @@ re-issue.
 
 ## Verifying
 
-CAA records are signed automatically when the zone has DNSSEC enabled; no extra
-steps. After an apply, confirm what resolvers see:
+A CAA record that *looks* right in Route 53 proves nothing by itself: CAA has
+no effect on existing certificates or mail flow, and only gates *new*
+issuance. A wrong record therefore breaks nothing today and then quietly
+blocks the next renewal. Verify both directions - that the policy blocks what
+it should and still allows what it must - by forcing real issuance attempts
+rather than waiting for the next renewal to find out.
+
+Requesting a certificate your own CAA policy forbids is responsible and
+routine: CAA denial is designed-for CA behavior, the refusal is logged like
+any failed validation, and nothing reaches Certificate Transparency (CT logs
+record only issued certificates). Use staging endpoints where offered and
+keep it to a handful of manual attempts.
+
+### 1. Record visibility
+
+After an apply, confirm what public resolvers see (the CA queries your
+authoritative servers, not your local cache):
 
 ```
-dig +short CAA <control_domain>
-dig +short CAA <mail_domain>
+dig +short CAA <control_domain> @1.1.1.1
+dig +short CAA <mail_domain> @1.1.1.1
 ```
 
 You should see the `issue`/`issuewild` lines for the authorized CAs and the
-`iodef` line. Allow for the record TTL (one hour by default) before expecting a
-change to be visible everywhere.
+`iodef` line. Allow for the record TTL (one hour by default) before expecting
+a change to be visible everywhere.
+
+Where the zone is DNSSEC-signed, also confirm the CAA RRset validates - a CA
+whose CAA lookup gets SERVFAIL must treat it as a hard failure, so a broken
+signature blocks issuance even when the record content is correct:
+
+```
+dig +dnssec CAA <mail_domain> @1.1.1.1
+```
+
+Expect the records plus an `RRSIG CAA`, and the `ad` flag in the header.
+
+### 2. Negative test: an unauthorized CA is refused
+
+Let's Encrypt is not authorized on the mail domains, and its staging endpoint
+performs real CAA checks without touching production rate limits - so it makes
+a perfect refusal probe. From CloudShell in the account that owns the zone
+(certbot's Route 53 plugin picks up the session credentials automatically):
+
+```
+pip3 install --user certbot certbot-dns-route53
+
+~/.local/bin/certbot certonly --staging --dns-route53 \
+  --domains caa-test.<mail_domain> \
+  --config-dir /tmp/cb --work-dir /tmp/cb --logs-dir /tmp/cb \
+  --email <you> --agree-tos --non-interactive
+```
+
+Expected: failure citing `CAA record for caa-test.<mail_domain> prevents
+issuance`. A DNS or permission error from the plugin *before* any CAA mention
+means the Route 53 TXT write failed (wrong account) - that is not a CAA
+result. To probe the control domain's lockdown with a CA outside its
+authorized set, ZeroSSL or Buypass (both free ACME CAs) behave the same way.
+
+### 3. Positive test: the authorized CAs can still issue
+
+This is the higher-stakes direction - it is the one whose failure mode is a
+silently broken renewal weeks later.
+
+- **Let's Encrypt on the control domain**: rerun the certbot command above
+  with `--domains caa-test.<control_domain>`. Expected: a staging certificate
+  is issued. The fuller version is invoking the `cabal-certbot-renewal`
+  Lambda, which exercises the production renewal path itself at the cost of
+  rolling the mail tiers.
+- **ACM on the control domain**: request a throwaway DNS-validated
+  certificate for `caa-test.<control_domain>`, confirm it reaches ISSUED,
+  then delete it. This proves whichever Amazon issuing intermediate serves
+  your region is within the authorized set.
+
+For a zero-issuance preflight, [Let's Debug](https://letsdebug.net) runs
+Let's Encrypt-style CAA and DNSSEC checks against a domain without requesting
+anything.

--- a/docs/caa.md
+++ b/docs/caa.md
@@ -53,10 +53,35 @@ issue for them without a deliberate policy change here.
 
 ## Violation reporting (iodef)
 
-Each record carries an `iodef` property pointing at the Let's Encrypt contact
-email (`TF_VAR_EMAIL`). A conformant CA that receives a request violating the
-policy can report it to that address. Treat any such report as a signal worth
-investigating.
+Each record carries an `iodef` property pointing at
+`caa-reports@mail-admin.<first mail domain>`, a system-managed address
+provisioned alongside `dmarc-reports` and delivered to the same system
+mailbox. A conformant CA that receives a request violating the policy can
+report it there.
+
+These reports follow the DMARC-report pipeline: the scheduled `process_dmarc`
+Lambda recognizes messages addressed to `caa-reports`, archives the raw
+message to S3 (`caa/` prefix in the cache bucket), records it in the
+`cabal-caa-reports` DynamoDB table, and the admin site's **CAA** view (admin
+group only) lists them with the raw message viewable and downloadable.
+
+Unlike DMARC aggregate reports, which arrive daily from every major receiving
+provider, CAA violation reports are expected to *never* arrive: a CA sends one
+only when it refuses a certificate request that violates this policy, and
+`iodef` support is optional and patchy among CAs (Let's Encrypt does not send
+them). An empty CAA view is the healthy state. Any report that does appear
+means someone asked a CA to issue for one of your domains and was refused -
+investigate it.
+
+Two operational notes:
+
+- Messages to `caa-reports` bypass the DMARC sender allowlist
+  (`DMARC_REPORT_SENDERS`): reports come from whichever CA refused the
+  request, and the set of CA sender domains is not knowable in advance.
+- The address row is written to DynamoDB by Terraform, so the mail tiers pick
+  it up at the next periodic sendmail map regeneration rather than instantly
+  (the SNS-triggered reconfigure fires only for addresses created through the
+  app).
 
 ## Authorizing a new CA
 

--- a/docs/caa.md
+++ b/docs/caa.md
@@ -82,6 +82,11 @@ Two operational notes:
   it up at the next periodic sendmail map regeneration rather than instantly
   (the SNS-triggered reconfigure fires only for addresses created through the
   app).
+- To also receive these reports in a personal mailbox, assign an additional
+  user to the address via the `assign_address` admin API (the owning `dmarc`
+  user is hidden from the admin UI, but the API only validates the user being
+  added). Terraform ignores drift on this row, so the assignment survives
+  later applies.
 
 ## Authorizing a new CA
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -139,7 +139,7 @@ DNSSEC signing for your zones is off by default (`TF_VAR_DNSSEC_ENABLED`). Enabl
 
 ## CAA records
 
-CAA records authorizing only the CAs Cabalmail uses (ACM and Let's Encrypt on the control domain, ACM only on the mail domains) are published automatically from Terraform. The `iodef` violation-report contact is set to `TF_VAR_EMAIL`. See [CAA records](./caa.md) for what is authorized, why Let's Encrypt is control-domain only, and how to authorize an additional CA (e.g. for a BIMI mark certificate).
+CAA records authorizing only the CAs Cabalmail uses (ACM and Let's Encrypt on the control domain, ACM only on the mail domains) are published automatically from Terraform. The `iodef` violation-report contact is a system-managed address whose messages appear in the admin site's CAA view. See [CAA records](./caa.md) for what is authorized, why Let's Encrypt is control-domain only, and how to authorize an additional CA (e.g. for a BIMI mark certificate).
 
 ## Port 25 Block (What to do with the `relay_ips` output)
 

--- a/lambda/api/list_caa_reports/function.py
+++ b/lambda/api/list_caa_reports/function.py
@@ -1,0 +1,71 @@
+'''Lists CAA iodef violation report records (admin only)'''
+import base64
+import json
+import os
+import boto3  # pylint: disable=import-error
+from helper import sign_url  # pylint: disable=import-error
+
+table_name = os.environ.get('CAA_TABLE_NAME', 'cabal-caa-reports')
+control_domain = os.environ['CONTROL_DOMAIN']
+RAW_BUCKET = f'cache.{control_domain}'
+
+ddb = boto3.resource('dynamodb')
+table = ddb.Table(table_name)
+
+
+def handler(event, _context):
+    '''Returns CAA violation report records in reverse chronological order'''
+    groups = event['requestContext']['authorizer']['claims'].get('cognito:groups', '')
+    if 'admin' not in groups.strip('[]').replace(',', ' ').split():
+        return {
+            'statusCode': 403,
+            'body': json.dumps({'Error': 'Admin access required'})
+        }
+    try:
+        params = event.get('queryStringParameters') or {}
+        scan_kwargs = {
+            'Limit': 50
+        }
+
+        next_token = params.get('next_token', '')
+        if next_token:
+            scan_kwargs['ExclusiveStartKey'] = json.loads(
+                base64.b64decode(next_token).decode('utf-8')
+            )
+
+        response = table.scan(**scan_kwargs)
+        items = response.get('Items', [])
+
+        # Sort by received time descending for reverse chronological order
+        items.sort(key=lambda x: x.get('received', '0'), reverse=True)
+
+        reports = []
+        for item in items:
+            raw_key = item.get('raw_key', '')
+            reports.append({
+                'from_addr': item.get('from_addr', ''),
+                'from_name': item.get('from_name', ''),
+                'from_domain': item.get('from_domain', ''),
+                'subject': item.get('subject', ''),
+                'received': item.get('received', ''),
+                'message_id': item.get('message_id', ''),
+                'raw_url': sign_url(RAW_BUCKET, raw_key) if raw_key else ''
+            })
+
+        result = {'Reports': reports}
+
+        last_key = response.get('LastEvaluatedKey')
+        if last_key:
+            result['NextToken'] = base64.b64encode(
+                json.dumps(last_key).encode('utf-8')
+            ).decode('utf-8')
+
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        return {
+            'statusCode': 500,
+            'body': json.dumps({'Error': str(err)})
+        }
+    return {
+        'statusCode': 200,
+        'body': json.dumps(result)
+    }

--- a/lambda/api/list_caa_reports/function.py
+++ b/lambda/api/list_caa_reports/function.py
@@ -1,4 +1,5 @@
 '''Lists CAA iodef violation report records (admin only)'''
+# pylint: disable=duplicate-code
 import base64
 import json
 import os

--- a/lambda/api/list_caa_reports/requirements.txt
+++ b/lambda/api/list_caa_reports/requirements.txt
@@ -1,0 +1,11 @@
+imapclient==2.3.1 \
+    --hash=sha256:057f28025d2987c63e065afb0e4370b0b850b539b0e1494cea0427e88130108c \
+    --hash=sha256:26ea995664fae3a88b878ebce2aff7402931697b86658b7882043ddb01b0e6ba
+# six is imapclient's only runtime dependency; pinned and hashed so
+# pip --require-hashes can resolve the full tree.
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+dnspython==2.3.0 \
+    --hash=sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46 \
+    --hash=sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9

--- a/lambda/api/list_dmarc_reports/function.py
+++ b/lambda/api/list_dmarc_reports/function.py
@@ -1,4 +1,5 @@
 '''Lists DMARC aggregate report records (admin only)'''
+# pylint: disable=duplicate-code
 import base64
 import json
 import os

--- a/lambda/api/process_dmarc/function.py
+++ b/lambda/api/process_dmarc/function.py
@@ -1,11 +1,14 @@
-'''Ingests DMARC aggregate reports from the dmarc user's IMAP mailbox into DynamoDB'''
+'''Ingests DMARC aggregate reports and CAA iodef violation reports from the
+dmarc user's IMAP mailbox into DynamoDB'''
 import email
 import email.header
+import email.utils
 import gzip
 import io
 import json
 import os
 import re
+import time
 import urllib.error
 import urllib.request
 import zipfile
@@ -16,13 +19,19 @@ from defusedxml.common import DefusedXmlException  # pylint: disable=import-erro
 
 control_domain = os.environ['CONTROL_DOMAIN']
 table_name = os.environ['DMARC_TABLE_NAME']
+caa_table_name = os.environ.get('CAA_TABLE_NAME', 'cabal-caa-reports')
 dmarc_user = os.environ.get('DMARC_USER', 'dmarc')
 ping_param = os.environ.get('HEALTHCHECK_PING_PARAM', '')
 XML_BUCKET = f'cache.{control_domain}'
 
+# Local part that marks a message as a CAA iodef violation report (the
+# modules/caa iodef target shares this mailbox with dmarc-reports).
+CAA_REPORT_LOCAL_PART = os.environ.get('CAA_REPORT_LOCAL_PART', 'caa-reports').lower()
+
 ssm = boto3.client('ssm')
 ddb = boto3.resource('dynamodb')
 table = ddb.Table(table_name)
+caa_table = ddb.Table(caa_table_name)
 s3 = boto3.client('s3')
 
 PROCESSED_FOLDER = 'INBOX.Processed'
@@ -167,6 +176,24 @@ def sender_allowed(domain):
     return any(domain.endswith('.' + allowed) for allowed in DMARC_REPORT_SENDERS)
 
 
+def is_caa_recipient(envelope):
+    '''True when any To: recipient's local part is the CAA iodef mailbox.
+
+    CAA messages bypass the DMARC sender allowlist: they come from whichever
+    CA refused a certificate request, and the set of CA sender domains is not
+    knowable in advance.
+    '''
+    if envelope is None or not envelope.to:
+        return False
+    for addr in envelope.to:
+        mailbox = addr.mailbox
+        if isinstance(mailbox, bytes):
+            mailbox = mailbox.decode('ascii', errors='replace')
+        if (mailbox or '').strip().lower() == CAA_REPORT_LOCAL_PART:
+            return True
+    return False
+
+
 def _el_text(parent, tag, default=''):
     '''Safely extracts text from an XML child element'''
     el = parent.find(tag) if parent is not None else None
@@ -232,18 +259,18 @@ def xml_key_for(meta):
     )
 
 
-def upload_xml(xml_data, key):
-    '''Uploads the raw DMARC report XML to S3'''
+def upload_xml(xml_data, key, content_type='application/xml'):
+    '''Uploads a raw report artifact (DMARC XML or CAA iodef message) to S3'''
     try:
         s3.put_object(
             Bucket=XML_BUCKET,
             Key=key,
             Body=xml_data,
-            ContentType='application/xml'
+            ContentType=content_type
         )
         return True
     except Exception as err:  # pylint: disable=broad-exception-caught
-        print(f'Failed to upload XML to s3://{XML_BUCKET}/{key}: {err}')
+        print(f'Failed to upload artifact to s3://{XML_BUCKET}/{key}: {err}')
         return False
 
 
@@ -274,7 +301,7 @@ def write_records(records, xml_key):
 
 
 def decode_filename(raw_filename):
-    '''Decodes an RFC 2047 encoded filename'''
+    '''Decodes an RFC 2047 encoded header value (filename, subject)'''
     if not raw_filename:
         return ''
     decoded_parts = email.header.decode_header(raw_filename)
@@ -360,6 +387,56 @@ def process_message(msg_data, counters):
     return total
 
 
+def _received_epoch(msg):
+    '''Epoch seconds from the Date: header, falling back to ingest time'''
+    try:
+        parsed = email.utils.parsedate_to_datetime(msg.get('Date', ''))
+        if parsed is not None:
+            return int(parsed.timestamp())
+    except (TypeError, ValueError):
+        pass
+    return int(time.time())
+
+
+def process_caa_message(msg_data, counters):
+    '''Stores a CAA iodef violation report: raw message to S3, one item to
+    the CAA table.
+
+    iodef payload formats vary by CA (RFC 7970 XML when conformant, prose
+    otherwise) and the volume is near zero - any message here means a CA
+    refused a certificate request that violated our CAA policy. So rather
+    than parse deeply, keep the whole message reviewable and surface the
+    envelope facts the admin view needs.
+    '''
+    msg = email.message_from_bytes(msg_data)
+    from_name, from_addr = email.utils.parseaddr(msg.get('From', ''))
+    from_domain = from_addr.rsplit('@', 1)[-1].lower() if '@' in from_addr else 'unknown'
+    subject = decode_filename(msg.get('Subject', ''))
+    message_id = (msg.get('Message-ID', '') or '').strip()
+    received = _received_epoch(msg)
+
+    key = (
+        f'caa/{received}/'
+        f'{_safe_segment(from_domain)}-{_safe_segment(message_id)}.eml'
+    )
+    stored = upload_xml(msg_data, key, content_type='message/rfc822')
+
+    caa_table.put_item(Item={
+        'pk': f'{from_domain}#{received}',
+        'sk': message_id or f'no-msgid-{received}',
+        'from_addr': from_addr,
+        'from_name': from_name,
+        'from_domain': from_domain,
+        'subject': subject,
+        'received': str(received),
+        'message_id': message_id,
+        'raw_key': key if stored else '',
+    })
+    counters['caa_reports'] += 1
+    print(f'[process_dmarc] CAA iodef report from {from_addr!r}: {subject!r}')
+    return 1
+
+
 def _response(counters):
     '''Builds the Lambda response from the per-run counters'''
     return {
@@ -374,6 +451,7 @@ def _new_counters():
         'queued': 0,
         'processed': 0,
         'records': 0,
+        'caa_reports': 0,
         'unknown_sender': 0,
         'oversize_message': 0,
         'no_attachment': 0,
@@ -386,34 +464,41 @@ def _new_counters():
 def _partition_candidates(client, candidates, counters):
     '''Cheap metadata pass over candidate UIDs.
 
-    Returns (to_fetch, skipped_ids): messages from unknown senders or over the
-    size cap are skipped (and tallied) before their full bodies are downloaded.
+    Returns (to_fetch, caa_fetch, skipped_ids): messages from unknown senders
+    or over the size cap are skipped (and tallied) before their full bodies
+    are downloaded. Messages addressed to the CAA iodef mailbox are routed to
+    caa_fetch; the size cap applies but the DMARC sender allowlist does not.
     '''
     meta = client.fetch(candidates, ['ENVELOPE', 'RFC822.SIZE'])
     to_fetch = []
+    caa_fetch = []
     skipped_ids = []
     for msg_id in candidates:
         info = meta.get(msg_id, {})
-        domain = sender_domain(info.get(b'ENVELOPE'))
+        envelope = info.get(b'ENVELOPE')
+        domain = sender_domain(envelope)
         size = info.get(b'RFC822.SIZE', 0) or 0
-        if not sender_allowed(domain):
-            counters['unknown_sender'] += 1
-            skipped_ids.append(msg_id)
-            print(f'[process_dmarc] skip message {msg_id}: '
-                  f'sender domain {domain!r} not in allowlist')
-        elif size > MAX_MESSAGE_BYTES:
+        is_caa = is_caa_recipient(envelope)
+        if size > MAX_MESSAGE_BYTES:
             counters['oversize_message'] += 1
             skipped_ids.append(msg_id)
             print(f'[process_dmarc] skip message {msg_id}: '
                   f'size {size} exceeds {MAX_MESSAGE_BYTES} bytes')
+        elif is_caa:
+            caa_fetch.append(msg_id)
+        elif not sender_allowed(domain):
+            counters['unknown_sender'] += 1
+            skipped_ids.append(msg_id)
+            print(f'[process_dmarc] skip message {msg_id}: '
+                  f'sender domain {domain!r} not in allowlist')
         else:
             to_fetch.append(msg_id)
-    return to_fetch, skipped_ids
+    return to_fetch, caa_fetch, skipped_ids
 
 
-def _ingest_messages(client, to_fetch, counters):
-    '''Fetches the RFC822 bodies for to_fetch and ingests each, returning the
-    list of successfully-handled UIDs.'''
+def _ingest_messages(client, to_fetch, counters, processor=process_message):
+    '''Fetches the RFC822 bodies for to_fetch and ingests each through
+    processor, returning the list of successfully-handled UIDs.'''
     if not to_fetch:
         return []
     fetched = client.fetch(to_fetch, ['RFC822'])
@@ -425,7 +510,7 @@ def _ingest_messages(client, to_fetch, counters):
             print(f'[process_dmarc] message {msg_id}: empty RFC822 fetch')
             continue
         try:
-            count = process_message(data[b'RFC822'], counters)
+            count = processor(data[b'RFC822'], counters)
             counters['processed'] += 1
             processed_ids.append(msg_id)
             print(f'[process_dmarc] message {msg_id}: {count} records')
@@ -466,9 +551,12 @@ def handler(_event, _context):
             if len(messages) > len(candidates):
                 print(f'[process_dmarc] {len(messages)} messages queued; '
                       f'processing first {len(candidates)} this run')
-            to_fetch, skipped_ids = _partition_candidates(client, candidates, counters)
+            to_fetch, caa_fetch, skipped_ids = _partition_candidates(
+                client, candidates, counters)
             processed_ids = _ingest_messages(client, to_fetch, counters)
-            _move_handled(client, processed_ids, skipped_ids)
+            caa_ids = _ingest_messages(
+                client, caa_fetch, counters, processor=process_caa_message)
+            _move_handled(client, processed_ids + caa_ids, skipped_ids)
         else:
             print('[process_dmarc] no messages to process')
     finally:

--- a/react/admin/src/ApiClient.js
+++ b/react/admin/src/ApiClient.js
@@ -568,6 +568,32 @@ export default class ApiClient {
     });
   }
 
+  // Admin — CAA violation reports (iodef messages ingested by process_dmarc)
+
+  listCaaReports(nextToken) {
+    const params = {};
+    if (nextToken) {
+      params.next_token = nextToken;
+    }
+    const response = axios.get('/list_caa_reports', {
+      params: params,
+      baseURL: this.baseURL,
+      headers: {
+        'Authorization': this.token
+      },
+      timeout: TIMEOUT
+    });
+    return response;
+  }
+
+  fetchCaaReport(signedUrl) {
+    return axios.get(signedUrl, {
+      responseType: 'text',
+      transformResponse: [(v) => v],
+      timeout: ONE_SECOND * 30,
+    });
+  }
+
   checkDnsRecord(domain, recordType) {
     return axios.get('/check_dns_record', {
       params: { domain: domain, record_type: recordType },

--- a/react/admin/src/App.jsx
+++ b/react/admin/src/App.jsx
@@ -15,6 +15,7 @@ const Email = React.lazy(() => import('./Email'));
 const Addresses = React.lazy(() => import('./Addresses'));
 const Users = React.lazy(() => import('./Users'));
 const Dmarc = React.lazy(() => import('./Dmarc'));
+const Caa = React.lazy(() => import('./Caa'));
 const About = React.lazy(() => import('./About'));
 
 // Pre-login Components
@@ -307,7 +308,7 @@ function App() {
   // Bounce non-admins away from admin-only views (e.g. "Addresses" persisted
   // in localStorage from a prior admin session, or a deep-link).
   useEffect(() => {
-    const adminOnlyViews = ["Addresses", "Users", "DMARC"];
+    const adminOnlyViews = ["Addresses", "Users", "DMARC", "CAA"];
     if (state.loggedIn && !isAdmin && adminOnlyViews.includes(state.view)) {
       setState({ view: "Email" });
     }
@@ -547,6 +548,12 @@ function App() {
         return (
           <ErrorBoundary name="DMARC">
             <Dmarc />
+          </ErrorBoundary>
+        );
+      case "CAA":
+        return (
+          <ErrorBoundary name="CAA">
+            <Caa />
           </ErrorBoundary>
         );
       case "Addresses":

--- a/react/admin/src/Caa/Caa.css
+++ b/react/admin/src/Caa/Caa.css
@@ -1,0 +1,72 @@
+div.App div.Caa {
+  max-width: 70em;
+  margin-left: auto;
+  margin-right: auto;
+  overflow: auto;
+  max-height: calc(100vh - 7em);
+}
+
+div.App div.Caa #reload {
+  font-size: 140%;
+  display: block;
+  width: auto;
+  float: right;
+  padding: 0.2em 0.5em;
+  margin: 0;
+}
+
+div.App div.Caa h2 {
+  clear: both;
+}
+
+ul.caa-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+ul.caa-list li.caa-header {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 18% 26% 16% 38%;
+  grid-column-gap: 0.5%;
+  align-items: center;
+  font-weight: bold;
+  border-bottom: 2px solid #666;
+  padding: 0.3em 0;
+}
+
+ul.caa-list li.caa-row {
+  list-style: none;
+  border-bottom: 1px solid #888;
+  display: grid;
+  grid-template-columns: 18% 26% 16% 38%;
+  grid-column-gap: 0.5%;
+  align-items: center;
+  min-height: 2.5em;
+  padding: 0.3em 0;
+}
+
+ul.caa-list li.caa-row span,
+ul.caa-list li.caa-header span {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+ul.caa-list button.date-link {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: underline dotted;
+}
+
+ul.caa-list button.date-link:hover {
+  text-decoration: underline;
+}

--- a/react/admin/src/Caa/index.jsx
+++ b/react/admin/src/Caa/index.jsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback } from 'react';
+import useApi from '../hooks/useApi';
+import { useAppMessage } from '../contexts/AppMessageContext';
+import XmlSourceModal from '../Dmarc/XmlSourceModal';
+// Dmarc.css carries the shared modal scaffold (.source-*) that
+// XmlSourceModal styles against; the CAA list grid lives in Caa.css.
+import '../Dmarc/Dmarc.css';
+import './Caa.css';
+
+function formatDateTime(epoch) {
+  if (!epoch || epoch === '0') return '';
+  const d = new Date(Number(epoch) * 1000);
+  return d.toLocaleString();
+}
+
+function sortByReceived(reports) {
+  return [...reports].sort((a, b) => Number(b.received || 0) - Number(a.received || 0));
+}
+
+function rawFilename(report) {
+  const safe = (s) => (s || 'unknown').replace(/[^A-Za-z0-9._-]+/g, '_');
+  return `caa-report-${safe(report.from_domain)}-${safe(report.received)}.eml`;
+}
+
+function Caa() {
+  const api = useApi();
+  const { setMessage } = useAppMessage();
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [nextToken, setNextToken] = useState(null);
+
+  const [rawOpen, setRawOpen] = useState(false);
+  const [rawTitle, setRawTitle] = useState('');
+  const [rawFile, setRawFile] = useState('caa-report.eml');
+  const [rawText, setRawText] = useState('');
+  const [rawLoading, setRawLoading] = useState(false);
+  const [rawError, setRawError] = useState(false);
+
+  const loadReports = useCallback((token) => {
+    setLoading(true);
+    api.listCaaReports(token).then(
+      (response) => {
+        const data = response.data || response;
+        const newReports = data.Reports || [];
+        if (token) {
+          setReports(prev => sortByReceived([...prev, ...newReports]));
+        } else {
+          setReports(sortByReceived(newReports));
+        }
+        setNextToken(data.NextToken || null);
+        setLoading(false);
+      },
+      (err) => {
+        setMessage("Failed to load CAA reports: " + (err.message || err), true);
+        setLoading(false);
+      }
+    );
+  }, [api, setMessage]);
+
+  useEffect(() => {
+    loadReports();
+  }, [loadReports]);
+
+  const handleRefresh = useCallback(() => {
+    setNextToken(null);
+    loadReports();
+  }, [loadReports]);
+
+  const handleLoadMore = useCallback(() => {
+    if (nextToken) {
+      loadReports(nextToken);
+    }
+  }, [nextToken, loadReports]);
+
+  const openRaw = useCallback((report) => {
+    if (!report.raw_url) {
+      setMessage('No raw message stored for this report.', true);
+      return;
+    }
+    setRawTitle(`${report.from_addr || ''} - ${report.subject || ''}`);
+    setRawFile(rawFilename(report));
+    setRawText('');
+    setRawError(false);
+    setRawLoading(true);
+    setRawOpen(true);
+    api.fetchCaaReport(report.raw_url).then(
+      (r) => {
+        setRawText(typeof r.data === 'string' ? r.data : String(r.data || ''));
+        setRawLoading(false);
+      },
+      () => {
+        setRawError(true);
+        setRawLoading(false);
+      }
+    );
+  }, [api, setMessage]);
+
+  if (loading && reports.length === 0) {
+    return <div className="Caa"><div className="loading">Loading...</div></div>;
+  }
+
+  return (
+    <div className="Caa">
+      <button id="reload" onClick={handleRefresh}>&#x21bb;</button>
+
+      <h2>CAA Violation Reports</h2>
+      {reports.length === 0 ? (
+        <p className="empty">
+          No CAA violation reports. That is the expected state: a certificate
+          authority sends one only when it refuses a certificate request that
+          violates this system&apos;s CAA policy. Any report that appears here
+          is a mis-issuance attempt (or a deliberate test) worth investigating.
+        </p>
+      ) : (
+        <>
+          <ul className="caa-list">
+            <li className="caa-header">
+              <span>Received</span>
+              <span>From</span>
+              <span>Domain</span>
+              <span>Subject</span>
+            </li>
+            {reports.map((r, i) => (
+              <li key={`${r.message_id}-${r.received}-${i}`} className="caa-row">
+                <span className="date">
+                  {r.raw_url ? (
+                    <button
+                      type="button"
+                      className="date-link"
+                      onClick={() => openRaw(r)}
+                      title="View raw message"
+                    >
+                      {formatDateTime(r.received)}
+                    </button>
+                  ) : (
+                    <>{formatDateTime(r.received)}</>
+                  )}
+                </span>
+                <span className="from" title={r.from_addr}>{r.from_addr}</span>
+                <span className="domain">{r.from_domain}</span>
+                <span className="subject" title={r.subject}>{r.subject}</span>
+              </li>
+            ))}
+          </ul>
+          {nextToken && (
+            <button className="load-more" onClick={handleLoadMore} disabled={loading}>
+              {loading ? 'Loading...' : 'Load more'}
+            </button>
+          )}
+        </>
+      )}
+
+      <XmlSourceModal
+        open={rawOpen}
+        title={rawTitle}
+        filename={rawFile}
+        xmlText={rawText}
+        loading={rawLoading}
+        error={rawError}
+        onClose={() => setRawOpen(false)}
+      />
+    </div>
+  );
+}
+
+export default Caa;

--- a/react/admin/src/Nav/Nav.test.jsx
+++ b/react/admin/src/Nav/Nav.test.jsx
@@ -71,6 +71,7 @@ describe('Nav', () => {
     expect(screen.queryByRole('menuitem', { name: 'Addresses' })).not.toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'Users' })).not.toBeInTheDocument();
     expect(screen.queryByRole('menuitem', { name: 'DMARC' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'CAA' })).not.toBeInTheDocument();
   });
 
   it('shows admin-only items when isAdmin is true', () => {
@@ -79,6 +80,7 @@ describe('Nav', () => {
     expect(screen.getByRole('menuitem', { name: 'Addresses' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'Users' })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: 'DMARC' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'CAA' })).toBeInTheDocument();
   });
 
   it('marks the active view in the menu', () => {

--- a/react/admin/src/Nav/index.jsx
+++ b/react/admin/src/Nav/index.jsx
@@ -8,6 +8,7 @@ const NAV_VIEWS = [
   { id: 'addresses', name: 'Addresses', label: 'Addresses', requiresAdmin: true  },
   { id: 'users',     name: 'Users',     label: 'Users',     requiresAdmin: true  },
   { id: 'dmarc',     name: 'DMARC',     label: 'DMARC',     requiresAdmin: true  },
+  { id: 'caa',       name: 'CAA',       label: 'CAA',       requiresAdmin: true  },
   { id: 'about',     name: 'About',     label: 'About',     requiresAdmin: false },
 ];
 

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -156,7 +156,10 @@ module "caa" {
   control_domain         = var.control_domain
   control_domain_zone_id = data.terraform_remote_state.zone.outputs.control_domain_zone_id
   mail_domains           = [for d in module.domains.domains : { domain = d.domain, zone_id = d.zone_id }]
-  iodef_email            = var.email
+  # iodef reports land in the dmarc system user's mailbox (the caa-reports
+  # address is provisioned next to dmarc-reports in modules/app/dmarc_user.tf)
+  # and are ingested by process_dmarc into the admin site's CAA view.
+  iodef_email = "caa-reports@mail-admin.${module.domains.domains[0].domain}"
 }
 
 # Public front door site at www.<control_domain>. Hosts the home page

--- a/terraform/infra/modules/app/dmarc.tf
+++ b/terraform/infra/modules/app/dmarc.tf
@@ -1,10 +1,44 @@
 # DMARC report ingestion pipeline: DynamoDB table, Lambda, IAM, and EventBridge schedule.
+# The same Lambda also ingests CAA iodef violation reports (delivered to the
+# caa-reports address in the same mailbox) into cabal-caa-reports; one reader
+# per mailbox, so the two report streams cannot race each other's IMAP moves.
 
 # -- DynamoDB table for parsed DMARC report records ----------
 
 #tfsec:ignore:aws-dynamodb-table-customer-key
 resource "aws_dynamodb_table" "dmarc_reports" {
   name                        = "cabal-dmarc-reports"
+  billing_mode                = "PAY_PER_REQUEST"
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = true
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+  point_in_time_recovery {
+    enabled = true
+  }
+}
+
+# -- DynamoDB table for CAA iodef violation reports ----------
+
+# One item per report message. Expected to stay empty in normal operation: a
+# CA sends an iodef report only when it refuses a certificate request that
+# violates our CAA policy, so any row here is a mis-issuance attempt (or a
+# deliberate test) and worth investigating.
+#tfsec:ignore:aws-dynamodb-table-customer-key
+resource "aws_dynamodb_table" "caa_reports" {
+  name                        = "cabal-caa-reports"
   billing_mode                = "PAY_PER_REQUEST"
   hash_key                    = "pk"
   range_key                   = "sk"
@@ -73,12 +107,18 @@ resource "aws_iam_role_policy" "process_dmarc" {
           "dynamodb:Query",
           "dynamodb:Scan"
         ]
-        Resource = aws_dynamodb_table.dmarc_reports.arn
+        Resource = [
+          aws_dynamodb_table.dmarc_reports.arn,
+          aws_dynamodb_table.caa_reports.arn,
+        ]
       },
       {
-        Effect   = "Allow"
-        Action   = ["s3:PutObject"]
-        Resource = "arn:aws:s3:::cache.${var.control_domain}/dmarc/*"
+        Effect = "Allow"
+        Action = ["s3:PutObject"]
+        Resource = [
+          "arn:aws:s3:::cache.${var.control_domain}/dmarc/*",
+          "arn:aws:s3:::cache.${var.control_domain}/caa/*",
+        ]
       },
       {
         Effect = "Allow"
@@ -126,8 +166,15 @@ resource "aws_lambda_function" "process_dmarc" {
     variables = {
       CONTROL_DOMAIN         = var.control_domain
       DMARC_TABLE_NAME       = aws_dynamodb_table.dmarc_reports.name
+      CAA_TABLE_NAME         = aws_dynamodb_table.caa_reports.name
       DMARC_USER             = "dmarc"
       HEALTHCHECK_PING_PARAM = var.dmarc_healthcheck_ping_param
+
+      # Local part that marks a message as a CAA iodef violation report (the
+      # modules/caa iodef target). Messages To: this mailbox bypass the DMARC
+      # sender allowlist - they come from whichever CA refused the request,
+      # and the set of CA sender domains is not knowable in advance.
+      CAA_REPORT_LOCAL_PART = "caa-reports"
 
       # Phase 1 hardening (docs/0.10.x/application-surface-hardening-plan.md).
       # Allowlist of From: domains permitted to deliver reports; subdomains of

--- a/terraform/infra/modules/app/dmarc_user.tf
+++ b/terraform/infra/modules/app/dmarc_user.tf
@@ -52,6 +52,16 @@ resource "aws_dynamodb_table_item" "caa_address" {
   })
 
   depends_on = [aws_cognito_user.dmarc]
+
+  # The admin may assign additional users to this address (assign_address
+  # appends to the slash-delimited user attribute) so CAA reports also land
+  # in a personal mailbox. Ignore item drift so an apply never silently
+  # reverts that assignment back to the dmarc user alone. Trade-off: later
+  # Terraform edits to this row (e.g. a changed comment) will not apply
+  # either - taint the resource to force an intentional rewrite.
+  lifecycle {
+    ignore_changes = [item]
+  }
 }
 
 # DNS records for the mail-admin subdomain on the first mail domain.

--- a/terraform/infra/modules/app/dmarc_user.tf
+++ b/terraform/infra/modules/app/dmarc_user.tf
@@ -34,6 +34,26 @@ resource "aws_dynamodb_table_item" "dmarc_address" {
   depends_on = [aws_cognito_user.dmarc]
 }
 
+# Address record so mail to caa-reports@mail-admin.<domain> is also delivered
+# to the dmarc user. This is the CAA iodef target (see modules/caa): a CA that
+# receives a certificate request violating our CAA policy reports it here, and
+# process_dmarc ingests it into cabal-caa-reports alongside the DMARC pipeline.
+resource "aws_dynamodb_table_item" "caa_address" {
+  table_name = "cabal-addresses"
+  hash_key   = "address"
+  item = jsonencode({
+    address   = { S = "caa-reports@mail-admin.${var.domains[0].domain}" }
+    tld       = { S = var.domains[0].domain }
+    user      = { S = "dmarc" }
+    username  = { S = "caa-reports" }
+    subdomain = { S = "mail-admin" }
+    "zone-id" = { S = var.domains[0].zone_id }
+    comment   = { S = "System address for CAA iodef violation reports" }
+  })
+
+  depends_on = [aws_cognito_user.dmarc]
+}
+
 # DNS records for the mail-admin subdomain on the first mail domain.
 # If these already exist from a previously created address, import them:
 #   terraform import 'module.admin.aws_route53_record.dmarc_subdomain_mx' <zone_id>_mail-admin.<domain>_MX

--- a/terraform/infra/modules/app/locals.tf
+++ b/terraform/infra/modules/app/locals.tf
@@ -257,6 +257,14 @@ locals {
       cache     = false
       cache_ttl = 0
     },
+    list_caa_reports = {
+      runtime = "python3.13"
+
+      method    = "GET"
+      memory    = 128
+      cache     = false
+      cache_ttl = 0
+    },
     check_dns_record = {
       runtime = "python3.13"
 

--- a/terraform/infra/modules/app/modules/call/lambda.tf
+++ b/terraform/infra/modules/app/modules/call/lambda.tf
@@ -123,6 +123,7 @@ resource "aws_iam_role_policy" "lambda" {
             "Resource": [
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-addresses",
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-dmarc-reports",
+                "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-caa-reports",
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-user-preferences",
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-user-domain-access",
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-rate-limits"
@@ -207,6 +208,7 @@ resource "aws_lambda_function" "api_call" {
       ADDRESS_CHANGED_TOPIC_ARN   = var.address_changed_topic_arn
       USER_POOL_ID                = var.user_pool_id
       DMARC_TABLE_NAME            = "cabal-dmarc-reports"
+      CAA_TABLE_NAME              = "cabal-caa-reports"
       USER_PREFERENCES_TABLE_NAME = "cabal-user-preferences"
       IMAP_POOL_ENABLED           = var.imap_pool_enabled ? "true" : "false"
     }

--- a/terraform/infra/modules/caa/README.md
+++ b/terraform/infra/modules/caa/README.md
@@ -28,7 +28,7 @@ authorized for both `issue` and `issuewild`.
 | <a name="input_control_domain"></a> [control\_domain](#input\_control\_domain) | Root domain for infrastructure. CAA authorizing ACM and Let's Encrypt is published at its apex. | `string` | n/a | yes |
 | <a name="input_control_domain_zone_id"></a> [control\_domain\_zone\_id](#input\_control\_domain\_zone\_id) | Route 53 Zone ID for the control domain (owned by the bootstrap terraform/dns stack). | `string` | n/a | yes |
 | <a name="input_mail_domains"></a> [mail\_domains](#input\_mail\_domains) | Mail domains and their Route 53 zone IDs (module.domains.domains). Each gets an ACM-only CAA record; the control domain is skipped here as it is covered by control\_domain\_zone\_id. | `list(object({ domain = string, zone_id = string }))` | n/a | yes |
-| <a name="input_iodef_email"></a> [iodef\_email](#input\_iodef\_email) | Contact address for the CAA iodef property, where a CA reports requests that violate the policy. The root stack sets this to the Let's Encrypt contact email (var.email). | `string` | n/a | yes |
+| <a name="input_iodef_email"></a> [iodef\_email](#input\_iodef\_email) | Contact address for the CAA iodef property, where a CA reports requests that violate the policy. The root stack sets this to caa-reports@mail-admin.<first mail domain>, which is delivered to the dmarc system user and ingested by process\_dmarc. | `string` | n/a | yes |
 | <a name="input_ttl"></a> [ttl](#input\_ttl) | TTL in seconds for the CAA records. | `number` | `3600` | no |
 ## Modules
 

--- a/terraform/infra/modules/caa/variables.tf
+++ b/terraform/infra/modules/caa/variables.tf
@@ -18,7 +18,7 @@ variable "mail_domains" {
 
 variable "iodef_email" {
   type        = string
-  description = "Contact address for the CAA iodef property, where a CA reports requests that violate the policy. The root stack sets this to the Let's Encrypt contact email (var.email)."
+  description = "Contact address for the CAA iodef property, where a CA reports requests that violate the policy. The root stack sets this to caa-reports@mail-admin.<first mail domain>, which is delivered to the dmarc system user and ingested by process_dmarc."
 }
 
 variable "ttl" {


### PR DESCRIPTION
## What

Follows up #627. Retargets the CAA `iodef` violation-report contact and gives those reports the full DMARC-report treatment: ingestion, storage, and an admin-site view.

- **New system address** — `caa-reports@mail-admin.<first mail domain>`, provisioned in Terraform next to `dmarc-reports` and mapped to the same `dmarc` system user (same inbox, per the ask). The CAA module's `iodef_email` now derives from the first mail domain instead of `TF_VAR_EMAIL`.
- **Ingestion** — `process_dmarc` routes messages by recipient. `To: caa-reports` → archive raw message to `s3://cache.<control_domain>/caa/…` and write one item per report to a new `cabal-caa-reports` table. One reader per mailbox, so the two report streams can't race each other's IMAP moves. CAA messages bypass `DMARC_REPORT_SENDERS` (the refusing CA's sender domain isn't knowable in advance); the size caps still apply. No deep IODEF parse — formats vary by CA and volume is ~zero, so the envelope facts plus the reviewable raw message are the artifact.
- **API** — new admin-only `GET /list_caa_reports` (mirrors `list_dmarc_reports`: paginated scan, signed S3 URL for the raw message).
- **Admin site** — new admin-only **CAA** view (nav entry, lazy chunk, 4-column table: received / from / domain / subject) with raw-message view/download via the shared source modal. The empty state explains that empty is healthy — any row means a CA refused a mis-issuance attempt.

## Notes for review

- The `cabal-addresses` row is written by Terraform, so the mail tiers pick it up at the next periodic sendmail map regeneration (the SNS reconfigure only fires for app-created addresses) — delivery starts within ~15 min of apply.
- iodef is optional and patchy among CAs (Let's Encrypt doesn't send them), so this view is defense-in-depth visibility, not a routine dashboard. `docs/caa.md` covers this.
- The pending #627 changelog fragment's iodef sentence was corrected in place (still uncollated).

## Verification

- `pylint` 10.00/10 on `process_dmarc` + `list_caa_reports`.
- React: Nav tests pass (incl. new CAA admin-visibility assertions); `vite build` clean. (65 pre-existing local test failures are environmental — identical count on a clean tree; CI is authoritative.)
- Terraform validates in CI; no ECS task-def changes.

End-to-end test after stage deploy: send any email to `caa-reports@mail-admin.<first mail domain>`, wait for the next `process_dmarc` run (≤6 h, or invoke `process_dmarc` from CloudShell), then check the CAA view as an admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)