### PR TITLE
Watch credential bridge over WatchConnectivity (Watch app, Phase 3)

### DIFF
--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -245,20 +245,6 @@ final class AppState {
         }
     }
 
-    /// Last-used control domain, persisted so repeat launches skip re-entry.
-    var controlDomain: String {
-        get { UserDefaults.standard.string(forKey: "cabalmail.controlDomain") ?? "" }
-        set { UserDefaults.standard.set(newValue, forKey: "cabalmail.controlDomain") }
-    }
-
-    /// Last-used username, same persistence rationale. Passwords are never
-    /// persisted here — `CognitoAuthService` holds them in the data-protection
-    /// keychain via `KeychainSecureStore`.
-    var lastUsername: String {
-        get { UserDefaults.standard.string(forKey: "cabalmail.lastUsername") ?? "" }
-        set { UserDefaults.standard.set(newValue, forKey: "cabalmail.lastUsername") }
-    }
-
     private(set) var client: CabalmailClient?
 
     /// Cross-client navigation cursor for the current session: remembers and
@@ -304,6 +290,7 @@ final class AppState {
             self.status = .signedIn
             startInboxBadgePolling()
             requestContactsAccessIfNeeded()
+            await pushSessionToWatch(client: newClient, username: username)
         } catch let error as CabalmailError {
             status = .error(message(for: error))
         } catch {
@@ -321,6 +308,8 @@ final class AppState {
         // cache.
         await client.clearLocalData()
         try? await client.authService.signOut()
+        // Tell the watch to drop its copy of the credentials too.
+        WatchSessionBridge.shared.pushSignedOut()
         self.client = nil
         self.navCoordinator = nil
         self.status = .signedOut
@@ -387,6 +376,9 @@ final class AppState {
             self.status = .signedIn
             startInboxBadgePolling()
             requestContactsAccessIfNeeded()
+            // Restore is the common launch path, so this is what keeps the
+            // watch's copy of the session fresh across app launches.
+            await pushSessionToWatch(client: newClient, username: username)
         } catch let error as CabalmailError {
             switch error {
             case .authExpired, .invalidCredentials, .notSignedIn:
@@ -489,6 +481,24 @@ final class AppState {
     }
 }
 
+// MARK: - Persisted last-session fields
+
+extension AppState {
+    /// Last-used control domain, persisted so repeat launches skip re-entry.
+    var controlDomain: String {
+        get { UserDefaults.standard.string(forKey: "cabalmail.controlDomain") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "cabalmail.controlDomain") }
+    }
+
+    /// Last-used username, same persistence rationale. Passwords are never
+    /// persisted here — `CognitoAuthService` holds them in the data-protection
+    /// keychain via `KeychainSecureStore`.
+    var lastUsername: String {
+        get { UserDefaults.standard.string(forKey: "cabalmail.lastUsername") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "cabalmail.lastUsername") }
+    }
+}
+
 // MARK: - Cache directory
 
 extension AppState {
@@ -505,6 +515,22 @@ extension AppState {
         let directory = base.appendingPathComponent("Cabalmail", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+}
+
+// MARK: - Watch hand-off
+
+extension AppState {
+    /// Hands the signed-in session (configuration + Cognito tokens) to the
+    /// paired watch. `WatchSessionBridge` is a no-op stub on platforms
+    /// without WatchConnectivity, so callers don't need platform guards.
+    private func pushSessionToWatch(client: CabalmailClient, username: String) async {
+        guard let tokens = await client.authService.currentTokens() else { return }
+        WatchSessionBridge.shared.pushSession(
+            configuration: client.configuration,
+            tokens: tokens,
+            username: username
+        )
     }
 }
 

--- a/apple/Cabalmail/WatchSessionBridge.swift
+++ b/apple/Cabalmail/WatchSessionBridge.swift
@@ -1,0 +1,99 @@
+// Phone side of the watch credential hand-off.
+//
+// WatchConnectivity exists on iOS (and watchOS) only, so the real
+// implementation compiles solely into the iOS slice; visionOS builds of
+// this target and the macOS target (which shares AppState.swift and this
+// file) get the no-op stub below. Same API either way, which keeps the
+// AppState call-sites free of per-platform conditionals.
+#if canImport(WatchConnectivity) && os(iOS)
+import CabalmailKit
+import Foundation
+import WatchConnectivity
+
+/// Pushes the signed-in session (Configuration + Cognito tokens + username)
+/// to the paired watch via the WCSession application context, and a
+/// versioned "signed out" context on sign-out. Application-context delivery
+/// is latest-state: the watch receives whatever was pushed most recently the
+/// next time it wakes, even if both apps were dead in between — exactly the
+/// semantics a credential hand-off wants.
+///
+/// Failures are deliberately quiet. There is no user-visible surface for
+/// "the watch didn't get the tokens yet": every sign-in / restore pushes a
+/// fresh context, and the watch shows its own "connect from your iPhone"
+/// state until one arrives.
+final class WatchSessionBridge: NSObject, WCSessionDelegate, @unchecked Sendable {
+    static let shared = WatchSessionBridge()
+
+    /// Context waiting for session activation to complete. Guarded by
+    /// `lock` — delegate callbacks arrive on WatchConnectivity's own queue.
+    private let lock = NSLock()
+    private var pendingContext: [String: Any]?
+
+    func pushSession(configuration: Configuration, tokens: AuthTokens, username: String) {
+        let handoff = WatchHandoff(
+            configuration: configuration,
+            tokens: tokens,
+            username: username
+        )
+        guard let context = try? handoff.applicationContext() else { return }
+        push(context)
+    }
+
+    func pushSignedOut() {
+        push(WatchHandoff.signedOutContext())
+    }
+
+    private func push(_ context: [String: Any]) {
+        // isSupported is false on iPad — only iPhones pair with a watch.
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        if session.delegate !== self {
+            session.delegate = self
+        }
+        if session.activationState == .activated {
+            try? session.updateApplicationContext(context)
+        } else {
+            lock.lock()
+            pendingContext = context
+            lock.unlock()
+            session.activate()
+        }
+    }
+
+    // MARK: - WCSessionDelegate
+
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: (any Error)?
+    ) {
+        guard activationState == .activated else { return }
+        lock.lock()
+        let context = pendingContext
+        pendingContext = nil
+        lock.unlock()
+        if let context {
+            try? session.updateApplicationContext(context)
+        }
+    }
+
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        // Apple's contract for the user switching to a different paired
+        // watch: reactivate so the new watch keeps receiving contexts.
+        session.activate()
+    }
+}
+#else
+import CabalmailKit
+
+/// No-op stand-in for platforms without WatchConnectivity — only iPhones
+/// pair with a watch, so there is nothing to hand off elsewhere.
+final class WatchSessionBridge: Sendable {
+    static let shared = WatchSessionBridge()
+
+    func pushSession(configuration: Configuration, tokens: AuthTokens, username: String) {}
+    func pushSignedOut() {}
+}
+#endif

--- a/apple/CabalmailKit/Sources/CabalmailKit/Auth/AuthService.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Auth/AuthService.swift
@@ -139,6 +139,17 @@ public actor CognitoAuthService: AuthService {
         try secureStore.remove(SecureStoreKey.imapPassword)
     }
 
+    /// Installs externally obtained tokens — the watch app's credential
+    /// bootstrap, where the paired iPhone hands its session over via a
+    /// `WatchHandoff`. The password never leaves the phone, so
+    /// `currentImapCredentials()` stays unavailable on the adopting device;
+    /// the API-backed clients only need `currentIdToken()`, which refreshes
+    /// off the adopted refresh token.
+    public func adopt(tokens: AuthTokens, username: String) throws {
+        try persist(tokens: tokens)
+        try secureStore.setString(username, forKey: SecureStoreKey.imapUsername)
+    }
+
     // MARK: - Token access
 
     public func currentIdToken() async throws -> String {

--- a/apple/CabalmailKit/Sources/CabalmailKit/Watch/WatchHandoff.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Watch/WatchHandoff.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Credential hand-off from the iPhone app to its paired watch app.
+///
+/// The iPhone and the watch are separate devices with separate keychains, so
+/// the watch cannot read the phone's Cognito session — it has to be handed
+/// one. The phone encodes a `WatchHandoff` into the WatchConnectivity
+/// application context (latest-state semantics: delivered whenever the watch
+/// next wakes, surviving both apps being dead); the watch decodes it, adopts
+/// the tokens into its own keychain via `CognitoAuthService.adopt`, and from
+/// then on refreshes ID tokens autonomously for the refresh token's lifetime.
+///
+/// The user's password is deliberately NOT part of the hand-off. When the
+/// refresh token expires the watch shows a "reconnect from your iPhone"
+/// state rather than re-authenticating itself.
+///
+/// This type is pure Foundation (no WatchConnectivity import) so the codec
+/// is exercised by `swift test` on any platform; the session plumbing that
+/// actually ships the dictionary lives in the app targets.
+public struct WatchHandoff: Sendable, Codable, Equatable {
+    public let configuration: Configuration
+    public let tokens: AuthTokens
+    public let username: String
+
+    public init(configuration: Configuration, tokens: AuthTokens, username: String) {
+        self.configuration = configuration
+        self.tokens = tokens
+        self.username = username
+    }
+}
+
+public extension WatchHandoff {
+    /// Keys inside the WCSession application-context dictionary. The version
+    /// gates decoding: a watch app older or newer than the phone app ignores
+    /// contexts it doesn't understand instead of mis-decoding them.
+    static let contextVersionKey = "cabalmail.handoff.version"
+    static let contextPayloadKey = "cabalmail.handoff.payload"
+    static let contextVersion = 1
+
+    /// Context announcing "signed out" — versioned but carrying no payload.
+    /// Pushed by the phone on sign-out so the watch drops its credentials.
+    static func signedOutContext() -> [String: Any] {
+        [contextVersionKey: contextVersion]
+    }
+
+    /// Application-context encoding of this hand-off. The payload rides as a
+    /// single JSON `Data` value because WCSession dictionaries are limited to
+    /// property-list types.
+    func applicationContext() throws -> [String: Any] {
+        [
+            Self.contextVersionKey: Self.contextVersion,
+            Self.contextPayloadKey: try JSONEncoder().encode(self),
+        ]
+    }
+
+    /// Decodes a received application context. Returns nil for a version
+    /// mismatch, a missing payload (the signed-out context), or a payload
+    /// that fails to decode — callers distinguish "signed out" from "not a
+    /// hand-off at all" with `isSignedOut(applicationContext:)`.
+    static func from(applicationContext context: [String: Any]) -> WatchHandoff? {
+        guard
+            context[contextVersionKey] as? Int == contextVersion,
+            let data = context[contextPayloadKey] as? Data
+        else {
+            return nil
+        }
+        return try? JSONDecoder().decode(WatchHandoff.self, from: data)
+    }
+
+    /// True when the context is a versioned hand-off that explicitly carries
+    /// no session — the phone's sign-out signal.
+    static func isSignedOut(applicationContext context: [String: Any]) -> Bool {
+        context[contextVersionKey] as? Int == contextVersion
+            && context[contextPayloadKey] == nil
+    }
+}

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/WatchHandoffTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/WatchHandoffTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import CabalmailKit
+
+final class WatchHandoffTests: XCTestCase {
+    private func makeConfiguration() -> Configuration {
+        Configuration(
+            controlDomain: "cabalmail.example",
+            domains: [MailDomain(domain: "cabalmail.example")],
+            invokeUrl: URL(string: "https://api.cabalmail.example/prod")!,
+            cognito: .init(region: "us-east-1", userPoolId: "us-east-1_ABC", clientId: "clientX")
+        )
+    }
+
+    private func makeTokens(expiresAt: Date = Date(timeIntervalSince1970: 2_000_000_000)) -> AuthTokens {
+        AuthTokens(
+            idToken: "ID-TOKEN",
+            accessToken: "ACCESS-TOKEN",
+            refreshToken: "REFRESH-TOKEN",
+            tokenType: "Bearer",
+            expiresAt: expiresAt
+        )
+    }
+
+    // MARK: - Application-context codec
+
+    func testApplicationContextRoundTrip() throws {
+        let handoff = WatchHandoff(
+            configuration: makeConfiguration(),
+            tokens: makeTokens(),
+            username: "alice"
+        )
+
+        let context = try handoff.applicationContext()
+        let decoded = WatchHandoff.from(applicationContext: context)
+
+        XCTAssertEqual(decoded, handoff)
+        XCTAssertFalse(WatchHandoff.isSignedOut(applicationContext: context))
+    }
+
+    func testVersionMismatchDecodesToNil() throws {
+        let handoff = WatchHandoff(
+            configuration: makeConfiguration(),
+            tokens: makeTokens(),
+            username: "alice"
+        )
+
+        var context = try handoff.applicationContext()
+        context[WatchHandoff.contextVersionKey] = WatchHandoff.contextVersion + 1
+
+        XCTAssertNil(WatchHandoff.from(applicationContext: context))
+        // A future version isn't this version's sign-out signal either.
+        XCTAssertFalse(WatchHandoff.isSignedOut(applicationContext: context))
+    }
+
+    func testGarbagePayloadDecodesToNil() {
+        let context: [String: Any] = [
+            WatchHandoff.contextVersionKey: WatchHandoff.contextVersion,
+            WatchHandoff.contextPayloadKey: Data("not json".utf8),
+        ]
+
+        XCTAssertNil(WatchHandoff.from(applicationContext: context))
+    }
+
+    func testSignedOutContext() {
+        let context = WatchHandoff.signedOutContext()
+
+        XCTAssertNil(WatchHandoff.from(applicationContext: context))
+        XCTAssertTrue(WatchHandoff.isSignedOut(applicationContext: context))
+        // An empty / foreign dictionary is not a sign-out signal.
+        XCTAssertFalse(WatchHandoff.isSignedOut(applicationContext: [:]))
+    }
+
+    // MARK: - Token adoption (the watch's receive path)
+
+    func testAdoptedTokensServeCurrentIdToken() async throws {
+        let http = RecordingHTTPTransport(responses: [])
+        let store = InMemorySecureStore()
+        let service = CognitoAuthService(
+            configuration: makeConfiguration(),
+            transport: http,
+            secureStore: store
+        )
+
+        try await service.adopt(tokens: makeTokens(), username: "alice")
+
+        // A fresh adopted token is returned as-is — no network traffic.
+        let token = try await service.currentIdToken()
+        XCTAssertEqual(token, "ID-TOKEN")
+        let requests = await http.requests
+        XCTAssertTrue(requests.isEmpty)
+    }
+
+    func testAdoptedExpiredTokensRefreshWithAdoptedRefreshToken() async throws {
+        let refreshed = """
+        {
+          "AuthenticationResult": {
+            "IdToken": "NEW-ID",
+            "AccessToken": "NEW-ACCESS",
+            "ExpiresIn": 3600,
+            "TokenType": "Bearer"
+          }
+        }
+        """
+        let http = RecordingHTTPTransport(responses: [(Data(refreshed.utf8), 200)])
+        let store = InMemorySecureStore()
+        let service = CognitoAuthService(
+            configuration: makeConfiguration(),
+            transport: http,
+            secureStore: store
+        )
+
+        // Adopt tokens that are already expired — the realistic hand-off
+        // case when the watch has been out of range for an hour.
+        try await service.adopt(
+            tokens: makeTokens(expiresAt: Date(timeIntervalSinceNow: -60)),
+            username: "alice"
+        )
+
+        let token = try await service.currentIdToken()
+
+        XCTAssertEqual(token, "NEW-ID")
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 1)
+        let body = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(body?["AuthFlow"] as? String, "REFRESH_TOKEN_AUTH")
+        let params = body?["AuthParameters"] as? [String: Any]
+        XCTAssertEqual(params?["REFRESH_TOKEN"] as? String, "REFRESH-TOKEN")
+    }
+
+    func testAdoptDoesNotInventImapCredentials() async throws {
+        let http = RecordingHTTPTransport(responses: [])
+        let store = InMemorySecureStore()
+        let service = CognitoAuthService(
+            configuration: makeConfiguration(),
+            transport: http,
+            secureStore: store
+        )
+
+        try await service.adopt(tokens: makeTokens(), username: "alice")
+
+        // The password never rides the hand-off, so the IMAP/SMTP credential
+        // pair must stay unavailable rather than surfacing a bogus one.
+        do {
+            _ = try await service.currentImapCredentials()
+            XCTFail("expected notSignedIn")
+        } catch let error as CabalmailError {
+            guard case .notSignedIn = error else {
+                XCTFail("expected notSignedIn, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/apple/CabalmailWatch/CabalmailWatchApp.swift
+++ b/apple/CabalmailWatch/CabalmailWatchApp.swift
@@ -7,9 +7,17 @@ import SwiftUI
 /// anywhere else. Mail reading and compose stay on the other platforms.
 @main
 struct CabalmailWatchApp: App {
+    @State private var model = WatchAppModel()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(model)
+                .task {
+                    // Arms the WCSession receiver and restores a previously
+                    // handed-off session. Idempotent across `.task` re-fires.
+                    model.start()
+                }
         }
     }
 }

--- a/apple/CabalmailWatch/ContentView.swift
+++ b/apple/CabalmailWatch/ContentView.swift
@@ -1,31 +1,91 @@
 import CabalmailKit
 import SwiftUI
 
-/// Placeholder root view for the target-scaffolding phase. The next phases
-/// replace this with the WatchConnectivity credential bootstrap and the
-/// address list / create / revoke screens.
+/// Root view: reconnect prompt, loading spinner, or the address list,
+/// depending on where the credential lifecycle stands (see WatchAppModel).
 struct ContentView: View {
-    /// Deliberate CabalmailKit reference: forces the package to link into
-    /// the watch binary, so this scaffold proves kit portability at link
-    /// time rather than only at typecheck time.
-    private static let kitLinkProbe = String(describing: Address.self)
+    @Environment(WatchAppModel.self) private var model
 
     var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Cabalmail")
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch model.phase {
+        case .waiting:
+            waiting
+        case .loading:
+            ProgressView()
+        case .ready(let addresses):
+            list(addresses)
+        case .failed(let message):
+            failed(message)
+        }
+    }
+
+    private var waiting: some View {
         VStack(spacing: 8) {
-            Image(systemName: "envelope.badge.shield.half.filled")
+            Image(systemName: "iphone.and.arrow.right.inward")
                 .font(.title3)
                 .foregroundStyle(.tint)
-            Text("Cabalmail")
-                .font(.headline)
-            Text("Address management is on its way.")
+            Text("Open Cabalmail on your iPhone to connect this watch.")
                 .font(.footnote)
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
         }
         .accessibilityElement(children: .combine)
     }
-}
 
-#Preview {
-    ContentView()
+    private func failed(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Text(message)
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button("Retry") {
+                Task { await model.refresh() }
+            }
+        }
+    }
+
+    private func list(_ addresses: [Address]) -> some View {
+        List {
+            if addresses.isEmpty {
+                Text("No addresses yet.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(addresses, id: \.address) { address in
+                row(address)
+            }
+        }
+        .refreshable {
+            await model.refresh()
+        }
+    }
+
+    private func row(_ address: Address) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                if address.favorite {
+                    Image(systemName: "star.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.yellow)
+                }
+                Text(address.address)
+                    .font(.footnote)
+                    .lineLimit(2)
+            }
+            if let comment = address.comment, !comment.isEmpty {
+                Text(comment)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
 }

--- a/apple/CabalmailWatch/WatchAppModel.swift
+++ b/apple/CabalmailWatch/WatchAppModel.swift
@@ -1,0 +1,176 @@
+import CabalmailKit
+import Foundation
+import WatchConnectivity
+
+/// Observable root for the watch app: owns the credential lifecycle and the
+/// address list.
+///
+/// Credentials arrive from the paired iPhone as a `WatchHandoff` in the
+/// WCSession application context (see WatchSessionBridge.swift on the phone
+/// side) — the two devices don't share a keychain, so the session has to be
+/// handed over. The watch persists the `Configuration` in UserDefaults and
+/// adopts the tokens into its own keychain via `CognitoAuthService.adopt`,
+/// after which it refreshes ID tokens autonomously for the refresh token's
+/// lifetime. When that expires (or the phone signs out) the app falls back
+/// to `.waiting`, which tells the user to open Cabalmail on their iPhone.
+@MainActor
+@Observable
+final class WatchAppModel {
+    enum Phase {
+        /// No credentials — ask the user to open the iPhone app.
+        case waiting
+        case loading
+        case ready([Address])
+        case failed(String)
+    }
+
+    private(set) var phase: Phase = .waiting
+
+    private let secureStore: any SecureStore
+    private let defaults: UserDefaults
+    private var apiClient: URLSessionApiClient?
+    /// Retains the WCSession delegate (the session holds it weakly).
+    private var sessionRelay: SessionRelay?
+
+    private static let configurationDefaultsKey = "cabalmail.watch.configuration"
+
+    init(secureStore: any SecureStore = KeychainSecureStore(), defaults: UserDefaults = .standard) {
+        self.secureStore = secureStore
+        self.defaults = defaults
+    }
+
+    /// Launch entry point: arm the WCSession receiver and try to restore a
+    /// previously handed-off session from local storage. Idempotent, so the
+    /// app's `.task` can call it across scene re-attaches.
+    func start() {
+        activateSessionIfPossible()
+        if apiClient == nil {
+            restoreFromStorage()
+        }
+    }
+
+    func refresh() async {
+        await loadAddresses()
+    }
+
+    // MARK: - Hand-off intake
+
+    func apply(_ handoff: WatchHandoff) {
+        guard let data = try? JSONEncoder().encode(handoff.configuration) else { return }
+        defaults.set(data, forKey: Self.configurationDefaultsKey)
+        let auth = CognitoAuthService(
+            configuration: handoff.configuration,
+            secureStore: secureStore
+        )
+        apiClient = URLSessionApiClient(
+            configuration: handoff.configuration,
+            authService: auth
+        )
+        Task {
+            do {
+                try await auth.adopt(tokens: handoff.tokens, username: handoff.username)
+                await loadAddresses()
+            } catch {
+                phase = .failed("Couldn't store the credentials from your iPhone.")
+            }
+        }
+    }
+
+    /// The phone signed out (or the session died): drop everything local.
+    func clear() {
+        try? secureStore.remove(SecureStoreKey.authTokens)
+        try? secureStore.remove(SecureStoreKey.imapUsername)
+        defaults.removeObject(forKey: Self.configurationDefaultsKey)
+        apiClient = nil
+        phase = .waiting
+    }
+
+    // MARK: - Internals
+
+    private func activateSessionIfPossible() {
+        guard WCSession.isSupported(), sessionRelay == nil else { return }
+        let relay = SessionRelay(model: self)
+        sessionRelay = relay
+        let session = WCSession.default
+        session.delegate = relay
+        session.activate()
+    }
+
+    private func restoreFromStorage() {
+        guard
+            let data = defaults.data(forKey: Self.configurationDefaultsKey),
+            let configuration = try? JSONDecoder().decode(Configuration.self, from: data),
+            ((try? secureStore.get(SecureStoreKey.authTokens)) ?? nil) != nil
+        else {
+            phase = .waiting
+            return
+        }
+        let auth = CognitoAuthService(configuration: configuration, secureStore: secureStore)
+        apiClient = URLSessionApiClient(configuration: configuration, authService: auth)
+        Task { await loadAddresses() }
+    }
+
+    private func loadAddresses() async {
+        guard let apiClient else { return }
+        phase = .loading
+        do {
+            let addresses = try await apiClient.listAddresses()
+            phase = .ready(addresses.sorted { lhs, rhs in
+                if lhs.favorite != rhs.favorite {
+                    return lhs.favorite
+                }
+                return lhs.address.localizedCaseInsensitiveCompare(rhs.address) == .orderedAscending
+            })
+        } catch let error as CabalmailError {
+            switch error {
+            case .authExpired, .invalidCredentials, .notSignedIn:
+                // The refresh token is gone — a stale session shouldn't keep
+                // failing quietly. Back to the reconnect prompt.
+                clear()
+            default:
+                phase = .failed("Couldn't load your addresses.")
+            }
+        } catch {
+            phase = .failed("Couldn't load your addresses.")
+        }
+    }
+}
+
+/// WCSession delegate. Split out of the model because WCSession requires an
+/// NSObject delegate and calls it on its own queue; the relay decodes the
+/// context off the main actor (`WatchHandoff` is Sendable, the raw context
+/// dictionary is not) and hops to the model with the typed result.
+private final class SessionRelay: NSObject, WCSessionDelegate {
+    private weak var model: WatchAppModel?
+
+    init(model: WatchAppModel) {
+        self.model = model
+    }
+
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith activationState: WCSessionActivationState,
+        error: (any Error)?
+    ) {
+        guard activationState == .activated else { return }
+        // A context pushed while this app was dead is waiting on the
+        // session rather than being redelivered through the delegate.
+        let context = session.receivedApplicationContext
+        guard !context.isEmpty else { return }
+        dispatch(context)
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext context: [String: Any]) {
+        dispatch(context)
+    }
+
+    private func dispatch(_ context: [String: Any]) {
+        if let handoff = WatchHandoff.from(applicationContext: context) {
+            Task { @MainActor [weak model] in model?.apply(handoff) }
+        } else if WatchHandoff.isSignedOut(applicationContext: context) {
+            Task { @MainActor [weak model] in model?.clear() }
+        }
+        // Unknown version → ignore. An out-of-step phone app shouldn't
+        // wipe a working watch session.
+    }
+}

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -187,6 +187,9 @@ targets:
       - path: Cabalmail/AppStateSignals.swift
       - path: Cabalmail/NavStateCoordinator.swift
       - path: Cabalmail/Pasteboard.swift
+      # Shared with AppState.swift: the no-op stub branch compiles here
+      # (WatchConnectivity is iOS-only). See WatchSessionBridge.swift.
+      - path: Cabalmail/WatchSessionBridge.swift
       - path: Cabalmail/Views
       - path: Cabalmail/ViewModels
     dependencies:


### PR DESCRIPTION
## Summary

Phase 3 of the watch companion app (Phase 1 = #631, Phase 2 = #632): the **credential bridge**. The iPhone and watch are separate devices with separate keychains, so the phone hands its signed-in session across WatchConnectivity; from then on the watch refreshes ID tokens autonomously for the refresh token's lifetime and loads the address list through the Lambda API.

### Kit
- **`WatchHandoff`** — versioned payload (`Configuration` + `AuthTokens` + username) with an application-context codec. Pure Foundation, so the codec is covered by `swift test`; a versioned no-payload context is the phone's sign-out signal, and unknown versions are ignored (an out-of-step phone can't wipe a working watch session).
- **`CognitoAuthService.adopt(tokens:username:)`** — installs externally obtained tokens. The user's **password never rides the hand-off**: `currentImapCredentials()` stays unavailable on the adopting device, and when the refresh token dies the watch falls back to a "reconnect from your iPhone" prompt rather than re-authenticating itself. (Transport is Apple's encrypted phone↔watch channel — the standard mechanism for this.)
- **7 new tests**: codec round-trip, version gating, garbage payload, sign-out signal, adopt-then-serve, adopt-expired-then-refresh (asserts the `REFRESH_TOKEN_AUTH` wire call), and no-invented-IMAP-credentials.

### Phone (Cabalmail target)
- **`WatchSessionBridge`** pushes the session via `WCSession.updateApplicationContext` (latest-state semantics — delivered whenever the watch next wakes, even if both apps were dead) on **sign-in**, **restore** (the common launch path, which keeps the watch fresh), and **sign-out** (drop signal). Real implementation on iOS; a no-op stub on visionOS/macOS keeps the `AppState` call-sites platform-conditional-free.
- `AppState`: `controlDomain`/`lastUsername` moved to an extension — the class body was sitting exactly at SwiftLint's 250-line `type_body_length` cap, and the three one-line bridge calls needed the headroom.

### Watch (CabalmailWatch target)
- **`WatchAppModel`** — arms the WCSession receiver (including the context parked on the session while the app was dead), persists `Configuration` in defaults, adopts tokens into the watch's own keychain, loads addresses. Auth-expiry → reconnect prompt; phone sign-out → wipe.
- **`ContentView`** — reconnect prompt / loading / address list (favorites first, star + comment) / retry-able error.

## Verification

- Kit tests: **313 pass** (+7 new; the 4 pre-existing `AcknowledgementsTests` vendored-license failures are unrelated).
- All four platforms build unsigned: **watchOS sim, iOS, visionOS, macOS** (visionOS proves the `canImport` stub branch; macOS proves the shared-`AppState` stub wiring).
- `swiftlint lint --strict`: clean.
- Watch app runs in the simulator showing the reconnect prompt (screenshot-verified).

**Not verified: the live hand-off.** That needs a signed-in iPhone paired with a watch (real devices, or paired sims with real credentials) — flagged for device testing when the target ships to TestFlight.

## Not user-facing

The watch app still isn't embedded in the iOS app, so nothing reaches testers; the phone-side push is inert without the watch app installed. Keeping the `no-changelog` opt-out — the `Apple:` fragment lands with the shipping PR.

## Next phases

4. Create / revoke screens (the hero: dictate a label → pick a subdomain → big copyable address).
5. Icon artwork, signing (`WATCHOS_APP_STORE_PROFILE_UUID`), embedding in the iOS app, TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)