### PR TITLE
Make CabalmailKit build for watchOS (Watch app, Phase 1)

### DIFF
--- a/apple/CabalmailKit/Package.swift
+++ b/apple/CabalmailKit/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
         .iOS("18.0"),
         .macOS("15.0"),
         .visionOS("2.0"),
+        .watchOS("11.0"),
     ],
     products: [
         .library(name: "CabalmailKit", targets: ["CabalmailKit"]),

--- a/apple/CabalmailKit/Sources/CabalmailKit/Compose/RichTextEditorController.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Compose/RichTextEditorController.swift
@@ -1,4 +1,10 @@
 import Foundation
+// The rich-text composer is backed by WKWebView, which does not exist on
+// watchOS. Guarding the whole file keeps CabalmailKit buildable for a watchOS
+// companion target (address management only); the type is self-contained and
+// referenced solely from the iOS/macOS/visionOS compose views in the app
+// targets, so compiling it out has no effect on those platforms.
+#if canImport(WebKit)
 @preconcurrency import WebKit
 #if canImport(AppKit)
 import AppKit
@@ -372,3 +378,4 @@ extension RichTextEditorController.Selection {
         canRedo = states["canRedo"] as? Bool ?? false
     }
 }
+#endif


### PR DESCRIPTION
## Summary

Phase 1 of a planned Apple Watch companion app scoped to **email-address management** (create / list / revoke burner addresses — the one Cabalmail feature that's genuinely better on the wrist). This PR only makes `CabalmailKit` compile for watchOS. **No watch target or user-facing feature ships here.**

- Add `.watchOS("11.0")` to the package `platforms`.
- Guard `RichTextEditorController` (the WKWebView-backed composer) behind `#if canImport(WebKit)`. WebKit doesn't exist on watchOS; the type is self-contained and referenced only from the iOS/macOS/visionOS compose views in the app targets, so this is a no-op there.

This was the whole point of doing Phase 1 first: a whole-module `swiftc -typecheck` against the watchOS SDK surfaced exactly **one** portability gap (the unguarded `import WebKit`) across all 75 kit files — confirming the auth + address + config layers are already watch-clean, with the IMAP/SMTP/Reachability/offline-queue code correctly behind `#if canImport(Network)` and the UIKit bits behind `!os(watchOS)`.

## Verification

- `swiftc -typecheck -target arm64-apple-watchos11.0 -sdk <watchOS SDK>` over the whole module: **0 errors** (with a stub standing in for SwiftPM's generated `Bundle.module` accessor, which exists on watchOS under a real build).
- Host `swift build`: clean.
- `swift test`: unchanged. The 4 failures are the pre-existing `AcknowledgementsTests` missing-vendored-license-files issue (`did sync-vendored.sh run?`) — this worktree has no vendored license files on disk; unrelated to a compile-guard change.

## Not user-facing

No watch app exists yet, so there's nothing for a TestFlight tester to see — opting out of the `Apple:` changelog requirement via the `no-changelog` label. The real `- Apple:` entry lands when the watch app itself ships.

## Next phases (not in this PR)

2. `project.yml` watch target + hello-world app in the sim.
3. WatchConnectivity credential bridge (phone → watch config + refresh token; watch refreshes id-tokens autonomously).
4. New / list / revoke screens.
5. Signing / CI / docs → TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)