### PR TITLE
Scope TestFlight notes to Apple-tagged changelog entries

### DIFF
--- a/.github/scripts/check-apple-changelog.sh
+++ b/.github/scripts/check-apple-changelog.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Require an `Apple:`-prefixed changelog fragment when a PR changes the Apple
+# client sources.
+#
+# The TestFlight "What to Test" notes are built (by set-testflight-notes.py)
+# from only the changelog entries prefixed `Apple:`, so an Apple client change
+# that ships without such a fragment silently drops out of the notes testers
+# read. This check is the enforcement half of that convention (see CLAUDE.md
+# and changelog.d/README.md): if a PR touches the Apple client sources, it must
+# add a changelog fragment whose entry begins `- Apple:`.
+#
+# It is a heuristic backstop, not a proof: a CI check cannot know whether a
+# fragment truly describes the Apple change, only that a well-formed one exists.
+# Some Apple-source PRs are legitimately not user-facing (refactors, test-only,
+# CI, xcodegen). Apply the `no-changelog` PR label to opt those out.
+#
+# Runs from lint.yml on pull_request, gated on the apple_src path filter.
+#
+# Required env:
+#   BASE_SHA  PR base branch tip (github.event.pull_request.base.sha)
+#   HEAD_SHA  PR head commit     (github.event.pull_request.head.sha)
+# Optional env:
+#   OPT_OUT   "true" when the PR carries the no-changelog label; skips the check
+
+set -euo pipefail
+
+: "${BASE_SHA:?missing BASE_SHA}"
+: "${HEAD_SHA:?missing HEAD_SHA}"
+
+# The Apple client sources whose changes warrant a tester-visible note. Scoped
+# to shipped client code - not Tests/, project.yml, or apple/*.md - to keep the
+# gate off PRs with no user-facing Apple surface. Keep in sync with the
+# apple_src filter in lint.yml.
+apple_src_re='^apple/(Cabalmail|CabalmailMac|CabalmailKit/Sources)/'
+
+# Three-dot: changes on the PR head since it diverged from base, matching what
+# dorny/paths-filter reports (ignores unrelated commits landed on base since).
+changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
+
+apple_changed="$(printf '%s\n' "$changed" | grep -E "$apple_src_re" || true)"
+if [ -z "$apple_changed" ]; then
+  echo "[apple-changelog] No Apple client source changes; nothing to require."
+  exit 0
+fi
+
+echo "[apple-changelog] Apple client sources changed:"
+printf '%s\n' "$apple_changed" | sed 's/^/  /'
+
+if [ "${OPT_OUT:-false}" = "true" ]; then
+  echo "::notice::'no-changelog' label present; skipping the Apple changelog requirement."
+  exit 0
+fi
+
+# Look for an added/modified changelog fragment whose first bullet is Apple:.
+# The working tree is the PR merge checkout, so added fragments are present.
+while IFS= read -r file; do
+  case "$file" in
+    changelog.d/*.md) ;;
+    *) continue ;;
+  esac
+  [ "$file" = "changelog.d/README.md" ] && continue
+  [ -f "$file" ] || continue  # deleted in the PR
+  first_bullet="$(grep -m1 '^- ' "$file" || true)"
+  if printf '%s' "$first_bullet" | grep -qE '^- Apple:'; then
+    echo "[apple-changelog] Found Apple changelog fragment: $file"
+    exit 0
+  fi
+done <<< "$changed"
+
+echo "::error::Apple client sources changed but no 'Apple:'-prefixed changelog fragment was added."
+cat >&2 <<'MSG'
+Add a fragment changelog.d/<slug>.<category>.md whose entry begins with
+"- Apple:" (e.g. "- Apple: **Threaded reader.** Messages now group ...").
+The Apple: prefix scopes the entry into the TestFlight "What to Test" notes.
+
+If this PR has no user-facing Apple-client change (refactor, test-only, CI),
+apply the "no-changelog" label to the PR to opt out.
+MSG
+exit 1

--- a/.github/scripts/set-testflight-notes.py
+++ b/.github/scripts/set-testflight-notes.py
@@ -18,6 +18,14 @@
 # one marketing version, so the whole section maps to that one TestFlight
 # version; multiple builds under it would all carry the same notes.
 #
+# Apple scoping: these notes go to Apple-client testers, so only entries that
+# describe an Apple-client change are relevant. Such entries are prefixed
+# `Apple:` in the changelog (a convention enforced for Apple client PRs - see
+# CLAUDE.md and changelog.d/README.md). This script keeps only those bullets,
+# strips the redundant `Apple:` prefix, and drops any section heading left with
+# no bullets. A release with no Apple-scoped entries falls back to generic
+# maintenance text so testers never see a blank "What to Test".
+#
 # Best-effort by design: the binary is already uploaded by the time this runs,
 # so any failure here (build still processing past the timeout, transient API
 # error, missing config) emits a `::warning::` and exits 0 rather than turning
@@ -60,6 +68,12 @@ import jwt  # PyJWT, installed in the calling step's venv
 
 API_BASE = "https://api.appstoreconnect.apple.com"
 WHATS_NEW_MAX = 4000  # App Store Connect's hard cap on the field.
+
+# Changelog bullets meant for Apple-client testers are prefixed `Apple:`.
+APPLE_PREFIX = re.compile(r"^Apple:\s*")
+# Shown when a release carries no Apple-scoped entries, so the field is never
+# blank for testers.
+FALLBACK_NOTES = "Bug fixes and behind-the-scenes improvements."
 
 
 def warn(message):
@@ -123,7 +137,13 @@ def flatten_changelog(changelog_path):
     Takes everything from the first `## [x.y.z]` heading up to the next one,
     drops the version heading itself, turns `### Section` into `Section:`, and
     rejoins hard-wrapped bullets (two-space continuation indent) into single
-    lines. Truncates to App Store Connect's field cap.
+    lines.
+
+    Then narrows to the Apple-client audience: only bullets prefixed `Apple:`
+    are kept (with that prefix stripped), and any `### Section` heading left
+    with no surviving bullets is dropped. If nothing Apple-scoped remains,
+    returns generic maintenance text so the field is never blank. Truncates to
+    App Store Connect's field cap.
     """
     with open(changelog_path, encoding="utf-8") as handle:
         lines = handle.read().splitlines()
@@ -142,13 +162,15 @@ def flatten_changelog(changelog_path):
             break
         section.append(line)
 
-    out = []
+    # Parse the section into ordered tokens: ("heading", text) and
+    # ("bullet", text), rejoining hard-wrapped bullet continuations.
+    tokens = []
     current = None
 
     def flush():
         nonlocal current
         if current is not None:
-            out.append(f"- {current}")
+            tokens.append(("bullet", current))
             current = None
 
     for line in section:
@@ -158,23 +180,48 @@ def flatten_changelog(changelog_path):
         heading = re.match(r"^### (.+)$", line)
         if heading:
             flush()
-            if out and out[-1] != "":
-                out.append("")
-            out.append(f"{heading.group(1).strip()}:")
+            tokens.append(("heading", heading.group(1).strip()))
         elif line.startswith("- "):
             flush()
             current = line[2:].strip()
         elif line.startswith("  ") and current is not None:
             # Continuation of the current hard-wrapped bullet.
             current += " " + line.strip()
-        else:
-            flush()
-            out.append(line.strip())
+        # Stray non-bullet, non-heading text is not Apple-scoped; drop it.
     flush()
+
+    # Keep only Apple-scoped bullets (prefix stripped), then drop headings that
+    # have no surviving bullet before the next heading.
+    scoped = [
+        ("bullet", APPLE_PREFIX.sub("", text, count=1))
+        if kind == "bullet" and APPLE_PREFIX.match(text)
+        else (kind, text)
+        for kind, text in tokens
+        if kind == "heading" or APPLE_PREFIX.match(text)
+    ]
+
+    out = []
+    for index, (kind, text) in enumerate(scoped):
+        if kind == "heading":
+            # Emit the heading only if a bullet follows it before the next one.
+            has_bullet = False
+            for next_kind, _ in scoped[index + 1:]:
+                if next_kind == "heading":
+                    break
+                has_bullet = True
+                break
+            if not has_bullet:
+                continue
+            if out and out[-1] != "":
+                out.append("")
+            out.append(f"{text}:")
+        else:
+            out.append(f"- {text}")
 
     text = "\n".join(out).strip()
     if not text:
-        raise RuntimeError("flattened changelog section is empty")
+        # No Apple-scoped entries this release; give testers sensible notes.
+        return FALLBACK_NOTES
     if len(text) > WHATS_NEW_MAX:
         # Truncate on a line boundary where possible, leaving room for the marker.
         marker = "\n..."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,12 @@ name: Lint
 #   - Swift:     swiftlint --strict (from apple.yml).
 #   - React:     eslint (new for the PR gate; the deploy path only builds).
 #
+# It also adds one PR-only convention gate with no deploy-workflow counterpart:
+#
+#   - Changelog: a PR touching the Apple client sources must add an `Apple:`-
+#                prefixed changelog fragment (opt out via the `no-changelog`
+#                label), so the change reaches the TestFlight notes.
+#
 # This is lint-only: no AWS credentials, no Terraform backend, no deploy. The
 # Terraform scanners read the committed source directly (exactly as the
 # infra.yml scanner jobs do), so they need neither a generated backend.tf nor
@@ -46,6 +52,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       swift: ${{ steps.filter.outputs.swift }}
       react: ${{ steps.filter.outputs.react }}
+      apple_src: ${{ steps.filter.outputs.apple_src }}
     steps:
     - name: checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -69,6 +76,15 @@ jobs:
           swift:
             - 'apple/**'
             - '.github/workflows/lint.yml'
+          # Narrower than `swift`: only shipped Apple client code, so the
+          # changelog gate stays off PRs that touch tests, project.yml, or docs.
+          # Deliberately excludes lint.yml/the check script so a pure-CI edit
+          # does not demand an Apple fragment. Keep in sync with the
+          # apple_src_re in check-apple-changelog.sh.
+          apple_src:
+            - 'apple/Cabalmail/**'
+            - 'apple/CabalmailMac/**'
+            - 'apple/CabalmailKit/Sources/**'
           react:
             - 'react/admin/**'
             - '.github/workflows/lint.yml'
@@ -245,3 +261,27 @@ jobs:
       run: npm ci
     - name: eslint
       run: npm run lint
+
+  # ---------------------------------------------------------------------------
+  # Apple changelog scope. When a PR touches the shipped Apple client sources,
+  # require an `Apple:`-prefixed changelog fragment so the change reaches the
+  # TestFlight "What to Test" notes (set-testflight-notes.py filters the notes
+  # to Apple-scoped entries). Opt out with the `no-changelog` PR label for
+  # non-user-facing Apple work. See CLAUDE.md and changelog.d/README.md.
+  # ---------------------------------------------------------------------------
+  changelog:
+    needs: changes
+    if: needs.changes.outputs.apple_src == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        # Need base and head commits to diff the PR range and read fragments.
+        fetch-depth: 0
+    - name: require-apple-fragment
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        OPT_OUT: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+      run: ./.github/scripts/check-apple-changelog.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,8 @@ Use semantic versioning. Record changelog entries as **fragments**, not by editi
 
 Don't repeat the category subheading word (or a close synonym) in the fragment text - the collator already prints it as an `### Added:`/`### Removed:`/etc. heading, so "Added a new UI element for X" reads as redundant under `### Added:`. Instead, lead with a bold noun-phrase summary followed by details: `- **New UI element for X.** <details>`. Same for `Removed`, `Deprecated`, `Changed`, `Fixed`, `Security`.
 
+Any fragment describing a change to the **Apple clients** (`apple/Cabalmail`, `apple/CabalmailMac`, `apple/CabalmailKit/Sources`) **must** prefix its entry with `Apple:` - right after the leading `- ` and before the bold summary: `- Apple: **Threaded reader.** <details>`. This prefix scopes the entry into the TestFlight "What to Test" notes: `set-testflight-notes.py` keeps only `Apple:`-prefixed entries (stripping the prefix, since it's redundant in an Apple app) and drops the rest, so an Apple change without the prefix silently vanishes from the notes testers read. A PR that touches the Apple client sources fails the `changelog` gate in `lint.yml` unless it adds such a fragment; opt out for non-user-facing Apple work (refactors, test-only, CI) with the `no-changelog` PR label.
+
 ## Roadmap
 
 See the [project wiki](https://github.com/cabalmail/cabal-infra/wiki) for the current roadmap.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -39,6 +39,26 @@ an `## [Unreleased]` section - the collator owns the top of that file. Record
 only what shipped to users: no fragment for a bug introduced and fixed within
 the same unreleased cycle, or a latent bug fixed before exposure.
 
+## Apple client entries
+
+Any fragment describing a change to the Apple clients (`apple/Cabalmail`,
+`apple/CabalmailMac`, `apple/CabalmailKit/Sources`) must prefix its entry with
+`Apple:`, right after the leading `- `:
+
+    - Apple: **Threaded reader.** Messages now group into conversation
+      threads in the reader pane.
+
+The TestFlight "What to Test" notes are built from the released `CHANGELOG.md`
+section by `.github/scripts/set-testflight-notes.py`, which keeps only the
+`Apple:`-prefixed entries (stripping the prefix, since it is redundant inside
+an Apple app) and drops everything else. So an Apple-client change without the
+prefix silently disappears from the notes testers see.
+
+A PR that touches the Apple client sources fails the `changelog` job in
+`.github/workflows/lint.yml` unless it adds such a fragment. For a genuinely
+non-user-facing Apple change (refactor, test-only, CI, xcodegen), apply the
+`no-changelog` label to the PR to opt out.
+
 ## Releasing
 
 `scripts/promote.sh` (or `make promote VERSION=<x.y.z>`) runs the

--- a/changelog.d/apple-scoped-testflight-notes.changed.md
+++ b/changelog.d/apple-scoped-testflight-notes.changed.md
@@ -1,0 +1,5 @@
+- Apple: **Release notes now show only app-relevant changes.** The
+  TestFlight "What to Test" notes are built from just the changelog entries
+  scoped to the Apple clients, instead of the whole release. Entries are
+  tagged `Apple:` in the changelog and a PR check requires the tag when a
+  change touches the Apple client sources.


### PR DESCRIPTION
## What

Make the TestFlight "What to Test" changelog relevant to app testers by scoping it to Apple-client changes only.

Today `set-testflight-notes.py` flattens the *entire* released `CHANGELOG.md` section into the notes, so testers see Terraform, Lambda, and infra entries that mean nothing in the app.

## How

1. **Convention** — any changelog fragment describing an Apple-client change (`apple/Cabalmail`, `apple/CabalmailMac`, `apple/CabalmailKit/Sources`) must prefix its entry with `Apple:`, right after the leading `- `. The prefix lives in `CHANGELOG.md` permanently as a scope label. Documented in `CLAUDE.md` and `changelog.d/README.md`.

2. **Notes build** (`set-testflight-notes.py`) — `flatten_changelog` now keeps only `Apple:`-prefixed bullets, strips the redundant prefix, and drops any `### Section` heading left with no bullets. A release with no Apple entries falls back to `"Bug fixes and behind-the-scenes improvements."` so the field is never blank.

3. **Enforcement** (`lint.yml` + `check-apple-changelog.sh`) — a new `changelog` PR job fails when a PR touches the Apple client sources without adding an `Apple:`-prefixed fragment. Opt out for non-user-facing Apple work (refactors, test-only, CI) with the **`no-changelog`** PR label.

### Note on the check

It's a heuristic backstop, not a proof: CI can't know whether a fragment truly *describes* the Apple change, only that a well-formed one exists. The `CLAUDE.md` convention is the real guarantee; the gate catches the common miss.

## Testing

- `flatten_changelog` verified against a sample section: non-Apple bullets and their now-empty headings dropped, prefixes stripped, empty-release fallback returned.
- `check-apple-changelog.sh` verified across five cases (apple change w/o fragment → fail; opt-out label → pass; non-Apple fragment → fail; `Apple:` fragment → pass; docs-only → skip).
- `actionlint` clean on the new job (the one reported finding is a pre-existing SC2035 on the existing `pylint-api` step).

## Follow-up

The `no-changelog` label must exist in the repo for the opt-out to be selectable in the PR UI (the check reads it from the event payload regardless). Create it once if it isn't already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)