### PR TITLE
Add the CabalmailWatch app target (Watch app, Phase 2)

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -176,6 +176,9 @@ jobs:
           - scheme: CabalmailMac
             platform: macOS
             destination: 'generic/platform=macOS'
+          - scheme: CabalmailWatch
+            platform: watchOS
+            destination: 'generic/platform=watchOS'
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -184,6 +187,17 @@ jobs:
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Ensure watchOS platform
+        # The runner image ships every platform for its default Xcode, but a
+        # setup-xcode selection can land on a copy without the watchOS
+        # runtime, and even a `generic/platform=watchOS` device build fails
+        # destination resolution when the platform bundle is absent. No-op
+        # when it is already installed.
+        if: matrix.platform == 'watchOS'
+        run: |
+          xcrun simctl list runtimes | grep -q watchOS \
+            || sudo xcodebuild -downloadPlatform watchOS
 
       - name: Install XcodeGen + xcbeautify
         # See the kit-test job for the rationale on the per-package check.

--- a/apple/.gitignore
+++ b/apple/.gitignore
@@ -2,6 +2,7 @@
 Cabalmail.xcodeproj/
 Cabalmail/Info.plist
 CabalmailMac/Info.plist
+CabalmailWatch/Info.plist
 
 # Local per-developer overrides (team ID, etc.). Never commit.
 Local.xcconfig

--- a/apple/.swiftlint.yml
+++ b/apple/.swiftlint.yml
@@ -5,6 +5,7 @@
 included:
   - Cabalmail
   - CabalmailMac
+  - CabalmailWatch
   - CabalmailKit/Sources
   - CabalmailKit/Tests
 

--- a/apple/CabalmailWatch/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apple/CabalmailWatch/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x89",
+          "green" : "0xC2",
+          "red" : "0x79"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/CabalmailWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apple/CabalmailWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "watchos",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/CabalmailWatch/Assets.xcassets/Contents.json
+++ b/apple/CabalmailWatch/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/CabalmailWatch/CabalmailWatch.entitlements
+++ b/apple/CabalmailWatch/CabalmailWatch.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        This file is wired into the watch target's signing via
+        `apple/project.yml` (CODE_SIGN_ENTITLEMENTS). It ships empty on
+        purpose, mirroring the iOS target's convention: wiring the file
+        from day one means later phases only edit the entitlements file,
+        not `project.yml`. The watch app stores its own credentials in
+        its own keychain (bootstrapped from the phone over
+        WatchConnectivity), so no keychain-sharing or app-group
+        entitlement is needed for the core address features.
+    -->
+</dict>
+</plist>

--- a/apple/CabalmailWatch/CabalmailWatchApp.swift
+++ b/apple/CabalmailWatch/CabalmailWatchApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// Entry point for the watch companion app.
+///
+/// Scope is deliberately narrow: the address lifecycle (create / list /
+/// revoke) — the one Cabalmail feature that is better on the wrist than
+/// anywhere else. Mail reading and compose stay on the other platforms.
+@main
+struct CabalmailWatchApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/apple/CabalmailWatch/ContentView.swift
+++ b/apple/CabalmailWatch/ContentView.swift
@@ -1,0 +1,31 @@
+import CabalmailKit
+import SwiftUI
+
+/// Placeholder root view for the target-scaffolding phase. The next phases
+/// replace this with the WatchConnectivity credential bootstrap and the
+/// address list / create / revoke screens.
+struct ContentView: View {
+    /// Deliberate CabalmailKit reference: forces the package to link into
+    /// the watch binary, so this scaffold proves kit portability at link
+    /// time rather than only at typecheck time.
+    private static let kitLinkProbe = String(describing: Address.self)
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "envelope.badge.shield.half.filled")
+                .font(.title3)
+                .foregroundStyle(.tint)
+            Text("Cabalmail")
+                .font(.headline)
+            Text("Address management is on its way.")
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -21,6 +21,7 @@ options:
     iOS: "18.0"
     macOS: "15.0"
     visionOS: "2.0"
+    watchOS: "11.0"
   createIntermediateGroups: true
   generateEmptyDirectories: true
 
@@ -262,6 +263,64 @@ targets:
           CODE_SIGN_IDENTITY: "Apple Distribution"
           PROVISIONING_PROFILE_SPECIFIER: "$(MAC_APP_STORE_PROFILE_UUID)"
 
