### PR TITLE
Match the macOS Create Address form to the iOS layout

### DIFF
--- a/apple/Cabalmail/Views/NewAddressSheet.swift
+++ b/apple/Cabalmail/Views/NewAddressSheet.swift
@@ -34,79 +34,147 @@ struct NewAddressSheet: View {
 
     var body: some View {
         NavigationStack {
-            Form {
-                Section("New address") {
-                    HStack {
-                        TextField("username", text: $username)
-                            .autocorrectionDisabled()
-                            #if os(iOS) || os(visionOS)
-                            .textInputAutocapitalization(.never)
-                            #endif
-                        Text("@")
-                            .foregroundStyle(.secondary)
-                        TextField("subdomain", text: $subdomain)
-                            .autocorrectionDisabled()
-                            #if os(iOS) || os(visionOS)
-                            .textInputAutocapitalization(.never)
-                            #endif
-                        Text(".")
-                            .foregroundStyle(.secondary)
-                        Picker("", selection: $domain) {
-                            Text("domain").tag("")
-                            ForEach(domains) { entry in
-                                Text(entry.domain).tag(entry.domain)
+            content
+                .navigationTitle("Create Address")
+                #if os(iOS) || os(visionOS)
+                .navigationBarTitleDisplayMode(.inline)
+                #endif
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button {
+                            Task { await submit() }
+                        } label: {
+                            if isSubmitting {
+                                ProgressView()
+                            } else {
+                                Text("Create")
                             }
                         }
-                        .labelsHidden()
-                    }
-                    if let preview = composedAddress {
-                        Text(preview)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
+                        .disabled(!canSubmit || isSubmitting)
                     }
                 }
-                Section("Comment") {
-                    TextField("optional reminder", text: $comment)
-                        .autocorrectionDisabled()
-                }
-                if let errorMessage {
-                    Section {
-                        Label(errorMessage, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
+                .onAppear {
+                    if domain.isEmpty, let first = domains.first?.domain {
+                        domain = first
                     }
                 }
+        }
+    }
+
+    // MARK: - Platform layouts
+    //
+    // `Form` is kept for iOS/visionOS, where its grouped list style renders
+    // the field titles as in-field placeholders and section headers as tidy
+    // group captions. On macOS that same `Form` instead pins every title as
+    // an external left-hand label — which shatters the email-shaped row and
+    // drops the in-field placeholders — so macOS gets a hand-built layout
+    // that reproduces the iOS look: in-field placeholders, an `@`/`.`
+    // email-shaped row, headline section captions, and real content margins.
+
+    @ViewBuilder
+    private var content: some View {
+        #if os(macOS)
+        macContent
+        #else
+        formContent
+        #endif
+    }
+
+    #if os(macOS)
+    private var macContent: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("New address")
+                    .font(.headline)
+                addressRow
+                    .textFieldStyle(.roundedBorder)
+                if let preview = composedAddress {
+                    Text(preview)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Comment")
+                    .font(.headline)
+                TextField("optional reminder", text: $comment)
+                    .autocorrectionDisabled()
+                    .textFieldStyle(.roundedBorder)
+            }
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+            }
+            HStack {
+                Button("Random", action: randomize)
+                    .disabled(domains.isEmpty)
+                Spacer()
+            }
+        }
+        .padding(24)
+        .frame(width: 460, alignment: .leading)
+    }
+    #else
+    private var formContent: some View {
+        Form {
+            Section("New address") {
+                addressRow
+                if let preview = composedAddress {
+                    Text(preview)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            Section("Comment") {
+                TextField("optional reminder", text: $comment)
+                    .autocorrectionDisabled()
+            }
+            if let errorMessage {
                 Section {
-                    Button("Random", action: randomize)
-                        .disabled(domains.isEmpty)
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
                 }
             }
-            .navigationTitle("Create Address")
-            #if os(iOS) || os(visionOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button {
-                        Task { await submit() }
-                    } label: {
-                        if isSubmitting {
-                            ProgressView()
-                        } else {
-                            Text("Create")
-                        }
-                    }
-                    .disabled(!canSubmit || isSubmitting)
+            Section {
+                Button("Random", action: randomize)
+                    .disabled(domains.isEmpty)
+            }
+        }
+    }
+    #endif
+
+    /// The email-shaped input row shared by both layouts: `username @
+    /// subdomain . domain`, with the domain drawn from the deployment's
+    /// configured mail domains.
+    @ViewBuilder
+    private var addressRow: some View {
+        HStack {
+            TextField("username", text: $username)
+                .autocorrectionDisabled()
+                #if os(iOS) || os(visionOS)
+                .textInputAutocapitalization(.never)
+                #endif
+            Text("@")
+                .foregroundStyle(.secondary)
+            TextField("subdomain", text: $subdomain)
+                .autocorrectionDisabled()
+                #if os(iOS) || os(visionOS)
+                .textInputAutocapitalization(.never)
+                #endif
+            Text(".")
+                .foregroundStyle(.secondary)
+            Picker("", selection: $domain) {
+                Text("domain").tag("")
+                ForEach(domains) { entry in
+                    Text(entry.domain).tag(entry.domain)
                 }
             }
-            .onAppear {
-                if domain.isEmpty, let first = domains.first?.domain {
-                    domain = first
-                }
-            }
+            .labelsHidden()
         }
     }
 

--- a/changelog.d/mac-create-address-layout.fixed.md
+++ b/changelog.d/mac-create-address-layout.fixed.md
@@ -1,4 +1,4 @@
-- **Create Address sheet on macOS.** The compose "Create Address" form now
+- Apple: **Create Address sheet on macOS.** The compose "Create Address" form now
   matches the iOS/iPadOS layout — in-field placeholders, an email-shaped
   `username @ subdomain . domain` row, headline section captions, and proper
   content margins — instead of `Form`'s macOS default, which pinned each

--- a/changelog.d/mac-create-address-layout.fixed.md
+++ b/changelog.d/mac-create-address-layout.fixed.md
@@ -1,0 +1,5 @@
+- **Create Address sheet on macOS.** The compose "Create Address" form now
+  matches the iOS/iPadOS layout — in-field placeholders, an email-shaped
+  `username @ subdomain . domain` row, headline section captions, and proper
+  content margins — instead of `Form`'s macOS default, which pinned each
+  field title as an external label and broke up the address components.


### PR DESCRIPTION
## Problem

On macOS the compose **Create Address** sheet looked hand-assembled: the field titles (`username`, `subdomain`, `optional reminder`) rendered as external left-hand labels, breaking up the `username @ subdomain . domain` email shape, and the sheet had no content margin. On iOS/iPadOS the same view looks right.

Root cause is a SwiftUI `Form` platform divergence — a `TextField`'s title becomes an in-field placeholder on iOS but an external label on macOS, and section headers collapse into leading labels.

## Change

- Keep `Form` for iOS/visionOS (unchanged — it already looks right there).
- Give macOS a purpose-built layout that reproduces the iOS look: in-field placeholders, the email-shaped `username @ subdomain . domain` row, headline section captions, rounded-border text fields, real padding, and a fixed width.
- Factor the email-shaped input row into a shared `addressRow` so the two platform paths can't drift.

## Verification

- `scripts/build-apple.sh macos` — Build Succeeded.
- `scripts/build-apple.sh lint` — swiftlint `--strict` clean.

Visual confirmation is best done on the stage build / on-device, since the sheet is only reachable after login from the compose From picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)