### PR TITLE
Watch: tap an address to show it in large type

### DIFF
--- a/apple/CabalmailWatch/AddressDetailView.swift
+++ b/apple/CabalmailWatch/AddressDetailView.swift
@@ -1,0 +1,32 @@
+import CabalmailKit
+import SwiftUI
+
+/// Large-type display of one address — the "show your wrist" view.
+///
+/// Tapping a list row lands here so the address can be read out (or shown
+/// to someone) without squinting at a two-line row. watchOS has no
+/// pasteboard, so large and legible IS the hand-off — same rationale as
+/// the new-address success screen.
+struct AddressDetailView: View {
+    let address: Address
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                if let comment = address.comment, !comment.isEmpty {
+                    Text(comment)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text(address.address)
+                    .font(.system(.title3, design: .monospaced, weight: .semibold))
+                if address.favorite {
+                    Label("Favorite", systemImage: "star.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.yellow)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/apple/CabalmailWatch/ContentView.swift
+++ b/apple/CabalmailWatch/ContentView.swift
@@ -9,9 +9,11 @@ struct ContentView: View {
     /// Row awaiting revoke confirmation (drives the dialog).
     @State private var pendingRevoke: Address?
 
-    /// Screenshot scaffolding: pushes the new-address flow on launch when
-    /// the CABAL_WATCH_PREVIEW=new seed is active (see WatchAppModel).
+    /// Screenshot scaffolding: pushes the new-address flow (or the first
+    /// address's large-type detail) on launch when the matching
+    /// CABAL_WATCH_PREVIEW seed is active (see WatchAppModel).
     @State private var autoPushNewAddress = false
+    @State private var autoPushDetail = false
 
     var body: some View {
         NavigationStack {
@@ -20,9 +22,15 @@ struct ContentView: View {
                 .navigationDestination(isPresented: $autoPushNewAddress) {
                     NewAddressView()
                 }
+                .navigationDestination(isPresented: $autoPushDetail) {
+                    if case .ready(let addresses) = model.phase, let first = addresses.first {
+                        AddressDetailView(address: first)
+                    }
+                }
                 .onAppear {
                     #if DEBUG
                     autoPushNewAddress = model.previewAutoPushNewAddress
+                    autoPushDetail = model.previewAutoPushDetail
                     #endif
                 }
         }
@@ -121,22 +129,28 @@ struct ContentView: View {
     }
 
     private func row(_ address: Address) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 4) {
-                if address.favorite {
-                    Image(systemName: "star.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.yellow)
+        // Tap → large-type display (AddressDetailView); the trailing
+        // swipe action for revoke coexists with the link.
+        NavigationLink {
+            AddressDetailView(address: address)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    if address.favorite {
+                        Image(systemName: "star.fill")
+                            .font(.caption2)
+                            .foregroundStyle(.yellow)
+                    }
+                    Text(address.address)
+                        .font(.footnote)
+                        .lineLimit(2)
                 }
-                Text(address.address)
-                    .font(.footnote)
-                    .lineLimit(2)
-            }
-            if let comment = address.comment, !comment.isEmpty {
-                Text(comment)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                if let comment = address.comment, !comment.isEmpty {
+                    Text(comment)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
         }
     }

--- a/apple/CabalmailWatch/WatchAppModel.swift
+++ b/apple/CabalmailWatch/WatchAppModel.swift
@@ -207,9 +207,13 @@ extension WatchAppModel {
         )
     }
 
+    var previewAutoPushDetail: Bool {
+        ProcessInfo.processInfo.environment["CABAL_WATCH_PREVIEW"] == "detail"
+    }
+
     fileprivate func seedPreviewStateIfRequested() -> Bool {
         guard let mode = ProcessInfo.processInfo.environment["CABAL_WATCH_PREVIEW"],
-              ["list", "new", "created"].contains(mode) else {
+              ["list", "new", "created", "detail"].contains(mode) else {
             return false
         }
         configuration = Configuration(

--- a/changelog.d/apple-watch-app.added.md
+++ b/changelog.d/apple-watch-app.added.md
@@ -1,6 +1,7 @@
 - Apple: **Apple Watch app.** Mint, list, and revoke relationship-scoped
   addresses from the wrist. Dictate a label, pick a mail domain, and the
-  minted address appears big enough to read aloud; a burned address is a
-  swipe (plus a confirmation) away from gone. The watch receives its
-  session from the paired iPhone automatically — open Cabalmail on the
-  phone once and the watch signs itself in, no wrist typing.
+  minted address appears big enough to read aloud; tapping any address in
+  the list shows it in the same large type; a burned address is a swipe
+  (plus a confirmation) away from gone. The watch receives its session
+  from the paired iPhone automatically — open Cabalmail on the phone once
+  and the watch signs itself in, no wrist typing.


### PR DESCRIPTION
## Summary

Feature request from device testing: **tapping an address in the watch list now shows it in large type** — the "show your wrist" view. Comment as a small secondary header, the address in semibold monospaced `title3` wrapping across lines, favorite badge below. Same rationale as the new-address success screen: watchOS has no pasteboard, so large and legible *is* how an address gets handed to someone.

- `AddressDetailView` (new): the large-type display.
- `ContentView`: rows become `NavigationLink`s — the trailing revoke swipe coexists; list appearance is unchanged (screenshot-diffed).
- `WatchAppModel`: `detail` joins the DEBUG `CABAL_WATCH_PREVIEW` screenshot seed.
- Pending `Apple:` changelog fragment gains the tap-for-large-type clause (the watch app hasn't released yet, so the feature folds into its story).

## Verification

- Watch simulator build clean; `swiftlint --strict` clean.
- Screenshot-verified: detail view typography (46mm — address wraps to two lines at title3 monospaced) and the visually-unchanged list.

Branched directly off stage — independent of #636 (the hand-off re-offer fix), which remains open; the two touch disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)