+  # Watch companion app, scoped to the address lifecycle (create / list /
+  # revoke) — mail reading stays on the other platforms. Deliberately NOT
+  # embedded in the iOS app yet: embedding adds the watch app to the iOS
+  # archive's signing inputs (every App Store upload would need the watch
+  # provisioning profile), so that lands with the watch signing/TestFlight
+  # work. Until then the target builds and runs in the simulator via its
+  # own scheme and CI leg.
+  CabalmailWatch:
+    type: application
+    platform: watchOS
+    sources:
+      - path: CabalmailWatch
+    dependencies:
+      - package: CabalmailKit
+    info:
+      path: CabalmailWatch/Info.plist
+      properties:
+        CFBundleDisplayName: Cabalmail
+        ITSAppUsesNonExemptEncryption: false
+        # Single-target watchOS app (SwiftUI app lifecycle, no WatchKit
+        # extension bundle). Required for the watchOS 7+ app structure.
+        WKApplication: true
+        # Pairs the watch app with the iOS companion. The credential
+        # bootstrap (Configuration + Cognito refresh token) arrives from
+        # the phone over WatchConnectivity — the two devices do not share
+        # a keychain, so the watch cannot read the phone's tokens.
+        WKCompanionAppBundleIdentifier: com.cabalmail.Cabalmail
+        # See the Cabalmail target's equivalent comment — XcodeGen defaults
+        # these to "1" / "1.0" unless explicitly plumbed through to the
+        # build settings.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+    settings:
+      base:
+        # Apple's convention for a watch app paired to an iOS companion:
+        # the companion's bundle id plus a `.watchkitapp` suffix.
+        PRODUCT_BUNDLE_IDENTIFIER: com.cabalmail.Cabalmail.watchkitapp
+        # On-watch app name; defaults to the target name otherwise.
+        PRODUCT_NAME: Cabalmail
+        # App Store validation requires a watch app's version to match its
+        # iOS companion exactly — keep both fields in lockstep with the
+        # Cabalmail target above.
+        MARKETING_VERSION: "0.6.0"
+        CURRENT_PROJECT_VERSION: "1"
+        GENERATE_INFOPLIST_FILE: NO
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+        # XcodeGen defaults ASSETCATALOG_COMPILER_APPICON_NAME to AppIcon
+        # for application targets, so the catalog carries a placeholder
+        # (empty) AppIcon.appiconset — a single 1024pt universal watch
+        # slot. The actual artwork is generated with the signing /
+        # TestFlight work, alongside the CFBundleIconName plumbing the
+        # other targets carry.
+        CODE_SIGN_ENTITLEMENTS: CabalmailWatch/CabalmailWatch.entitlements
+      # No manual Release signing block yet — that arrives with the watch
+      # provisioning profile (WATCHOS_APP_STORE_PROFILE_UUID, mirroring the
+      # IOS_/MAC_ convention) when the TestFlight path is wired up. Debug
+      # uses the project-level Automatic style like the other targets.
+
 schemes:
   Cabalmail:
     build:
@@ -275,6 +334,14 @@ schemes:
     build:
       targets:
         CabalmailMac: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+  CabalmailWatch:
+    build:
+      targets:
+        CabalmailWatch: all
     run:
       config: Debug
     archive:


### PR DESCRIPTION
## Summary

Phase 2 of the watch companion app (Phase 1 = #631, merged): a buildable, runnable **watchOS target scaffold** with a placeholder root view. No watch feature ships yet, and nothing reaches TestFlight — the target is deliberately **not embedded** in the iOS app (embedding adds the watch app to the iOS archive's signing inputs; that lands with the watch signing work).

- **`CabalmailWatch` target** in `project.yml`: single-target watchOS app (`WKApplication`), bundle id `com.cabalmail.Cabalmail.watchkitapp` paired to the iOS companion via `WKCompanionAppBundleIdentifier`, versions in lockstep with the iOS target (App Store requires it), own scheme.
- **Scaffold sources** (`apple/CabalmailWatch/`): app entry point; placeholder `ContentView` that imports CabalmailKit and references `Address` — proving the kit **links** on watchOS, not just typechecks; empty entitlements mirroring the iOS convention; asset catalog with the brand accent color and a placeholder `AppIcon` set (XcodeGen defaults `ASSETCATALOG_COMPILER_APPICON_NAME` to `AppIcon` and actool fails without a matching set — found the hard way; artwork lands with signing).
- **CI**: `CabalmailWatch` leg in the `app-build` matrix (`generic/platform=watchOS`, unsigned), with a guarded `xcodebuild -downloadPlatform watchOS` in case the selected runner Xcode lacks the platform bundle.
- **swiftlint**: `CabalmailWatch` added to `included`; generated `Info.plist` gitignored like the other targets.

## Verification

- `xcodegen generate` clean; generated Info.plist carries `WKApplication` / `WKCompanionAppBundleIdentifier` as intended.
- Unsigned `xcodebuild build` for the watchOS simulator: **BUILD SUCCEEDED**.
- Installed + launched on an Apple Watch Series 11 (46mm) simulator and screenshot-verified the running app (brand-green accent, correct display name).
- `swiftlint lint --strict`: clean.

## Not user-facing

Not embedded in the iOS app, so no tester-visible surface — keeping the `no-changelog` opt-out. The `Apple:` changelog entry lands when the watch app actually ships to TestFlight.

## Next phases

3. WatchConnectivity credential bridge (phone → watch: config + Cognito refresh token; watch refreshes id-tokens autonomously).
4. Address list / create / revoke screens.
5. Icon artwork, signing (`WATCHOS_APP_STORE_PROFILE_UUID`), embedding in the iOS app, TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)