### PR TITLE
Wrap large-type addresses without inserting hyphens

### DIFF
--- a/apple/CabalmailWatch/AddressDetailView.swift
+++ b/apple/CabalmailWatch/AddressDetailView.swift
@@ -40,9 +40,19 @@ struct LargeTypeAddress: View {
     let address: String
 
     var body: some View {
-        Text(address)
+        Text(wrappableAddress)
             .font(.system(.largeTitle, design: .monospaced, weight: .semibold))
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel(address)
+    }
+
+    /// The address with a zero-width space after every character, so the
+    /// layout engine can wrap at any point instead of hyphenating a long
+    /// unbreakable token. A soft hyphen at a wrap point is ambiguous —
+    /// addresses can contain real hyphens — so every visible character
+    /// must be one the reader should type.
+    private var wrappableAddress: String {
+        String(address.flatMap { [$0, "\u{200B}"] }.dropLast())
     }
 }

--- a/changelog.d/watch-large-type-no-hyphens.fixed.md
+++ b/changelog.d/watch-large-type-no-hyphens.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **No more inserted hyphens in the watch's large-type address view.**
+  When a long address wrapped, the layout engine broke it mid-token and
+  inserted a soft hyphen — ambiguous, since an address can contain a real
+  hyphen. The address now wraps at any character with nothing inserted, so
+  every visible character is one the reader should type.


### PR DESCRIPTION
## Summary

In the watch's large-type address view (`LargeTypeAddress`, used by the address detail screen and the new-address success screen), a long address is one unbreakable token, so when it wraps the layout engine breaks it mid-token and inserts a soft hyphen. That's ambiguous: an address can contain a real hyphen, and a reader at arm's length can't tell a wrap artifact from a character they should type.

SwiftUI has no hyphenation switch, so instead the address is rendered with a zero-width space (U+200B) interleaved after every character. Every position becomes a legal wrap point, and a break at a zero-width space inserts nothing — every visible character is real. The raw address is kept as the accessibility label so VoiceOver reads the actual string.

## Testing

- `swiftlint` clean on the changed file
- `xcodebuild -scheme CabalmailWatch -destination 'generic/platform=watchOS'` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)