### PR TITLE
Watch: bump the large-type address to largeTitle

### DIFF
--- a/apple/CabalmailWatch/AddressDetailView.swift
+++ b/apple/CabalmailWatch/AddressDetailView.swift
@@ -19,7 +19,12 @@ struct AddressDetailView: View {
                         .foregroundStyle(.secondary)
                 }
                 Text(address.address)
-                    .font(.system(.title3, design: .monospaced, weight: .semibold))
+                    // largeTitle (~32pt on watchOS) over the original
+                    // title3 (~19pt): device testing found title3 not big
+                    // enough to comfortably show across a counter. Long
+                    // addresses wrap to more lines and scroll — the right
+                    // trade for a display meant to be read at arm's length.
+                    .font(.system(.largeTitle, design: .monospaced, weight: .semibold))
                 if address.favorite {
                     Label("Favorite", systemImage: "star.fill")
                         .font(.caption2)

--- a/apple/CabalmailWatch/AddressDetailView.swift
+++ b/apple/CabalmailWatch/AddressDetailView.swift
@@ -18,13 +18,7 @@ struct AddressDetailView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
-                Text(address.address)
-                    // largeTitle (~32pt on watchOS) over the original
-                    // title3 (~19pt): device testing found title3 not big
-                    // enough to comfortably show across a counter. Long
-                    // addresses wrap to more lines and scroll — the right
-                    // trade for a display meant to be read at arm's length.
-                    .font(.system(.largeTitle, design: .monospaced, weight: .semibold))
+                LargeTypeAddress(address: address.address)
                 if address.favorite {
                     Label("Favorite", systemImage: "star.fill")
                         .font(.caption2)
@@ -33,5 +27,22 @@ struct AddressDetailView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+}
+
+/// The shared large-type address treatment, used wherever an address is
+/// shown across a counter: this detail view and the new-address success
+/// screen. largeTitle (~32pt on watchOS) over the earlier title3 (~19pt) —
+/// device testing found title3 not big enough to read at arm's length.
+/// Long addresses wrap to more lines and scroll; the right trade for a
+/// display whose whole job is legibility.
+struct LargeTypeAddress: View {
+    let address: String
+
+    var body: some View {
+        Text(address)
+            .font(.system(.largeTitle, design: .monospaced, weight: .semibold))
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/apple/CabalmailWatch/NewAddressView.swift
+++ b/apple/CabalmailWatch/NewAddressView.swift
@@ -113,15 +113,16 @@ struct NewAddressView: View {
 
     private func success(_ address: String) -> some View {
         ScrollView {
-            VStack(spacing: 8) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.title3)
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Created", systemImage: "checkmark.circle.fill")
+                    .font(.caption2)
                     .foregroundStyle(.green)
-                Text(address)
-                    .font(.system(.footnote, design: .monospaced))
-                    .multilineTextAlignment(.center)
+                // Same treatment as the tap-a-row detail view: this screen
+                // is shown across the same counters.
+                LargeTypeAddress(address: address)
                 Button("Done") { dismiss() }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 


### PR DESCRIPTION
## Summary

Device-testing feedback on #637: the large-type address display should be **at least 50% larger** — and the new-address success screen should get the same treatment (same show-across-the-counter use case).

- `title3` (~19pt) → **`largeTitle` monospaced (~32pt)**, roughly +65%. About eight characters per line on a 46mm; longer addresses wrap and scroll — the right trade for a screen whose whole job is legibility.
- The treatment is extracted into a shared `LargeTypeAddress` view used by **both** the tap-a-row detail view and the new-address success screen, so the two can't drift. The success screen also adopts the detail view's layout language: small leading header ("Created", green) above the large address, Done below.

## Verification

Watch sim build + `swiftlint --strict` clean; both screens screenshot-verified at the new size via the `CABAL_WATCH_PREVIEW` seeds (`detail` and `created`).

`no-changelog`: pre-release refinement of the pending watch-app fragment, which already reads "big enough to read aloud" — now more true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)