### PR TITLE
Re-offer the watch session on foreground and watch-app install

### DIFF
--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -532,6 +532,17 @@ extension AppState {
             username: username
         )
     }
+
+    /// Re-offers the current session to the watch. Called on every return
+    /// to the foreground: the watch's "open Cabalmail on your iPhone"
+    /// instruction has to work when the app was *already running* — the
+    /// launch-time push has long since fired by then, and
+    /// `restoreIfPossible()` is deliberately a no-op while signed in, so
+    /// without this the instruction only worked after a cold start.
+    func refreshWatchSession() async {
+        guard let client else { return }
+        await pushSessionToWatch(client: client, username: lastUsername)
+    }
 }
 
 // MARK: - Message-menu selection intents

--- a/apple/Cabalmail/CabalmailApp.swift
+++ b/apple/Cabalmail/CabalmailApp.swift
@@ -11,6 +11,7 @@ import CabalmailKit
 struct CabalmailApp: App {
     @State private var appState = AppState()
     @State private var preferences = Preferences(store: UbiquitousPreferenceStore())
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
@@ -38,6 +39,14 @@ struct CabalmailApp: App {
                     if preferences.crashReportingEnabled {
                         appState.client?.setCrashReportingEnabled(true)
                     }
+                }
+                .onChange(of: scenePhase) { _, phase in
+                    // Re-offer the session to the watch on every return to
+                    // the foreground — see AppState.refreshWatchSession()
+                    // for why the launch-time push alone strands a watch
+                    // app installed while this app was already running.
+                    guard phase == .active else { return }
+                    Task { await appState.refreshWatchSession() }
                 }
                 .onOpenURL { url in
                     // Cold-launch mailto: arrives here before any view

--- a/apple/Cabalmail/WatchSessionBridge.swift
+++ b/apple/Cabalmail/WatchSessionBridge.swift
@@ -24,10 +24,14 @@ import WatchConnectivity
 final class WatchSessionBridge: NSObject, WCSessionDelegate, @unchecked Sendable {
     static let shared = WatchSessionBridge()
 
-    /// Context waiting for session activation to complete. Guarded by
-    /// `lock` — delegate callbacks arrive on WatchConnectivity's own queue.
+    /// Guarded by `lock` — delegate callbacks arrive on WatchConnectivity's
+    /// own queue. `pendingContext` waits for session activation to complete;
+    /// `lastContext` is re-offered when the watch state changes (e.g. the
+    /// watch app was just installed), so a watch that arrives after the
+    /// phone's launch-time push doesn't sit waiting for the next cold start.
     private let lock = NSLock()
     private var pendingContext: [String: Any]?
+    private var lastContext: [String: Any]?
 
     func pushSession(configuration: Configuration, tokens: AuthTokens, username: String) {
         let handoff = WatchHandoff(
@@ -51,10 +55,14 @@ final class WatchSessionBridge: NSObject, WCSessionDelegate, @unchecked Sendable
             session.delegate = self
         }
         if session.activationState == .activated {
+            lock.lock()
+            lastContext = context
+            lock.unlock()
             try? session.updateApplicationContext(context)
         } else {
             lock.lock()
             pendingContext = context
+            lastContext = context
             lock.unlock()
             session.activate()
         }
@@ -78,6 +86,22 @@ final class WatchSessionBridge: NSObject, WCSessionDelegate, @unchecked Sendable
     }
 
     func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        // Fires when pairing / watch-app-install state changes. The case
+        // that matters: the watch app was just installed while this app was
+        // already running, so the launch-time push predates the watch's
+        // existence. Re-offer the current session immediately rather than
+        // leaving the watch on its "open Cabalmail on your iPhone" screen
+        // until the phone's next cold start.
+        guard session.activationState == .activated else { return }
+        lock.lock()
+        let context = lastContext
+        lock.unlock()
+        if let context {
+            try? session.updateApplicationContext(context)
+        }
+    }
 
     func sessionDidDeactivate(_ session: WCSession) {
         // Apple's contract for the user switching to a different paired


### PR DESCRIPTION
## Summary

Fixes the first-run trap found in on-device testing of #635: the watch stuck on "Open Cabalmail on your iPhone" **because the phone app was already open**.

**Root cause**: the phone pushed the session only at sign-in and cold-launch restore (`restoreIfPossible` is deliberately a no-op while signed in). A watch app installed while the phone app was already running — the normal first-install sequence — got nothing until the phone's next cold start. The waiting screen's instruction ("open Cabalmail on your iPhone") couldn't work, because foregrounding an already-running app pushed nothing.

**Two complementary phone-side fixes:**

1. **Foreground re-offer** — `CabalmailApp` observes `scenePhase` and calls the new `AppState.refreshWatchSession()` on every return to `.active`. The on-screen instruction is now honest: opening the phone app, running or not, re-offers the session.
2. **Install-time re-offer** — `WatchSessionBridge` keeps the last-pushed context and re-sends it from `sessionWatchStateDidChange`, which fires the moment the watch app is installed. That covers the first-install case with **no user action at all** (when the phone app is running).

Re-pushing identical content is safe: `updateApplicationContext` is latest-state and the system drops unchanged dictionaries.

## Verification

- iOS / visionOS / macOS builds green (the non-iOS stub keeps shared call-sites compiling); `swiftlint --strict` clean.
- The fixed flow itself needs the next TestFlight build: install the watch app fresh (or reboot the watch to clear state) while the phone app is foregrounded — it should connect without relaunching anything.

## Changelog

`no-changelog`: this corrects pre-release behavior of the watch app, whose `Apple:` fragment (added in #635) is still pending release and already describes the fixed end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)