### PR TITLE
Push notifications: APNs pipeline end-to-end (phases 1-4)

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -621,7 +621,9 @@ jobs:
         aws-region: ${{ secrets.AWS_REGION }}
 
     - name: pylint
-      run: pip install pylint && cd ./lambda/api && pylint --rcfile .pylintrc _shared/*.py */function.py
+      # push_dispatch/apns.py is the one handler-sibling module shipped in a
+      # zip; the */function.py glob misses it, so name it explicitly.
+      run: pip install pylint && cd ./lambda/api && pylint --rcfile .pylintrc _shared/*.py */function.py push_dispatch/apns.py
 
     - name: build
       env:

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -289,6 +289,7 @@ jobs:
           S6: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           S7: ${{ secrets.IOS_APP_STORE_PROFILE }}
           S8: ${{ secrets.WATCHOS_APP_STORE_PROFILE }}
+          S9: ${{ secrets.IOS_NSE_APP_STORE_PROFILE }}
           PLATFORM: ${{ matrix.platform }}
         run: |
           MISSING=()
@@ -299,10 +300,12 @@ jobs:
           [ -z "$S5" ] && MISSING+=("APP_STORE_CONNECT_API_ISSUER_ID")
           [ -z "$S6" ] && MISSING+=("APP_STORE_CONNECT_API_KEY_P8")
           [ -z "$S7" ] && MISSING+=("IOS_APP_STORE_PROFILE")
-          # The iOS archive embeds the watch app, so it also needs the watch
-          # profile. The visionOS leg does not (the embed dependency is
-          # destination-filtered to iOS in project.yml).
+          # The iOS archive embeds the watch app and the Notification
+          # Service Extension, so it also needs their profiles. The visionOS
+          # leg does not (both embed dependencies are destination-filtered
+          # to iOS in project.yml).
           [ "$PLATFORM" = "iOS" ] && [ -z "$S8" ] && MISSING+=("WATCHOS_APP_STORE_PROFILE")
+          [ "$PLATFORM" = "iOS" ] && [ -z "$S9" ] && MISSING+=("IOS_NSE_APP_STORE_PROFILE")
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "::warning::Apple signing secrets missing: ${MISSING[*]}. Skipping upload."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -402,6 +405,16 @@ jobs:
           extension: mobileprovision
           env-name: WATCHOS_APP_STORE_PROFILE_UUID
 
+      - name: Install NSE App Store provisioning profile
+        # iOS leg only: the Notification Service Extension embed is
+        # destination-filtered to iOS in project.yml, same as the watch app.
+        if: steps.check.outputs.enabled == 'true' && matrix.platform == 'iOS'
+        uses: ./.github/actions/install-provisioning-profile
+        with:
+          base64: ${{ secrets.IOS_NSE_APP_STORE_PROFILE }}
+          extension: mobileprovision
+          env-name: IOS_NSE_APP_STORE_PROFILE_UUID
+
       - name: Archive Cabalmail
         if: steps.check.outputs.enabled == 'true'
         working-directory: apple
@@ -461,6 +474,7 @@ jobs:
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             IOS_APP_STORE_PROFILE_UUID="$IOS_APP_STORE_PROFILE_UUID" \
             WATCHOS_APP_STORE_PROFILE_UUID="${WATCHOS_APP_STORE_PROFILE_UUID:-}" \
+            IOS_NSE_APP_STORE_PROFILE_UUID="${IOS_NSE_APP_STORE_PROFILE_UUID:-}" \
             MARKETING_VERSION="$MARKETING_VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             | xcbeautify --renderer github-actions
@@ -482,6 +496,11 @@ jobs:
           WATCH_PROFILE_ENTRY=""
           if [ -n "${WATCHOS_APP_STORE_PROFILE_UUID:-}" ]; then
             WATCH_PROFILE_ENTRY="<key>com.cabalmail.Cabalmail.watchkitapp</key><string>$WATCHOS_APP_STORE_PROFILE_UUID</string>"
+          fi
+          # Same shape for the embedded Notification Service Extension.
+          NSE_PROFILE_ENTRY=""
+          if [ -n "${IOS_NSE_APP_STORE_PROFILE_UUID:-}" ]; then
+            NSE_PROFILE_ENTRY="<key>com.cabalmail.Cabalmail.NotificationService</key><string>$IOS_NSE_APP_STORE_PROFILE_UUID</string>"
           fi
           cat > "$PLIST" <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
@@ -505,6 +524,7 @@ jobs:
                   <key>com.cabalmail.Cabalmail</key>
                   <string>$IOS_APP_STORE_PROFILE_UUID</string>
                   $WATCH_PROFILE_ENTRY
+                  $NSE_PROFILE_ENTRY
               </dict>
           </dict>
           </plist>

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -300,12 +300,20 @@ jobs:
           [ -z "$S5" ] && MISSING+=("APP_STORE_CONNECT_API_ISSUER_ID")
           [ -z "$S6" ] && MISSING+=("APP_STORE_CONNECT_API_KEY_P8")
           [ -z "$S7" ] && MISSING+=("IOS_APP_STORE_PROFILE")
-          # The iOS archive embeds the watch app and the Notification
-          # Service Extension, so it also needs their profiles. The visionOS
-          # leg does not (both embed dependencies are destination-filtered
-          # to iOS in project.yml).
+          # The iOS archive embeds the watch app, so it also needs the watch
+          # profile. The visionOS leg does not (the embed dependency is
+          # destination-filtered to iOS in project.yml).
           [ "$PLATFORM" = "iOS" ] && [ -z "$S8" ] && MISSING+=("WATCHOS_APP_STORE_PROFILE")
-          [ "$PLATFORM" = "iOS" ] && [ -z "$S9" ] && MISSING+=("IOS_NSE_APP_STORE_PROFILE")
+          # The NSE profile gates BOTH legs even though only the iOS archive
+          # embeds the extension: the push entitlements (aps-environment,
+          # app group, keychain sharing) live on the shared Cabalmail target,
+          # so every leg's archive needs profiles regenerated with the new
+          # capabilities. The operator does that portal work in one sitting
+          # with the NSE App ID/profile creation, making this secret the
+          # "push signing assets are ready" sentinel — until it exists, both
+          # legs skip cleanly instead of failing codesign against stale
+          # profiles.
+          [ -z "$S9" ] && MISSING+=("IOS_NSE_APP_STORE_PROFILE")
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "::warning::Apple signing secrets missing: ${MISSING[*]}. Skipping upload."
             echo "enabled=false" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Versioned subdirectories of `docs/` (e.g. `docs/0.4.0/`, `docs/0.7.0/`, `docs/0.
 - Watch mode: `cd react/admin && npm run test:watch`
 
 ### Lambda Functions (`lambda/api`)
-- Lint all: `cd lambda/api && pylint --rcfile .pylintrc _shared/*.py */function.py` (covers the shared modules and every handler)
+- Lint all: `cd lambda/api && pylint --rcfile .pylintrc _shared/*.py */function.py push_dispatch/apns.py` (covers the shared modules, every handler, and the one handler-sibling module the `*/function.py` glob misses)
 - Local test: `cd lambda/api/[function_dir] && python -m function`
 
 ### Apple Clients (`apple/`)
@@ -229,7 +229,9 @@ Shared infrastructure:
   - Use locals for repeated values or complex expressions
 
 - **Docker/Shell**:
-  - `set -euo pipefail` in all scripts
+  - `set -euo pipefail` in all scripts (a best-effort delivery-path side
+    effect may drop `-e` with an in-file comment justifying it and explicit
+    handling on every failure path; see docker/shared/push-enqueue.sh)
   - Structured logging with `[component]` prefixes
   - Environment variable validation at script entry
   - Comments explaining non-obvious configuration choices

--- a/apple/.gitignore
+++ b/apple/.gitignore
@@ -3,6 +3,7 @@ Cabalmail.xcodeproj/
 Cabalmail/Info.plist
 CabalmailMac/Info.plist
 CabalmailWatch/Info.plist
+CabalmailNotificationService/Info.plist
 
 # Local per-developer overrides (team ID, etc.). Never commit.
 Local.xcconfig

--- a/apple/Cabalmail/AppDelegate.swift
+++ b/apple/Cabalmail/AppDelegate.swift
@@ -1,0 +1,70 @@
+#if os(iOS)
+import UIKit
+import UserNotifications
+import CabalmailKit
+
+/// UIKit app delegate for the iOS target, installed via
+/// `@UIApplicationDelegateAdaptor` in `CabalmailApp`. Exists solely for the
+/// push-notification surface — APNs token callbacks land here (there is no
+/// SwiftUI-native equivalent), and the `UNUserNotificationCenter` delegate
+/// must be wired before `didFinishLaunching` returns so a notification that
+/// launched the app is delivered. Everything else stays in SwiftUI land.
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        PushRegistrar.registerNotificationCategories()
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let tokenHex = deviceToken.map { String(format: "%02x", $0) }.joined()
+        PushRegistrar.shared.deviceTokenDidChange(tokenHex)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        // Simulator / entitlement-less builds land here on every launch;
+        // real devices only on APNs connectivity trouble. Either way the
+        // app works fine without push, so log and move on.
+        CabalmailLog.warn("Push", "remote-notification registration failed: \(error)")
+    }
+}
+
+// The UN delegate methods are called on an arbitrary queue, and the
+// protocol declares them nonisolated — without the explicit `nonisolated`
+// they'd inherit the class's UIApplicationDelegate-inferred @MainActor
+// isolation and trip strict concurrency (non-Sendable UN* parameters can't
+// cross into an isolated witness). Sendable values are extracted up front;
+// only those hop to the main actor.
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    /// Foreground delivery: the IDLE-driven UI already shows the new
+    /// message, so a banner would double-notify — play the sound only.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.sound]
+    }
+
+    /// Action dispatch (lock-screen buttons and the default tap). The async
+    /// variant's return *is* the completion handler, so returning only after
+    /// `handleNotificationAction` resolves keeps the system's background
+    /// budget honest for MARK_READ / ARCHIVE.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let identifier = response.actionIdentifier
+        let ref = PushMessageRef(userInfo: response.notification.request.content.userInfo)
+        await PushRegistrar.shared.handleNotificationAction(identifier: identifier, ref: ref)
+    }
+}
+#endif

--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -269,10 +269,10 @@ final class AppState {
         status = .signingIn
         do {
             let configuration = try await ConfigLoader.load(controlDomain: controlDomain)
-            let cacheDirectory = try makeCacheDirectory()
+            let cacheDirectory = try Self.makeCacheDirectory()
             let newClient = try CabalmailClient.make(
                 configuration: configuration,
-                secureStore: KeychainSecureStore(),
+                secureStore: Self.makeSecureStore(),
                 cacheDirectory: cacheDirectory
             )
             try await newClient.authService.signIn(username: username, password: password)
@@ -285,12 +285,7 @@ final class AppState {
             }
             self.controlDomain = controlDomain
             self.lastUsername = username
-            self.client = newClient
-            self.navCoordinator = NavStateCoordinator(client: newClient)
-            self.status = .signedIn
-            startInboxBadgePolling()
-            requestContactsAccessIfNeeded()
-            await pushSessionToWatch(client: newClient, username: username)
+            await wireSession(client: newClient, username: username)
         } catch let error as CabalmailError {
             status = .error(message(for: error))
         } catch {
@@ -301,6 +296,12 @@ final class AppState {
     func signOut() async {
         stopInboxBadgePolling()
         guard let client else { status = .signedOut; return }
+        #if os(iOS)
+        // Deregister the APNs token while the Cognito session still works —
+        // `/push_deregister` is an authenticated call like every other, and
+        // `authService.signOut()` below wipes the tokens.
+        await PushRegistrar.shared.sessionWillEnd()
+        #endif
         await client.imapClient.disconnect()
         // Wipe locally cached mail (envelopes, bodies, drafts, outbox) before
         // dropping the session so the next account to sign in on this device
@@ -351,7 +352,7 @@ final class AppState {
             status = .signedOut
             return
         }
-        let secureStore = KeychainSecureStore()
+        let secureStore = Self.makeSecureStore()
         guard (try? secureStore.get(SecureStoreKey.authTokens)) != nil else {
             status = .signedOut
             return
@@ -360,7 +361,7 @@ final class AppState {
         status = .restoring
         do {
             let configuration = try await ConfigLoader.load(controlDomain: domain)
-            let cacheDirectory = try makeCacheDirectory()
+            let cacheDirectory = try Self.makeCacheDirectory()
             let newClient = try CabalmailClient.make(
                 configuration: configuration,
                 secureStore: secureStore,
@@ -371,14 +372,10 @@ final class AppState {
             // silent refresh; an expired / revoked refresh throws
             // `.authExpired` (Cognito's `NotAuthorizedException`).
             _ = try await newClient.authService.currentIdToken()
-            self.client = newClient
-            self.navCoordinator = NavStateCoordinator(client: newClient)
-            self.status = .signedIn
-            startInboxBadgePolling()
-            requestContactsAccessIfNeeded()
             // Restore is the common launch path, so this is what keeps the
-            // watch's copy of the session fresh across app launches.
-            await pushSessionToWatch(client: newClient, username: username)
+            // watch's session copy and the device's `/push_register` row
+            // fresh across app launches (see `wireSession`).
+            await wireSession(client: newClient, username: username)
         } catch let error as CabalmailError {
             switch error {
             case .authExpired, .invalidCredentials, .notSignedIn:
@@ -499,13 +496,51 @@ extension AppState {
     }
 }
 
-// MARK: - Cache directory
+// MARK: - Session wiring
 
 extension AppState {
+    /// Shared tail of `signIn` and `restoreIfPossible`: installs the client,
+    /// flips to `.signedIn`, and kicks off the session-scoped side flows —
+    /// badge polling, the contacts prompt, push registration (iOS), and the
+    /// watch hand-off.
+    private func wireSession(client newClient: CabalmailClient, username: String) async {
+        self.client = newClient
+        self.navCoordinator = NavStateCoordinator(client: newClient)
+        self.status = .signedIn
+        startInboxBadgePolling()
+        requestContactsAccessIfNeeded()
+        #if os(iOS)
+        // Runs on both entry paths, so every launch re-registers the APNs
+        // token — `/push_register` upserts, making this a cheap refresh of
+        // the row's `last_seen_at`.
+        PushRegistrar.shared.sessionDidStart(appState: self, client: newClient)
+        #endif
+        await pushSessionToWatch(client: newClient, username: username)
+    }
+}
+
+// MARK: - Client construction helpers
+
+extension AppState {
+    /// The keychain store the session client persists Cognito tokens
+    /// through. On iOS it's wrapped in `PushMirroringSecureStore` so every
+    /// token write — sign-in and each silent refresh — also lands in the
+    /// shared containers the Notification Service Extension reads (see
+    /// `PushEnrichmentStore`). Static (and non-private) so the push
+    /// action-handler's cold-launch bootstrap builds an identical stack.
+    static func makeSecureStore() -> SecureStore {
+        #if os(iOS)
+        return PushMirroringSecureStore(base: KeychainSecureStore())
+        #else
+        return KeychainSecureStore()
+        #endif
+    }
+
     /// Returns the application-support cache directory for this app, creating
     /// it if needed. Per-folder subdirectories are created by the cache
-    /// actors themselves.
-    private func makeCacheDirectory() throws -> URL {
+    /// actors themselves. Static for the same bootstrap reason as
+    /// `makeSecureStore`.
+    static func makeCacheDirectory() throws -> URL {
         let base = try FileManager.default.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask,

--- a/apple/Cabalmail/Cabalmail.entitlements
+++ b/apple/Cabalmail/Cabalmail.entitlements
@@ -4,10 +4,9 @@
 <dict>
     <!--
         This file is wired into the iOS target's signing via
-        `apple/project.yml` (CODE_SIGN_ENTITLEMENTS). It ships empty
-        on purpose: the only iOS entitlement Cabalmail has ever needed
-        is `com.apple.developer.mail-client`, which Apple grants
-        case-by-case via:
+        `apple/project.yml` (CODE_SIGN_ENTITLEMENTS). One entitlement
+        remains absent on purpose: `com.apple.developer.mail-client`,
+        which Apple grants case-by-case via:
 
           https://developer.apple.com/contact/request/default-mail-client
 
@@ -20,5 +19,37 @@
         See the "Setting Cabalmail as the default mail handler" section
         in apple/README.md for the full rollout.
     -->
+
+    <!--
+        Push notifications (docs/0.11.0/push-notifications.md). The value
+        here is always `development`; a distribution provisioning profile
+        rewrites it to `production` at signing time, so no per-config
+        switching is needed.
+    -->
+    <key>aps-environment</key>
+    <string>development</string>
+
+    <!--
+        App Group shared with the Notification Service Extension. Carries
+        the API Gateway URL via `UserDefaults(suiteName:)` so the NSE can
+        call `/push_envelope` without linking CabalmailKit.
+    -->
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.cabalmail.Cabalmail</string>
+    </array>
+
+    <!--
+        Keychain sharing with the NSE. The app's own identifier stays FIRST:
+        items stored without an explicit access group default to the first
+        entry, so existing Cognito-token / IMAP-password items keep landing
+        in the app-private group exactly as before this entitlement existed.
+        Only `PushEnrichmentStore` targets the shared group, explicitly.
+    -->
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.cabalmail.Cabalmail</string>
+        <string>$(AppIdentifierPrefix)com.cabalmail.shared</string>
+    </array>
 </dict>
 </plist>

--- a/apple/Cabalmail/CabalmailApp.swift
+++ b/apple/Cabalmail/CabalmailApp.swift
@@ -9,6 +9,14 @@ import CabalmailKit
 /// for every downstream view.
 @main
 struct CabalmailApp: App {
+    #if os(iOS)
+    // Push notifications: APNs token callbacks and the notification-center
+    // delegate have no SwiftUI-native surface, so the iOS build carries a
+    // minimal UIKit delegate (see AppDelegate.swift). visionOS skips it —
+    // the NSE and push registration are iOS-only for now (project.yml
+    // destination-filters the extension the same way).
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    #endif
     @State private var appState = AppState()
     @State private var preferences = Preferences(store: UbiquitousPreferenceStore())
     @Environment(\.scenePhase) private var scenePhase

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -1,0 +1,316 @@
+#if os(iOS)
+import Foundation
+import UIKit
+import UserNotifications
+import CabalmailKit
+
+/// Message coordinates from the APNs payload's `msgRef` dictionary:
+/// `{"folder": "INBOX", "uid": 4271, "msg_id": "<...>"}`. `uid` is a
+/// best-effort hint stamped by the dispatch path; `msg_id` is the durable
+/// identity (see `docs/0.11.0/push-notifications.md`). For notification
+/// *actions* we use the uid as given rather than re-resolving through
+/// `/push_envelope` — the backend sends the resolved uid when it can, and a
+/// stale hint only costs a no-op flag/move on a message that already left
+/// the folder.
+struct PushMessageRef: Sendable {
+    let folder: String
+    let uid: UInt32?
+    let messageID: String?
+
+    init?(userInfo: [AnyHashable: Any]) {
+        guard
+            let ref = userInfo["msgRef"] as? [String: Any],
+            let folder = ref["folder"] as? String, !folder.isEmpty
+        else { return nil }
+        self.folder = folder
+        self.uid = (ref["uid"] as? NSNumber)?.uint32Value
+        self.messageID = ref["msg_id"] as? String
+    }
+}
+
+/// Owns the APNs registration lifecycle and the notification-action
+/// handlers for the iOS app (docs/0.11.0/push-notifications.md, phases
+/// 1/3/4). `AppState` drives the session edges (`sessionDidStart` /
+/// `sessionWillEnd`), `AppDelegate` feeds it token and action callbacks.
+///
+/// A singleton (rather than something hung off `AppState`) because the
+/// UIKit delegate callbacks it services — token registration, background
+/// notification actions — can fire before SwiftUI has built any state,
+/// e.g. on a cold background launch from a lock-screen action.
+@MainActor
+final class PushRegistrar {
+    static let shared = PushRegistrar()
+
+    /// Set by `sessionDidStart`; navigation targets (`navCoordinator`)
+    /// hang off it. Weak — the registrar outlives any session.
+    private(set) weak var appState: AppState?
+
+    /// The session client while signed in, or a throwaway bootstrap client
+    /// built for a background action on a terminated app (`activeClient()`).
+    private var client: CabalmailClient?
+
+    /// APNs token that arrived before a session was wired (iOS re-delivers
+    /// the token on every `registerForRemoteNotifications`, which can beat
+    /// the launch restore). Registered as soon as the session starts.
+    private var pendingToken: String?
+
+    /// A tapped notification that arrived before sign-in / restore
+    /// completed; routed once the session is wired.
+    private var pendingOpen: PushMessageRef?
+
+    /// UserDefaults key for the token most recently accepted by
+    /// `/push_register` — i.e. what sign-out must deregister.
+    static let lastTokenKey = "cabalmail.push.lastRegisteredToken"
+    /// Cached archive-folder path resolved by `archiveFolderPath(using:)`.
+    /// A Settings-visible override is deferred to the preferences phase.
+    static let archiveFolderKey = "cabalmail.push.archiveFolder"
+
+    /// Registers the `MAIL_MESSAGE` category the dispatch Lambda stamps on
+    /// every payload. Called once at launch from `AppDelegate`.
+    static func registerNotificationCategories() {
+        let category = UNNotificationCategory(
+            identifier: "MAIL_MESSAGE",
+            actions: [
+                UNNotificationAction(identifier: "OPEN", title: "Open", options: [.foreground]),
+                UNNotificationAction(identifier: "MARK_READ", title: "Mark as Read", options: []),
+                UNNotificationAction(identifier: "ARCHIVE", title: "Archive", options: []),
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+        UNUserNotificationCenter.current().setNotificationCategories([category])
+    }
+
+    /// Wires a signed-in session: mirrors the API URL for the NSE, asks for
+    /// notification permission, and (re-)registers for remote notifications.
+    /// iOS re-delivers the device token on every registration, so each
+    /// launch refreshes the server row — a cheap upsert by design.
+    func sessionDidStart(appState: AppState, client: CabalmailClient) {
+        self.appState = appState
+        self.client = client
+        PushEnrichmentStore().updateAPIURL(client.configuration.invokeUrl)
+        Task {
+            let center = UNUserNotificationCenter.current()
+            let granted = (try? await center.requestAuthorization(
+                options: [.alert, .badge, .sound]
+            )) ?? false
+            guard granted else { return }
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+        if let token = pendingToken {
+            pendingToken = nil
+            deviceTokenDidChange(token)
+        }
+        if let open = pendingOpen {
+            pendingOpen = nil
+            route(open)
+        }
+    }
+
+    /// Called with the hex-encoded APNs token — on every launch (iOS
+    /// re-delivers it) and whenever APNs rotates it.
+    func deviceTokenDidChange(_ tokenHex: String) {
+        guard let client else {
+            pendingToken = tokenHex
+            return
+        }
+        let registration = PushDeviceRegistration(
+            deviceToken: tokenHex,
+            bundleId: Bundle.main.bundleIdentifier ?? "com.cabalmail.Cabalmail",
+            appVersion: Bundle.main.object(
+                forInfoDictionaryKey: "CFBundleShortVersionString"
+            ) as? String ?? "0",
+            locale: Locale.current.identifier
+        )
+        Task {
+            do {
+                try await client.apiClient.registerPushDevice(registration)
+                UserDefaults.standard.set(tokenHex, forKey: Self.lastTokenKey)
+            } catch {
+                // Best-effort: a failed registration means no pushes until
+                // the next launch retries, never a broken sign-in.
+                CabalmailLog.warn("Push", "push_register failed: \(error)")
+            }
+        }
+    }
+
+    /// Deregisters this device's token. Called from `AppState.signOut()`
+    /// *before* the Cognito tokens are wiped — `/push_deregister` needs an
+    /// authenticated call like every other endpoint.
+    func sessionWillEnd() async {
+        defer {
+            client = nil
+            appState = nil
+            // Drop the NSE's mirrored credentials alongside the session
+            // (also cleared by the mirroring store when the tokens are
+            // removed; doing it here too keeps the edge explicit).
+            PushEnrichmentStore().clear()
+        }
+        guard
+            let client,
+            let token = UserDefaults.standard.string(forKey: Self.lastTokenKey)
+        else { return }
+        do {
+            try await client.apiClient.deregisterPushDevice(token: token)
+            UserDefaults.standard.removeObject(forKey: Self.lastTokenKey)
+        } catch {
+            // Best-effort: a row we fail to remove here is pruned by
+            // push_dispatch the next time APNs rejects its token, and a
+            // reinstall / re-sign-in upserts over it.
+            CabalmailLog.warn("Push", "push_deregister failed: \(error)")
+        }
+    }
+}
+
+// MARK: - Notification actions
+
+extension PushRegistrar {
+    /// Dispatches a notification response. Runs the IMAP work inside a
+    /// UIKit background task and returns only once the operation resolves,
+    /// so `AppDelegate` can end the system's action budget truthfully.
+    func handleNotificationAction(identifier: String, ref: PushMessageRef?) async {
+        switch identifier {
+        case "MARK_READ":
+            guard let ref, let uid = ref.uid else { return }
+            await withBackgroundTask(named: "cabal.push.markRead") { client in
+                try await client.imapClient.setFlags(
+                    folder: ref.folder,
+                    uids: [uid],
+                    flags: [.seen],
+                    operation: .add
+                )
+            }
+        case "ARCHIVE":
+            guard let ref, let uid = ref.uid else { return }
+            await withBackgroundTask(named: "cabal.push.archive") { [weak self] client in
+                guard let destination = await self?.archiveFolderPath(using: client) else {
+                    // No Archive folder on this account: creating one on
+                    // demand is deliberately not this path's job, so the
+                    // action degrades to a logged no-op.
+                    CabalmailLog.warn("Push", "archive action skipped: no Archive folder")
+                    return
+                }
+                try await client.imapClient.move(
+                    folder: ref.folder,
+                    uids: [uid],
+                    destination: destination
+                )
+            }
+        case "OPEN", UNNotificationDefaultActionIdentifier:
+            guard let ref else { return }
+            route(ref)
+        default:
+            break
+        }
+    }
+
+    /// Routes the app to the pushed message. While signed in this drives
+    /// the same `navigateRequest` machinery as the cross-device resume
+    /// toast; before the session is wired (cold launch from a tap) the ref
+    /// parks here and `sessionDidStart` re-routes it — `MailRootView`
+    /// drains a pre-mount request from its `.task`.
+    private func route(_ ref: PushMessageRef) {
+        guard let coordinator = appState?.navCoordinator else {
+            pendingOpen = ref
+            return
+        }
+        coordinator.navigateRequest = NavState(
+            folder: ref.folder,
+            messageID: ref.messageID,
+            uid: ref.uid,
+            clientID: coordinator.clientID
+        )
+    }
+
+    /// Resolves the archive destination: the cached path if the user has
+    /// archived before, else the folder conventionally named "Archive".
+    /// `LIST (SPECIAL-USE)` isn't exposed by the API-backed client, so the
+    /// name is the best signal available; nil means "no archive folder".
+    private func archiveFolderPath(using client: CabalmailClient) async -> String? {
+        if let cached = UserDefaults.standard.string(forKey: Self.archiveFolderKey) {
+            return cached
+        }
+        guard
+            let folders = try? await client.imapClient.listFolders(),
+            let archive = folders.first(where: {
+                $0.path.caseInsensitiveCompare("Archive") == .orderedSame
+            })
+        else { return nil }
+        UserDefaults.standard.set(archive.path, forKey: Self.archiveFolderKey)
+        return archive.path
+    }
+}
+
+// MARK: - Background execution plumbing
+
+extension PushRegistrar {
+    /// Runs `work` with an active session client inside a UIKit background
+    /// task, so a lock-screen action started with the app suspended isn't
+    /// killed mid-flight. Errors are logged, not surfaced — there is no UI
+    /// to surface them to.
+    private func withBackgroundTask(
+        named name: String,
+        _ work: (CabalmailClient) async throws -> Void
+    ) async {
+        let token = BackgroundTaskToken()
+        token.begin(named: name)
+        defer { token.end() }
+        guard let client = await activeClient() else {
+            CabalmailLog.warn("Push", "\(name) skipped: no signed-in session")
+            return
+        }
+        do {
+            try await work(client)
+        } catch {
+            CabalmailLog.warn("Push", "\(name) failed: \(error)")
+        }
+    }
+
+    /// The session client, or — on a cold background launch, where no scene
+    /// ever attaches and `AppState.restoreIfPossible()` never runs — a
+    /// client bootstrapped from the persisted control domain and keychain
+    /// tokens. Auth refresh happens through the normal client path either
+    /// way. Returns nil when signed out.
+    private func activeClient() async -> CabalmailClient? {
+        if let client { return client }
+        let domain = UserDefaults.standard.string(forKey: "cabalmail.controlDomain") ?? ""
+        guard !domain.isEmpty else { return nil }
+        let store = AppState.makeSecureStore()
+        guard (try? store.get(SecureStoreKey.authTokens)) != nil else { return nil }
+        guard
+            let configuration = try? await ConfigLoader.load(controlDomain: domain),
+            let cacheDirectory = try? AppState.makeCacheDirectory(),
+            let bootstrapped = try? CabalmailClient.make(
+                configuration: configuration,
+                secureStore: store,
+                cacheDirectory: cacheDirectory
+            )
+        else { return nil }
+        // Cache it: a burst of actions (several notifications triaged from
+        // the lock screen) shouldn't rebuild the client per action. A later
+        // sign-in replaces it via `sessionDidStart`.
+        client = bootstrapped
+        return bootstrapped
+    }
+}
+
+/// Minimal RAII-ish wrapper around `beginBackgroundTask` /
+/// `endBackgroundTask`. Class (not struct) so the expiration handler can
+/// reach back and end the task if the system calls time first.
+@MainActor
+private final class BackgroundTaskToken {
+    private var id: UIBackgroundTaskIdentifier = .invalid
+
+    func begin(named name: String) {
+        id = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+            self?.end()
+        }
+    }
+
+    func end() {
+        guard id != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(id)
+        id = .invalid
+    }
+}
+#endif

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -23,8 +23,15 @@ struct PushMessageRef: Sendable {
             let folder = ref["folder"] as? String, !folder.isEmpty
         else { return nil }
         self.folder = folder
-        self.uid = (ref["uid"] as? NSNumber)?.uint32Value
-        self.messageID = ref["msg_id"] as? String
+        // 0 is the dispatch Lambda's "no hint" sentinel; mapping it to nil
+        // makes the action handlers' `guard let uid` skip cleanly instead of
+        // flag/move-ing UID 0 (which the API rejects as out of range). The
+        // NSE rewrites msgRef with the server-resolved uid when enrichment
+        // succeeds, so a nil here means the uid genuinely never resolved.
+        let rawUid = (ref["uid"] as? NSNumber)?.uint32Value
+        self.uid = rawUid == 0 ? nil : rawUid
+        let rawMessageID = ref["msg_id"] as? String
+        self.messageID = (rawMessageID?.isEmpty ?? true) ? nil : rawMessageID
     }
 }
 

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -293,6 +293,20 @@ struct MailRootView: View {
             }
         }
         .task {
+            // A navigate request can be parked before this view exists —
+            // cold launch from a tapped push notification routes as soon as
+            // the session is wired, which precedes the first render, so the
+            // `.onChange` above never fires for it. Draining it here also
+            // pre-empts the sidebar's INBOX landing (`onFoldersLoaded`
+            // guards on `selectedFolder == nil`).
+            if let coordinator = appState.navCoordinator,
+               let request = coordinator.navigateRequest {
+                coordinator.navigateRequest = nil
+                coordinator.scheduleRestore(for: request)
+                if selectedFolder?.path != request.folder {
+                    selectedFolder = Folder(path: request.folder)
+                }
+            }
             if searchModel == nil, let client = appState.client {
                 searchModel = MessageListViewModel(
                     scope: .search,

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
@@ -126,6 +126,19 @@ public protocol ApiClient: Sendable {
     /// cursor from elsewhere and offer to follow it.
     func saveNavState(_ state: NavState) async throws
 
+    // MARK: Push notifications
+    /// Registers (or upserts) this device's APNs token via `/push_register`,
+    /// scoped server-side to the authenticated Cognito user. Called after
+    /// sign-in once notification permission is granted, and again whenever
+    /// APNs rotates the token — the Lambda upserts, so repeat calls are
+    /// cheap. See `docs/0.11.0/push-notifications.md`.
+    func registerPushDevice(_ registration: PushDeviceRegistration) async throws
+
+    /// Removes this device's APNs token via `/push_deregister` so a signed-
+    /// out device stops receiving mail notifications without operator
+    /// intervention.
+    func deregisterPushDevice(token: String) async throws
+
     // MARK: Send
     /// Submits an outgoing message via the Lambda send pipeline (Outbox
     /// APPEND -> SMTP -> Sent move). Mirrors `react/admin/src/ApiClient.js
@@ -406,6 +419,41 @@ public struct ApiSendAttachment: Sendable, Hashable {
         self.filename = filename
         self.mimeType = mimeType
         self.s3Key = s3Key
+    }
+}
+
+/// Parameters for `/push_register`. One row per device token in the
+/// `cabal-push-tokens` table; the Lambda upserts on every call, so the
+/// client re-registers freely on launch and on token rotation.
+public struct PushDeviceRegistration: Sendable, Hashable {
+    /// APNs device token, hex-encoded.
+    public let deviceToken: String
+    /// Host-app bundle id (`com.cabalmail.Cabalmail`). Determines which
+    /// APNs topic the dispatch Lambda uses.
+    public let bundleId: String
+    /// `ios` today; informational — `bundleId` is authoritative server-side.
+    public let platform: String
+    public let appVersion: String
+    public let locale: String
+    /// Folders to push for (`["*"]` = all). Nil omits the field so the
+    /// server keeps its stored / default value — the per-folder picker is
+    /// a later phase.
+    public let enabledFolders: [String]?
+
+    public init(
+        deviceToken: String,
+        bundleId: String,
+        platform: String = "ios",
+        appVersion: String,
+        locale: String,
+        enabledFolders: [String]? = nil
+    ) {
+        self.deviceToken = deviceToken
+        self.bundleId = bundleId
+        self.platform = platform
+        self.appVersion = appVersion
+        self.locale = locale
+        self.enabledFolders = enabledFolders
     }
 }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Push.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Push.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// MARK: - Push notifications
+//
+// The `/push_register` / `/push_deregister` Lambdas maintain the
+// `cabal-push-tokens` table the push-dispatch Lambda fans out to (see
+// `docs/0.11.0/push-notifications.md`). Same wire conventions as every
+// other endpoint: flat path under the API Gateway stage, Cognito ID token
+// in the Authorization header, snake_case JSON body.
+
+extension URLSessionApiClient {
+    public func registerPushDevice(_ registration: PushDeviceRegistration) async throws {
+        var body: [String: Any] = [
+            "device_token": registration.deviceToken,
+            "bundle_id": registration.bundleId,
+            "platform": registration.platform,
+            "app_version": registration.appVersion,
+            "locale": registration.locale,
+        ]
+        // Omitted (not null) when unset, so the Lambda's upsert preserves
+        // whatever folder selection the row already carries.
+        if let folders = registration.enabledFolders {
+            body["enabled_folders"] = folders
+        }
+        let request = try await post("/push_register", json: body)
+        _ = try await send(request, expectedStatuses: 200..<300)
+    }
+
+    public func deregisterPushDevice(token: String) async throws {
+        let request = try await post("/push_deregister", json: [
+            "device_token": token,
+        ])
+        _ = try await send(request, expectedStatuses: 200..<300)
+    }
+}

--- a/apple/CabalmailKit/Sources/CabalmailKit/Push/PushEnrichmentStore.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Push/PushEnrichmentStore.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Shared-container handoff to the Notification Service Extension (NSE).
+///
+/// The NSE enriches the wake-signal push ("New mail") by calling
+/// `/push_envelope`, so it needs the API Gateway URL and a valid Cognito ID
+/// token — but it deliberately does **not** link CabalmailKit (the extension
+/// stays tiny; see `apple/CabalmailNotificationService/`). This type is the
+/// writer half of that contract: the main app mirrors
+///
+/// - `Configuration.invokeUrl` into the App Group `UserDefaults`, and
+/// - the current ID token + expiry into a keychain item in the shared
+///   access group (`<TEAMID>.com.cabalmail.shared`),
+///
+/// and the NSE reads both back with its own local `UserDefaults` /
+/// `SecItem` helpers.
+///
+/// Every write is best-effort and never throws: simulator and unsigned
+/// builds lack the app-group / keychain-sharing entitlements (SecItem fails
+/// with errSecMissingEntitlement, surfaced by `KeychainSecureStore` as a
+/// thrown error we swallow here), and a missing mirror only costs
+/// notification enrichment — it must never break sign-in.
+public struct PushEnrichmentStore: @unchecked Sendable {
+    /// App Group shared between the app and the NSE. Declared in both
+    /// targets' entitlements files.
+    public static let appGroupID = "group.com.cabalmail.Cabalmail"
+    /// Unprefixed shared keychain access group. The runtime SecItem calls
+    /// need the fully-qualified `<TEAMID>.` form — see `resolvedAccessGroup`.
+    public static let keychainAccessGroupSuffix = "com.cabalmail.shared"
+    /// App Group `UserDefaults` key carrying the API Gateway stage URL.
+    public static let apiURLDefaultsKey = "cabal.push.api_url"
+    /// Keychain coordinates of the mirrored token JSON (`tokenPayload`).
+    public static let keychainService = "com.cabalmail.push"
+    public static let keychainAccount = "push.auth"
+
+    // Nil when the shared containers can't exist in this context (no team-ID
+    // prefix in Info.plist, e.g. unsigned builds or the test runner); every
+    // operation degrades to a no-op. `UserDefaults` is documented
+    // thread-safe, hence the `@unchecked Sendable` above.
+    private let secureStore: SecureStore?
+    private let defaults: UserDefaults?
+
+    /// Production initializer: shared-group keychain + App Group defaults.
+    public init() {
+        if let group = Self.resolvedAccessGroup() {
+            self.secureStore = KeychainSecureStore(
+                service: Self.keychainService,
+                accessGroup: group
+            )
+        } else {
+            self.secureStore = nil
+        }
+        self.defaults = UserDefaults(suiteName: Self.appGroupID)
+    }
+
+    /// Injection point for tests.
+    init(secureStore: SecureStore?, defaults: UserDefaults?) {
+        self.secureStore = secureStore
+        self.defaults = defaults
+    }
+
+    /// Fully-qualified shared access group (`<TEAMID>.com.cabalmail.shared`),
+    /// or nil when the team-ID prefix isn't available. The prefix comes from
+    /// the Info.plist `AppIdentifierPrefix` key, which project.yml routes
+    /// through the same-named build setting — SecItem needs the literal
+    /// prefixed group; the entitlement's `$(AppIdentifierPrefix)` shorthand
+    /// is resolved at signing time only.
+    static func resolvedAccessGroup() -> String? {
+        guard
+            let prefix = Bundle.main.object(forInfoDictionaryKey: "AppIdentifierPrefix") as? String,
+            !prefix.isEmpty
+        else { return nil }
+        return prefix + keychainAccessGroupSuffix
+    }
+
+    /// Mirrors the API Gateway URL. Called when a session is wired (sign-in
+    /// or launch restore); the value only changes with the control domain,
+    /// so overwriting on every session is harmlessly idempotent.
+    public func updateAPIURL(_ url: URL) {
+        defaults?.set(url.absoluteString, forKey: Self.apiURLDefaultsKey)
+    }
+
+    /// Mirrors a fresh ID token + expiry for the NSE to attach to
+    /// `/push_envelope`. Best-effort — see the type comment.
+    public func updateToken(idToken: String, expiresAt: Date) {
+        guard let secureStore else { return }
+        let payload = PushTokenPayload(idToken: idToken, expiresAt: expiresAt)
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        try? secureStore.set(data, forKey: Self.keychainAccount)
+    }
+
+    /// Convenience for the mirroring store: decodes the `AuthTokens` blob
+    /// `CognitoAuthService` persists and mirrors just the ID-token half.
+    /// A payload that doesn't decode is silently ignored.
+    public func updateToken(fromEncodedAuthTokens data: Data) {
+        guard let tokens = try? JSONDecoder().decode(AuthTokens.self, from: data) else { return }
+        updateToken(idToken: tokens.idToken, expiresAt: tokens.expiresAt)
+    }
+
+    /// Drops both mirrored values. Called on sign-out so a signed-out (or
+    /// switched) device can't keep enriching notifications with the previous
+    /// user's token.
+    public func clear() {
+        defaults?.removeObject(forKey: Self.apiURLDefaultsKey)
+        try? secureStore?.remove(Self.keychainAccount)
+    }
+}
+
+/// JSON payload stored under `PushEnrichmentStore.keychainAccount`.
+/// snake_case to match the hand-rolled decoder in the NSE (which has no
+/// shared type to import — keep in sync with
+/// `apple/CabalmailNotificationService/NotificationService.swift`).
+struct PushTokenPayload: Codable {
+    let idToken: String
+    let expiresAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case idToken = "id_token"
+        case expiresAt = "expires_at"
+    }
+}
+
+/// `SecureStore` decorator that mirrors Cognito token writes into the shared
+/// push-enrichment containers.
+///
+/// `CognitoAuthService` persists every sign-in *and every silent refresh*
+/// through its `SecureStore` under `SecureStoreKey.authTokens`; wrapping the
+/// store hooks exactly that point, so the NSE's copy of the ID token can
+/// never go stale relative to the app's without touching the auth service
+/// itself. The base write is the source of truth: it runs first and its
+/// errors propagate, while mirror failures are swallowed inside
+/// `PushEnrichmentStore`.
+public struct PushMirroringSecureStore: SecureStore {
+    private let base: SecureStore
+    private let mirror: PushEnrichmentStore
+
+    public init(base: SecureStore, mirror: PushEnrichmentStore = PushEnrichmentStore()) {
+        self.base = base
+        self.mirror = mirror
+    }
+
+    public func set(_ value: Data, forKey key: String) throws {
+        try base.set(value, forKey: key)
+        if key == SecureStoreKey.authTokens {
+            mirror.updateToken(fromEncodedAuthTokens: value)
+        }
+    }
+
+    public func get(_ key: String) throws -> Data? {
+        try base.get(key)
+    }
+
+    public func remove(_ key: String) throws {
+        try base.remove(key)
+        if key == SecureStoreKey.authTokens {
+            mirror.clear()
+        }
+    }
+}

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientPushTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientPushTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import CabalmailKit
+
+/// Wire-level tests for the `/push_register` / `/push_deregister` pair
+/// backing APNs token lifecycle (docs/0.11.0/push-notifications.md), plus
+/// the shared-container mirroring that hands the ID token to the
+/// Notification Service Extension.
+final class ApiClientPushTests: XCTestCase {
+    private func makeConfiguration() -> Configuration {
+        Configuration(
+            controlDomain: "cabalmail.example",
+            domains: [MailDomain(domain: "cabalmail.example")],
+            invokeUrl: URL(string: "https://api.cabalmail.example/prod")!,
+            cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
+        )
+    }
+
+    func testRegisterPushDevicePostsSnakeCaseBody() async throws {
+        let http = RecordingHTTPTransport(responses: [(Data("{}".utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        try await client.registerPushDevice(PushDeviceRegistration(
+            deviceToken: "ab12cd34",
+            bundleId: "com.cabalmail.Cabalmail",
+            appVersion: "0.6.0",
+            locale: "en_US"
+        ))
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].httpMethod, "POST")
+        XCTAssertEqual(
+            requests[0].url?.absoluteString,
+            "https://api.cabalmail.example/prod/push_register"
+        )
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Authorization"), "idtoken")
+        let payload = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(payload?["device_token"] as? String, "ab12cd34")
+        XCTAssertEqual(payload?["bundle_id"] as? String, "com.cabalmail.Cabalmail")
+        XCTAssertEqual(payload?["platform"] as? String, "ios")
+        XCTAssertEqual(payload?["app_version"] as? String, "0.6.0")
+        XCTAssertEqual(payload?["locale"] as? String, "en_US")
+        // Nil folder selection is OMITTED (not null) so the Lambda's upsert
+        // preserves whatever the row already carries.
+        XCTAssertNil(payload?["enabled_folders"])
+        XCTAssertEqual(payload?.count, 5)
+    }
+
+    func testRegisterPushDeviceIncludesEnabledFoldersWhenSet() async throws {
+        let http = RecordingHTTPTransport(responses: [(Data("{}".utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        try await client.registerPushDevice(PushDeviceRegistration(
+            deviceToken: "ab12cd34",
+            bundleId: "com.cabalmail.Cabalmail",
+            appVersion: "0.6.0",
+            locale: "en_US",
+            enabledFolders: ["*"]
+        ))
+        let requests = await http.requests
+        let payload = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(payload?["enabled_folders"] as? [String], ["*"])
+    }
+
+    func testDeregisterPushDevicePostsToken() async throws {
+        let http = RecordingHTTPTransport(responses: [(Data("{}".utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        try await client.deregisterPushDevice(token: "ab12cd34")
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].httpMethod, "POST")
+        XCTAssertEqual(
+            requests[0].url?.absoluteString,
+            "https://api.cabalmail.example/prod/push_deregister"
+        )
+        let payload = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(payload?.count, 1)
+        XCTAssertEqual(payload?["device_token"] as? String, "ab12cd34")
+    }
+
+    func testRegisterPushDeviceSurfacesServerError() async throws {
+        let http = RecordingHTTPTransport(responses: [(Data("boom".utf8), 500)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        do {
+            try await client.registerPushDevice(PushDeviceRegistration(
+                deviceToken: "ab12cd34",
+                bundleId: "com.cabalmail.Cabalmail",
+                appVersion: "0.6.0",
+                locale: "en_US"
+            ))
+            XCTFail("Expected server error")
+        } catch let error as CabalmailError {
+            guard case .server(let code, _) = error else {
+                return XCTFail("Expected .server, got \(error)")
+            }
+            XCTAssertEqual(code, "500")
+        }
+    }
+}
+
+/// The NSE handoff: `PushMirroringSecureStore` must mirror exactly the
+/// Cognito-token writes into `PushEnrichmentStore`, and leave every other
+/// key untouched.
+final class PushEnrichmentStoreTests: XCTestCase {
+    private func makeTokens(idToken: String, expiresAt: Date) -> AuthTokens {
+        AuthTokens(
+            idToken: idToken,
+            accessToken: "access",
+            refreshToken: "refresh",
+            expiresAt: expiresAt
+        )
+    }
+
+    func testMirrorsAuthTokenWritesIntoSharedStore() throws {
+        let base = InMemorySecureStore()
+        let shared = InMemorySecureStore()
+        let store = PushMirroringSecureStore(
+            base: base,
+            mirror: PushEnrichmentStore(secureStore: shared, defaults: nil)
+        )
+        let expiry = Date(timeIntervalSince1970: 2_000_000_000)
+        let encoded = try JSONEncoder().encode(makeTokens(idToken: "id-1", expiresAt: expiry))
+        try store.set(encoded, forKey: SecureStoreKey.authTokens)
+
+        // The base write is untouched...
+        XCTAssertEqual(try base.get(SecureStoreKey.authTokens), encoded)
+        // ...and the mirror holds the NSE's payload: id token + expiry only.
+        let mirrored = try XCTUnwrap(shared.get(PushEnrichmentStore.keychainAccount))
+        let payload = try JSONSerialization.jsonObject(with: mirrored) as? [String: Any]
+        XCTAssertEqual(payload?["id_token"] as? String, "id-1")
+        XCTAssertNotNil(payload?["expires_at"])
+        XCTAssertEqual(payload?.count, 2)
+    }
+
+    func testDoesNotMirrorOtherKeys() throws {
+        let base = InMemorySecureStore()
+        let shared = InMemorySecureStore()
+        let store = PushMirroringSecureStore(
+            base: base,
+            mirror: PushEnrichmentStore(secureStore: shared, defaults: nil)
+        )
+        try store.setString("hunter2", forKey: SecureStoreKey.imapPassword)
+        XCTAssertEqual(try store.getString(SecureStoreKey.imapPassword), "hunter2")
+        XCTAssertNil(try shared.get(PushEnrichmentStore.keychainAccount))
+    }
+
+    func testRemovingAuthTokensClearsTheMirror() throws {
+        let base = InMemorySecureStore()
+        let shared = InMemorySecureStore()
+        let store = PushMirroringSecureStore(
+            base: base,
+            mirror: PushEnrichmentStore(secureStore: shared, defaults: nil)
+        )
+        let encoded = try JSONEncoder().encode(makeTokens(idToken: "id-1", expiresAt: .distantFuture))
+        try store.set(encoded, forKey: SecureStoreKey.authTokens)
+        XCTAssertNotNil(try shared.get(PushEnrichmentStore.keychainAccount))
+
+        try store.remove(SecureStoreKey.authTokens)
+        XCTAssertNil(try base.get(SecureStoreKey.authTokens))
+        XCTAssertNil(try shared.get(PushEnrichmentStore.keychainAccount))
+    }
+
+    func testUndecodableTokenBlobIsIgnored() throws {
+        let base = InMemorySecureStore()
+        let shared = InMemorySecureStore()
+        let store = PushMirroringSecureStore(
+            base: base,
+            mirror: PushEnrichmentStore(secureStore: shared, defaults: nil)
+        )
+        // A corrupt blob must still persist to the base store (the auth
+        // service owns that contract) without poisoning the mirror.
+        try store.set(Data("not json".utf8), forKey: SecureStoreKey.authTokens)
+        XCTAssertNotNil(try base.get(SecureStoreKey.authTokens))
+        XCTAssertNil(try shared.get(PushEnrichmentStore.keychainAccount))
+    }
+}

--- a/apple/CabalmailNotificationService/CabalmailNotificationService.entitlements
+++ b/apple/CabalmailNotificationService/CabalmailNotificationService.entitlements
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Wired via `apple/project.yml` (CODE_SIGN_ENTITLEMENTS on the
+        CabalmailNotificationService target). The extension reads two
+        values the main app mirrors for it (see CabalmailKit's
+        `PushEnrichmentStore`):
+
+          - the API Gateway URL, from the App Group `UserDefaults`, and
+          - the Cognito ID token, from the shared keychain access group.
+
+        The NSE never registers for push itself, so no `aps-environment`
+        here — only the containers it reads from.
+    -->
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.cabalmail.Cabalmail</string>
+    </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.cabalmail.Cabalmail.NotificationService</string>
+        <string>$(AppIdentifierPrefix)com.cabalmail.shared</string>
+    </array>
+</dict>
+</plist>

--- a/apple/CabalmailNotificationService/NotificationService.swift
+++ b/apple/CabalmailNotificationService/NotificationService.swift
@@ -37,6 +37,12 @@ final class NotificationService: UNNotificationServiceExtension {
             return
         }
         let state = self.state
+        // The Swift 5.10 region-isolation checker emits a spurious
+        // "pattern ... does not understand" warning for this Task even
+        // though every capture is Sendable (endpoint/token/query are value
+        // types; DeliveryState is @unchecked Sendable with lock-guarded
+        // state). Extraction and Task.detached were both tried and do not
+        // silence it; revisit when the toolchain moves past 5.10.
         Task {
             let envelope = await Self.fetchEnvelope(endpoint: endpoint, token: token, query: query)
             state.deliver(envelope)
@@ -89,8 +95,13 @@ private struct EnvelopeQuery: Sendable {
             let folder = ref["folder"] as? String, !folder.isEmpty
         else { return nil }
         self.folder = folder
-        self.uid = (ref["uid"] as? NSNumber)?.uint32Value
-        self.messageID = ref["msg_id"] as? String
+        // 0 is the dispatch Lambda's explicit "no hint" sentinel (procmail
+        // could not read Dovecot's next-uid); map it to nil so it is never
+        // forwarded as if it were a real UID.
+        let rawUid = (ref["uid"] as? NSNumber)?.uint32Value
+        self.uid = rawUid == 0 ? nil : rawUid
+        let rawMessageID = ref["msg_id"] as? String
+        self.messageID = (rawMessageID?.isEmpty ?? true) ? nil : rawMessageID
     }
 
     var requestBody: [String: Any] {
@@ -101,11 +112,14 @@ private struct EnvelopeQuery: Sendable {
     }
 }
 
-/// Decoded `/push_envelope` response.
+/// Decoded `/push_envelope` response. `uid` is the server-resolved UID (the
+/// payload's was a pre-delivery hint); `deliver` writes it back into the
+/// notification's msgRef so the main app's actions target the right message.
 private struct PushEnvelope: Decodable, Sendable {
     let from: String
     let subject: String
     let snippet: String
+    let uid: UInt32?
 }
 
 /// Deliver-once box shared between `didReceive`'s enrichment task and
@@ -138,6 +152,16 @@ private final class DeliveryState: @unchecked Sendable {
            let enriched = original.mutableCopy() as? UNMutableNotificationContent {
             enriched.title = envelope.from
             enriched.body = envelope.subject + "\n" + envelope.snippet
+            // The payload's uid was a pre-delivery hint; the server resolved
+            // the real one by Message-ID. Rewrite msgRef so Mark as Read /
+            // Archive / Open act on the message this notification shows.
+            if let resolved = envelope.uid, resolved != 0,
+               var ref = enriched.userInfo["msgRef"] as? [String: Any] {
+                ref["uid"] = Int(resolved)
+                var info = enriched.userInfo
+                info["msgRef"] = ref
+                enriched.userInfo = info
+            }
             content = enriched
         } else {
             content = original

--- a/apple/CabalmailNotificationService/NotificationService.swift
+++ b/apple/CabalmailNotificationService/NotificationService.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Security
+import UserNotifications
+
+/// Notification Service Extension: enriches the wake-signal push.
+///
+/// The APNs payload deliberately carries no message content — just
+/// `{"aps": {"alert": "New mail", "mutable-content": 1, ...},
+///   "msgRef": {"folder": "INBOX", "uid": 4271, "msg_id": "<...>"}}`
+/// (see docs/0.11.0/push-notifications.md). This extension wakes on each
+/// delivery, calls the `/push_envelope` Lambda with the Cognito ID token
+/// the main app mirrors for it, and rewrites the alert into
+/// sender / subject / snippet. Any failure — no credentials, expired
+/// token, timeout, non-2xx, undecodable body — delivers the original
+/// "New mail" content instead. Never block, never crash: a hung NSE gets
+/// its process killed and the user sees nothing at all.
+///
+/// Deliberately tiny: Foundation + UserNotifications only, no CabalmailKit.
+/// The two inputs arrive via containers both processes share (written by
+/// CabalmailKit's `PushEnrichmentStore`):
+/// - `api_url` in the App Group `UserDefaults`, and
+/// - the ID token JSON in the shared keychain access group.
+final class NotificationService: UNNotificationServiceExtension {
+    private let state = DeliveryState()
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        state.begin(content: request.content, handler: contentHandler)
+        guard
+            let query = EnvelopeQuery(userInfo: request.content.userInfo),
+            let endpoint = PushHandoff.enrichmentEndpoint(),
+            let token = PushHandoff.currentIdToken()
+        else {
+            state.deliverFallback()
+            return
+        }
+        let state = self.state
+        Task {
+            let envelope = await Self.fetchEnvelope(endpoint: endpoint, token: token, query: query)
+            state.deliver(envelope)
+        }
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        // Out of wall time: ship whatever we have (the unenriched original —
+        // an enriched copy would already have been delivered).
+        state.deliverFallback()
+    }
+
+    /// One POST to `/push_envelope`. The 8-second timeout leaves headroom
+    /// inside the NSE's ~30s budget for `serviceExtensionTimeWillExpire`
+    /// to deliver the fallback cleanly.
+    private static func fetchEnvelope(
+        endpoint: URL,
+        token: String,
+        query: EnvelopeQuery
+    ) async -> PushEnvelope? {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 8
+        request.setValue(token, forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        guard let body = try? JSONSerialization.data(withJSONObject: query.requestBody) else {
+            return nil
+        }
+        request.httpBody = body
+        guard
+            let (data, response) = try? await URLSession.shared.data(for: request),
+            let http = response as? HTTPURLResponse,
+            (200..<300).contains(http.statusCode)
+        else { return nil }
+        return try? JSONDecoder().decode(PushEnvelope.self, from: data)
+    }
+}
+
+/// The `msgRef` coordinates, parsed from the payload. `uid` is a
+/// best-effort hint; `msg_id` is authoritative — both are forwarded and
+/// `/push_envelope` resolves the real uid server-side.
+private struct EnvelopeQuery: Sendable {
+    let folder: String
+    let uid: UInt32?
+    let messageID: String?
+
+    init?(userInfo: [AnyHashable: Any]) {
+        guard
+            let ref = userInfo["msgRef"] as? [String: Any],
+            let folder = ref["folder"] as? String, !folder.isEmpty
+        else { return nil }
+        self.folder = folder
+        self.uid = (ref["uid"] as? NSNumber)?.uint32Value
+        self.messageID = ref["msg_id"] as? String
+    }
+
+    var requestBody: [String: Any] {
+        var body: [String: Any] = ["folder": folder]
+        if let uid { body["uid"] = Int(uid) }
+        if let messageID { body["msg_id"] = messageID }
+        return body
+    }
+}
+
+/// Decoded `/push_envelope` response.
+private struct PushEnvelope: Decodable, Sendable {
+    let from: String
+    let subject: String
+    let snippet: String
+}
+
+/// Deliver-once box shared between `didReceive`'s enrichment task and
+/// `serviceExtensionTimeWillExpire`. A lock (rather than an actor) because
+/// both callers are synchronous system entry points; `@unchecked Sendable`
+/// is sound as every access to the mutable fields happens under `lock`.
+private final class DeliveryState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var original: UNNotificationContent?
+    private var handler: ((UNNotificationContent) -> Void)?
+
+    func begin(content: UNNotificationContent, handler: @escaping (UNNotificationContent) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        original = content
+        self.handler = handler
+    }
+
+    /// Delivers the enriched content, or the untouched original when
+    /// enrichment came back empty. Subsequent calls are no-ops.
+    func deliver(_ envelope: PushEnvelope?) {
+        lock.lock()
+        guard let handler, let original else {
+            lock.unlock()
+            return
+        }
+        self.handler = nil
+        let content: UNNotificationContent
+        if let envelope,
+           let enriched = original.mutableCopy() as? UNMutableNotificationContent {
+            enriched.title = envelope.from
+            enriched.body = envelope.subject + "\n" + envelope.snippet
+            content = enriched
+        } else {
+            content = original
+        }
+        lock.unlock()
+        handler(content)
+    }
+
+    func deliverFallback() {
+        deliver(nil)
+    }
+}
+
+/// Reads the two values the main app mirrors via CabalmailKit's
+/// `PushEnrichmentStore` — keep key names in sync with that type.
+private enum PushHandoff {
+    static let appGroupID = "group.com.cabalmail.Cabalmail"
+    static let apiURLDefaultsKey = "cabal.push.api_url"
+    static let keychainService = "com.cabalmail.push"
+    static let keychainAccount = "push.auth"
+
+    /// `<api_url>/push_envelope`, or nil before the app has ever signed in.
+    static func enrichmentEndpoint() -> URL? {
+        guard
+            let raw = UserDefaults(suiteName: appGroupID)?.string(forKey: apiURLDefaultsKey),
+            let base = URL(string: raw)
+        else { return nil }
+        return base.appendingPathComponent("push_envelope")
+    }
+
+    /// The mirrored Cognito ID token, or nil when absent or already expired
+    /// (the NSE has no way to refresh — the design accepts the "New mail"
+    /// fallback for that window; see the plan's open questions). No
+    /// `kSecAttrAccessGroup` in the query: a read searches every group this
+    /// extension can access, which avoids re-deriving the team-ID prefix.
+    static func currentIdToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard
+            SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+            let data = item as? Data,
+            let payload = try? JSONDecoder().decode(TokenPayload.self, from: data)
+        else { return nil }
+        // 60s of leeway: a token the API would reject mid-flight isn't
+        // worth the round trip; clock skew smaller than that still tries.
+        guard payload.expiresAt.timeIntervalSinceNow > -60 else { return nil }
+        return payload.idToken
+    }
+
+    /// Mirror of `PushEnrichmentStore.TokenPayload`'s wire shape.
+    private struct TokenPayload: Decodable {
+        let idToken: String
+        let expiresAt: Date
+
+        enum CodingKeys: String, CodingKey {
+            case idToken = "id_token"
+            case expiresAt = "expires_at"
+        }
+    }
+}

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -54,6 +54,14 @@ targets:
       # without this, the visionOS TestFlight leg would fail validation.
       - target: CabalmailWatch
         destinationFilters: [iOS]
+      # Notification Service Extension: enriches the wake-signal push
+      # ("New mail") with sender / subject / snippet on-device, so message
+      # content never transits APNs (see docs/0.11.0/push-notifications.md).
+      # iOS-only for now, same destination-filter rationale as the watch —
+      # the push feature ships on iOS first and a visionOS archive must not
+      # embed an extension its provisioning doesn't cover.
+      - target: CabalmailNotificationService
+        destinationFilters: [iOS]
     info:
       path: Cabalmail/Info.plist
       properties:
@@ -99,6 +107,14 @@ targets:
           and name next to mail you receive, and to add senders to
           your contacts when you choose. Your contacts stay on
           this device.
+        # Expands at build time to "<TEAMID>." — read at runtime by
+        # `PushEnrichmentStore` to compose the fully-qualified shared
+        # keychain access group (`<TEAMID>.com.cabalmail.shared`), which
+        # SecItem requires verbatim (the entitlement's
+        # `$(AppIdentifierPrefix)` shorthand is signing-time only). Unsigned
+        # builds expand it to the empty string; the resulting SecItem
+        # failure is tolerated (push enrichment is best-effort).
+        AppIdentifierPrefix: "$(AppIdentifierPrefix)"
         # Route the plist's version fields through build settings so CI's
         # `CURRENT_PROJECT_VERSION=<timestamp>` actually reaches the shipped
         # Info.plist. Without this, XcodeGen hardcodes "1" / "1.0" and
@@ -335,6 +351,57 @@ targets:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"
           PROVISIONING_PROFILE_SPECIFIER: "$(WATCHOS_APP_STORE_PROFILE_UUID)"
+
+  # Notification Service Extension for the iOS app. Wakes on every
+  # `mutable-content: 1` push, calls `/push_envelope` with the Cognito ID
+  # token the main app mirrors into the shared keychain group, and rewrites
+  # the bare "New mail" alert into sender / subject / snippet. Deliberately
+  # tiny: Foundation + UserNotifications only, no CabalmailKit — the values
+  # it needs arrive via the App Group container and the shared keychain
+  # (see docs/0.11.0/push-notifications.md and PushEnrichmentStore).
+  CabalmailNotificationService:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: CabalmailNotificationService
+    info:
+      path: CabalmailNotificationService/Info.plist
+      properties:
+        CFBundleDisplayName: Cabalmail Notification Service
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.usernotifications.service
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService"
+        # See the Cabalmail target's equivalent comment — XcodeGen defaults
+        # these to "1" / "1.0" unless explicitly plumbed through to the
+        # build settings. App Store validation additionally requires an
+        # extension's versions to match its host app exactly; CI passes both
+        # on the xcodebuild command line, reaching every target at once.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+    settings:
+      base:
+        # Apple's convention for app extensions: the host app's bundle id
+        # plus a suffix. The push-dispatch Lambda targets the *host* topic;
+        # this id only matters for embedding and provisioning.
+        PRODUCT_BUNDLE_IDENTIFIER: com.cabalmail.Cabalmail.NotificationService
+        # Keep in lockstep with the Cabalmail target above (host/extension
+        # version match is enforced at App Store validation).
+        MARKETING_VERSION: "0.6.0"
+        CURRENT_PROJECT_VERSION: "1"
+        GENERATE_INFOPLIST_FILE: NO
+        # App Group (shared UserDefaults for api_url) + shared keychain
+        # access group (Cognito ID token). Mirrors the host app's additions
+        # in Cabalmail/Cabalmail.entitlements.
+        CODE_SIGN_ENTITLEMENTS: CabalmailNotificationService/CabalmailNotificationService.entitlements
+      configs:
+        # See the Cabalmail target's matching block for why manual-signing
+        # settings live per-target instead of on the xcodebuild command
+        # line. CI injects IOS_NSE_APP_STORE_PROFILE_UUID as a user-defined
+        # setting when archiving the iOS app (which embeds this target).
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "$(IOS_NSE_APP_STORE_PROFILE_UUID)"
 
 schemes:
   Cabalmail:

--- a/changelog.d/archive-mailbox.added.md
+++ b/changelog.d/archive-mailbox.added.md
@@ -1,0 +1,4 @@
+- **Archive mailbox.** Dovecot now defines an auto-subscribed `Archive`
+  folder with the `\Archive` special-use flag for every mailbox, giving the
+  notification Archive action (and any IMAP client's archive gesture) a
+  standard target.

--- a/changelog.d/push-notifications-apple.added.md
+++ b/changelog.d/push-notifications-apple.added.md
@@ -1,0 +1,8 @@
+- Apple: **Push notifications.** New mail now raises a notification within
+  seconds of delivery, enriched on-device with the sender, subject, and a
+  snippet — Apple's servers never see message content, and with previews off
+  the lock screen shows only "New mail". Notifications offer Open, Mark as
+  Read, and Archive (the latter two complete in the background without
+  launching the app); foreground arrivals play a sound without a duplicate
+  banner. Enable by allowing notifications when prompted after sign-in;
+  signing out stops them.

--- a/changelog.d/push-notifications.added.md
+++ b/changelog.d/push-notifications.added.md
@@ -1,0 +1,13 @@
+- **Push notifications for the Apple clients.** New mail now raises an APNs
+  notification on iOS within seconds of delivery, without Apple's
+  infrastructure seeing message content: procmail enqueues a content-free
+  wake signal (`cabal-push-queue`) per local delivery, the new
+  `push_dispatch` Lambda fans it out to the user's registered devices
+  (`cabal-push-tokens`, managed by the new `/push_register` and
+  `/push_deregister` endpoints), and the app's Notification Service
+  Extension enriches the alert on-device via the new `/push_envelope`
+  endpoint — falling back to a generic "New mail" when enrichment cannot
+  complete. Notifications carry Open / Mark as Read / Archive actions; the
+  enqueue is a best-effort side effect that never blocks or fails mail
+  delivery, and spam-filed messages do not notify. Inert until an operator
+  provisions an APNs auth key (see docs/push-notifications.md).

--- a/changelog.d/push-notifications.added.md
+++ b/changelog.d/push-notifications.added.md
@@ -1,7 +1,9 @@
 - **Push notifications for the Apple clients.** New mail now raises an APNs
   notification on iOS within seconds of delivery, without Apple's
-  infrastructure seeing message content: procmail enqueues a content-free
-  wake signal (`cabal-push-queue`) per local delivery, the new
+  infrastructure seeing message content: procmail spools a content-free
+  wake signal per local delivery (forwarded to `cabal-push-queue` by a
+  credential-holding drain daemon, keeping AWS credentials away from the
+  per-user delivery agents), the new
   `push_dispatch` Lambda fans it out to the user's registered devices
   (`cabal-push-tokens`, managed by the new `/push_register` and
   `/push_deregister` endpoints), and the app's Notification Service

--- a/docker/imap/Dockerfile
+++ b/docker/imap/Dockerfile
@@ -142,9 +142,12 @@ COPY shared/prepare-sendmail.sh            /usr/local/bin/prepare-sendmail.sh
 # Clears the planned-maintenance SSM flag once Dovecot is serving (imap only).
 COPY shared/clear-maintenance.sh           /usr/local/bin/clear-maintenance.sh
 
-# Enqueues a push-notification wake signal per local delivery (imap only;
-# invoked by the :0c recipe in procmailrc).
+# Push wake signals (imap only): the :0c recipe in procmailrc spools one
+# JSON signal per local delivery via push-enqueue.sh; the push-spool-drain
+# supervisord program forwards the spool to SQS with the task-role
+# credentials the per-user delivery agents deliberately never see.
 COPY shared/push-enqueue.sh                /usr/local/bin/push-enqueue.sh
+COPY shared/push-spool-drain.sh            /usr/local/bin/push-spool-drain.sh
 
 # Rsyslog config (ships sendmail logs to /var/log/maillog for CloudWatch)
 COPY shared/rsyslog-mail.conf              /etc/rsyslog.conf

--- a/docker/imap/Dockerfile
+++ b/docker/imap/Dockerfile
@@ -142,6 +142,10 @@ COPY shared/prepare-sendmail.sh            /usr/local/bin/prepare-sendmail.sh
 # Clears the planned-maintenance SSM flag once Dovecot is serving (imap only).
 COPY shared/clear-maintenance.sh           /usr/local/bin/clear-maintenance.sh
 
+# Enqueues a push-notification wake signal per local delivery (imap only;
+# invoked by the :0c recipe in procmailrc).
+COPY shared/push-enqueue.sh                /usr/local/bin/push-enqueue.sh
+
 # Rsyslog config (ships sendmail logs to /var/log/maillog for CloudWatch)
 COPY shared/rsyslog-mail.conf              /etc/rsyslog.conf
 

--- a/docker/imap/configs/dovecot/15-mailboxes.conf
+++ b/docker/imap/configs/dovecot/15-mailboxes.conf
@@ -17,4 +17,12 @@ namespace inbox {
   mailbox Sent {
     special_use = \Sent
   }
+  mailbox Archive {
+    special_use = \Archive
+    # Subscribe (not just create) so existing clients discover it: the
+    # notification "Archive" action targets this folder and needs it to
+    # exist for every mailbox, old and new, without a Lambda-side
+    # create-on-demand round trip (docs/0.11.0/push-notifications.md).
+    auto = subscribe
+  }
 }

--- a/docker/imap/configs/procmailrc
+++ b/docker/imap/configs/procmailrc
@@ -7,3 +7,20 @@ MAILDIR=$HOME/Maildir       # Make sure this directory exists!
 :0:
 *^X-Mailer: Outlook Express 3.14159
 IN-spam/
+
+# Push notifications (docs/0.11.0/push-notifications.md): enqueue a
+# content-free wake signal as a delivery side effect. The :0c carbon-copy
+# flag means delivery continues unconditionally, and the script itself is
+# best-effort (always exits 0), so a slow or unreachable SQS can never
+# block mail flow. Placed after the spam rule on purpose: a message that
+# rule files away never reaches this recipe, so junk does not buzz phones.
+#
+# This same file is installed at /etc/procmailrc AND copied to each user's
+# ~/.procmailrc (sync-users.sh), and procmail processes both in one run.
+# The PUSH_ENQUEUED variable survives the /etc -> $HOME rcfile transition,
+# so the guard makes the enqueue fire exactly once whichever copy runs
+# first.
+:0c
+* ! PUSH_ENQUEUED ?? yes
+| /usr/local/bin/push-enqueue.sh "$LOGNAME" "INBOX"
+PUSH_ENQUEUED=yes

--- a/docker/imap/supervisord.conf
+++ b/docker/imap/supervisord.conf
@@ -61,6 +61,19 @@ autorestart=true
 priority=40
 stopwaitsecs=30
 
+# Forwards spooled push wake signals (written by procmail's push-enqueue.sh)
+# to the cabal-push-queue SQS queue. Runs as root so it carries the task-role
+# credentials the per-user delivery agents deliberately never see; idles
+# RUNNING when PUSH_QUEUE_URL is unset. See docs/0.11.0/push-notifications.md.
+[program:push-spool-drain]
+command=/usr/local/bin/push-spool-drain.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+autorestart=true
+startsecs=0
+priority=30
+
 # Clears the /cabal/maintenance/imap SSM flag set by the deploy pipeline once
 # Dovecot is accepting connections, then idles RUNNING (a one-shot exit would
 # just be restarted by autorestart=true). Fail-soft: never crash-loops on a

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -20,6 +20,8 @@
 # Optional:          NETWORK_CIDR (VPC CIDR for Dovecot login_trusted_networks)
 #                    PREFLIGHT (=1: run all preparation steps, then exit 0
 #                    instead of starting services - deploy validation)
+#                    PUSH_QUEUE_URL (imap: enables the procmail push-enqueue
+#                    side effect; see docs/0.11.0/push-notifications.md)
 # IMAP-only:         MASTER_PASSWORD
 # SMTP-OUT-only:     DKIM_PRIVATE_KEY
 set -euo pipefail
@@ -165,6 +167,23 @@ fi
 if [ "$TIER" = "imap" ]; then
   echo "[entrypoint] Setting dovecot master password..."
   htpasswd -b -c -s /etc/dovecot/master-users admin "${MASTER_PASSWORD}"
+fi
+
+# ── Step 5b: Push-enqueue environment (IMAP only) ─────────────
+# sendmail sanitizes the environment it hands delivery agents, so procmail's
+# push-enqueue.sh child cannot inherit the queue URL or the ECS task-role
+# credential URI from the container env. Persist them at startup; the
+# credential URI is stable for the life of the task. Absent PUSH_QUEUE_URL
+# (task definition predating push, or push retired) leaves no file and the
+# script no-ops. See docs/0.11.0/push-notifications.md.
+if [ "$TIER" = "imap" ] && [ -n "${PUSH_QUEUE_URL:-}" ]; then
+  echo "[entrypoint] Writing push-enqueue environment..."
+  cat > /etc/cabal-push-enqueue.env <<PUSHENV
+PUSH_QUEUE_URL=${PUSH_QUEUE_URL}
+AWS_REGION=${AWS_REGION}
+AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}
+PUSHENV
+  chmod 644 /etc/cabal-push-enqueue.env
 fi
 
 # ── Step 6: Prepare rsyslog working directory ─────────────────

--- a/docker/shared/entrypoint.sh
+++ b/docker/shared/entrypoint.sh
@@ -20,8 +20,9 @@
 # Optional:          NETWORK_CIDR (VPC CIDR for Dovecot login_trusted_networks)
 #                    PREFLIGHT (=1: run all preparation steps, then exit 0
 #                    instead of starting services - deploy validation)
-#                    PUSH_QUEUE_URL (imap: enables the procmail push-enqueue
-#                    side effect; see docs/0.11.0/push-notifications.md)
+#                    PUSH_QUEUE_URL (imap: consumed by the push-spool-drain
+#                    supervisord program, not this script; see
+#                    docs/0.11.0/push-notifications.md)
 # IMAP-only:         MASTER_PASSWORD
 # SMTP-OUT-only:     DKIM_PRIVATE_KEY
 set -euo pipefail
@@ -169,21 +170,17 @@ if [ "$TIER" = "imap" ]; then
   htpasswd -b -c -s /etc/dovecot/master-users admin "${MASTER_PASSWORD}"
 fi
 
-# ── Step 5b: Push-enqueue environment (IMAP only) ─────────────
-# sendmail sanitizes the environment it hands delivery agents, so procmail's
-# push-enqueue.sh child cannot inherit the queue URL or the ECS task-role
-# credential URI from the container env. Persist them at startup; the
-# credential URI is stable for the life of the task. Absent PUSH_QUEUE_URL
-# (task definition predating push, or push retired) leaves no file and the
-# script no-ops. See docs/0.11.0/push-notifications.md.
-if [ "$TIER" = "imap" ] && [ -n "${PUSH_QUEUE_URL:-}" ]; then
-  echo "[entrypoint] Writing push-enqueue environment..."
-  cat > /etc/cabal-push-enqueue.env <<PUSHENV
-PUSH_QUEUE_URL=${PUSH_QUEUE_URL}
-AWS_REGION=${AWS_REGION}
-AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI:-}
-PUSHENV
-  chmod 644 /etc/cabal-push-enqueue.env
+# ── Step 5b: Push wake-signal spool (IMAP only) ───────────────
+# procmail's push-enqueue.sh (run as the recipient user, with sendmail's
+# sanitized environment and no AWS credentials) writes wake signals here;
+# the push-spool-drain.sh supervisord program (root, full container env)
+# forwards them to SQS. Sticky world-writable, like /tmp: any user may
+# create signal files, none may delete another's; the drain daemon
+# authenticates each file by owner. See docs/0.11.0/push-notifications.md.
+if [ "$TIER" = "imap" ]; then
+  echo "[entrypoint] Preparing push wake-signal spool..."
+  mkdir -p /var/spool/cabal-push
+  chmod 1777 /var/spool/cabal-push
 fi
 
 # ── Step 6: Prepare rsyslog working directory ─────────────────

--- a/docker/shared/push-enqueue.sh
+++ b/docker/shared/push-enqueue.sh
@@ -1,56 +1,65 @@
 #!/bin/bash
-# Enqueues a push-notification wake signal for one delivered message.
+# Spools a push-notification wake signal for one delivered message.
 #
 # Invoked by the :0c procmail recipe in docker/imap/configs/procmailrc with
-# the message on stdin: push-enqueue.sh <user> <folder>. Sends one JSON line
-# {user, folder, uid, msg_id} to the cabal-push-queue SQS queue; the
-# push_dispatch Lambda fans it out to APNs (docs/0.11.0/push-notifications.md).
+# the message on stdin: push-enqueue.sh <user> <folder>. Writes one JSON file
+# {user, folder, uid, msg_id} into /var/spool/cabal-push; the companion
+# push-spool-drain.sh daemon (supervisord, root) forwards spool files to the
+# cabal-push-queue SQS queue with the task-role credentials from its own
+# environment. Splitting spool from send keeps this delivery-path hook fast
+# and credential-free: procmail's children run as the recipient user with a
+# sendmail-sanitized environment, and handing them AWS credentials would
+# regress the container-hardening posture for a best-effort side effect.
+# See docs/0.11.0/push-notifications.md.
 #
 # Best-effort BY CONTRACT: this script must never fail (or slow) mail
 # delivery, so it deviates from the house `set -e` rule — every failure path
 # logs to stderr (procmail appends child stderr to its own $LOGFILE) and
-# exits 0. The UID is a hint: procmail runs before Dovecot assigns one, so we
-# pass Dovecot's next-uid and the consumer side resolves by Message-ID.
-#
-# Env comes from /etc/cabal-push-enqueue.env (written by entrypoint.sh):
-# sendmail sanitizes its delivery agents' environment, so the ECS task-role
-# credential URI and queue URL never survive into procmail's children.
+# exits 0.
 set -uo pipefail
+
+SPOOL_DIR=/var/spool/cabal-push
+# A spool this deep means the drain daemon has been failing for a long time;
+# newer signals would age out of relevance before ever sending. Shed instead.
+MAX_SPOOL_FILES=1000
 
 log() {
   echo "[push-enqueue] $*" >&2
 }
 
-drain() {
+drain_stdin() {
   # Always swallow the rest of the message so procmail's writer never sees
   # SIGPIPE on the carbon-copy pipe.
   cat > /dev/null 2>&1 || true
 }
 
-if [ ! -r /etc/cabal-push-enqueue.env ]; then
-  # Not an error: environments predating the PUSH_QUEUE_URL task definition
-  # (or with push disabled) simply have no env file.
-  drain
-  exit 0
-fi
-# shellcheck source=/dev/null
-. /etc/cabal-push-enqueue.env
-
 user="${1:-}"
 folder="${2:-INBOX}"
-if [ -z "$user" ] || [ -z "${PUSH_QUEUE_URL:-}" ]; then
-  log "skipping: user or PUSH_QUEUE_URL missing"
-  drain
+if [ -z "$user" ] || [ ! -d "$SPOOL_DIR" ]; then
+  # Missing spool dir = push not provisioned on this tier/image; not an error.
+  drain_stdin
   exit 0
 fi
 
-# First Message-ID header before the body separator, angle brackets included.
-msg_id=$(sed -n '/^$/q; s/^[Mm][Ee][Ss][Ss][Aa][Gg][Ee]-[Ii][Dd]:[[:space:]]*\(<[^>]*>\).*/\1/p' | head -n 1)
-drain
+# First Message-ID header value, unfolded (RFC 5322 allows the value on a
+# continuation line, which Exchange commonly does), angle brackets included.
+msg_id=$(awk '
+  /^$/ { exit }
+  tolower($0) ~ /^message-id:/ { grab = 1; value = $0; next }
+  grab && /^[ \t]/ { value = value $0; next }
+  grab { exit }
+  END {
+    if (match(value, /<[^>]*>/)) {
+      print substr(value, RSTART, RLENGTH)
+    }
+  }
+')
+drain_stdin
 
 # Dovecot's next-uid for the mailbox ("3 V<validity> N<next-uid> ..."); the
 # message being delivered will get this UID when Dovecot next scans the
-# Maildir, unless another delivery races us — hence hint, not truth.
+# Maildir, unless another delivery races us — hence hint, not truth. The
+# consumer side resolves by Message-ID.
 home_dir=$(getent passwd "$user" | cut -d: -f6)
 uid_hint=0
 if [ -n "$home_dir" ] && [ -r "$home_dir/Maildir/dovecot-uidlist" ]; then
@@ -59,21 +68,33 @@ if [ -n "$home_dir" ] && [ -r "$home_dir/Maildir/dovecot-uidlist" ]; then
   uid_hint="${uid_hint:-0}"
 fi
 
+count=$(find "$SPOOL_DIR" -maxdepth 1 -name 'sig.*' 2>/dev/null | wc -l)
+if [ "$count" -ge "$MAX_SPOOL_FILES" ]; then
+  log "spool full ($count files); dropping signal for $user"
+  exit 0
+fi
+
 body=$(jq -cn \
   --arg user "$user" \
   --arg folder "$folder" \
   --arg msg_id "$msg_id" \
   --argjson uid "$uid_hint" \
   '{user: $user, folder: $folder, uid: $uid, msg_id: $msg_id}') || {
-  log "failed to build message body for $user"
+  log "failed to build signal body for $user"
   exit 0
 }
 
-if ! aws sqs send-message \
-    --queue-url "$PUSH_QUEUE_URL" \
-    --message-body "$body" \
-    --region "${AWS_REGION:-us-east-1}" \
-    > /dev/null 2>&1; then
-  log "enqueue failed for $user ($folder)"
+# Write-then-rename so the drain daemon never reads a partial file. The
+# daemon authenticates the signal by comparing the file's owner to its
+# `user` field, so the file must be created by this (recipient) uid.
+tmp=$(mktemp "$SPOOL_DIR/.tmp.XXXXXXXX" 2>/dev/null) || {
+  log "cannot write to spool for $user"
+  exit 0
+}
+if printf '%s\n' "$body" > "$tmp" 2>/dev/null \
+    && mv -f "$tmp" "$SPOOL_DIR/sig.${tmp##*/.tmp.}" 2>/dev/null; then
+  exit 0
 fi
+log "failed to spool signal for $user"
+rm -f "$tmp" 2>/dev/null
 exit 0

--- a/docker/shared/push-enqueue.sh
+++ b/docker/shared/push-enqueue.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Enqueues a push-notification wake signal for one delivered message.
+#
+# Invoked by the :0c procmail recipe in docker/imap/configs/procmailrc with
+# the message on stdin: push-enqueue.sh <user> <folder>. Sends one JSON line
+# {user, folder, uid, msg_id} to the cabal-push-queue SQS queue; the
+# push_dispatch Lambda fans it out to APNs (docs/0.11.0/push-notifications.md).
+#
+# Best-effort BY CONTRACT: this script must never fail (or slow) mail
+# delivery, so it deviates from the house `set -e` rule — every failure path
+# logs to stderr (procmail appends child stderr to its own $LOGFILE) and
+# exits 0. The UID is a hint: procmail runs before Dovecot assigns one, so we
+# pass Dovecot's next-uid and the consumer side resolves by Message-ID.
+#
+# Env comes from /etc/cabal-push-enqueue.env (written by entrypoint.sh):
+# sendmail sanitizes its delivery agents' environment, so the ECS task-role
+# credential URI and queue URL never survive into procmail's children.
+set -uo pipefail
+
+log() {
+  echo "[push-enqueue] $*" >&2
+}
+
+drain() {
+  # Always swallow the rest of the message so procmail's writer never sees
+  # SIGPIPE on the carbon-copy pipe.
+  cat > /dev/null 2>&1 || true
+}
+
+if [ ! -r /etc/cabal-push-enqueue.env ]; then
+  # Not an error: environments predating the PUSH_QUEUE_URL task definition
+  # (or with push disabled) simply have no env file.
+  drain
+  exit 0
+fi
+# shellcheck source=/dev/null
+. /etc/cabal-push-enqueue.env
+
+user="${1:-}"
+folder="${2:-INBOX}"
+if [ -z "$user" ] || [ -z "${PUSH_QUEUE_URL:-}" ]; then
+  log "skipping: user or PUSH_QUEUE_URL missing"
+  drain
+  exit 0
+fi
+
+# First Message-ID header before the body separator, angle brackets included.
+msg_id=$(sed -n '/^$/q; s/^[Mm][Ee][Ss][Ss][Aa][Gg][Ee]-[Ii][Dd]:[[:space:]]*\(<[^>]*>\).*/\1/p' | head -n 1)
+drain
+
+# Dovecot's next-uid for the mailbox ("3 V<validity> N<next-uid> ..."); the
+# message being delivered will get this UID when Dovecot next scans the
+# Maildir, unless another delivery races us — hence hint, not truth.
+home_dir=$(getent passwd "$user" | cut -d: -f6)
+uid_hint=0
+if [ -n "$home_dir" ] && [ -r "$home_dir/Maildir/dovecot-uidlist" ]; then
+  uid_hint=$(head -n 1 "$home_dir/Maildir/dovecot-uidlist" \
+    | tr ' ' '\n' | sed -n 's/^N\([0-9]*\)$/\1/p')
+  uid_hint="${uid_hint:-0}"
+fi
+
+body=$(jq -cn \
+  --arg user "$user" \
+  --arg folder "$folder" \
+  --arg msg_id "$msg_id" \
+  --argjson uid "$uid_hint" \
+  '{user: $user, folder: $folder, uid: $uid, msg_id: $msg_id}') || {
+  log "failed to build message body for $user"
+  exit 0
+}
+
+if ! aws sqs send-message \
+    --queue-url "$PUSH_QUEUE_URL" \
+    --message-body "$body" \
+    --region "${AWS_REGION:-us-east-1}" \
+    > /dev/null 2>&1; then
+  log "enqueue failed for $user ($folder)"
+fi
+exit 0

--- a/docker/shared/push-spool-drain.sh
+++ b/docker/shared/push-spool-drain.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Forwards spooled push wake signals to SQS (imap tier).
+#
+# The delivery-path half (push-enqueue.sh, run by procmail as the recipient
+# user) only writes JSON files into /var/spool/cabal-push; this daemon —
+# started by supervisord as root, so it inherits the container environment
+# including the ECS task-role credential URI — sends each file to the
+# cabal-push-queue SQS queue and deletes it. Splitting spool from send keeps
+# AWS credentials away from the per-user delivery agents (the 0.10.x
+# container-hardening posture) and keeps SQS latency and outages out of the
+# procmail hot path entirely. See docs/0.11.0/push-notifications.md.
+#
+# Env (from the task definition via supervisord):
+#   PUSH_QUEUE_URL  target queue; unset = push not provisioned, idle forever
+#   AWS_REGION      required by the aws CLI
+set -euo pipefail
+
+SPOOL_DIR=/var/spool/cabal-push
+POLL_SECONDS=2
+# A wake signal loses its point long before the queue's 1h retention; shed
+# anything the drain could not send for that long.
+MAX_AGE_SECONDS=3600
+
+echo "[push-spool-drain] Starting..."
+
+if [ -z "${PUSH_QUEUE_URL:-}" ]; then
+  # Idle RUNNING rather than exit: a one-shot exit would just be restarted
+  # by supervisord's autorestart (same convention as clear-maintenance.sh).
+  echo "[push-spool-drain] PUSH_QUEUE_URL not set; push disabled, idling."
+  exec sleep infinity
+fi
+
+mkdir -p "$SPOOL_DIR"
+chmod 1777 "$SPOOL_DIR"
+
+send_one() {
+  local file="$1"
+
+  # Age out stale signals (drain was down / SQS unreachable for a long time).
+  local now file_mtime
+  now=$(date +%s)
+  file_mtime=$(stat -c %Y "$file" 2>/dev/null || echo 0)
+  if [ $((now - file_mtime)) -gt "$MAX_AGE_SECONDS" ]; then
+    echo "[push-spool-drain] dropping stale signal $(basename "$file")"
+    rm -f "$file"
+    return 0
+  fi
+
+  # Authenticity: the spool is world-writable (sticky), so any local user
+  # could drop a file claiming to be someone else. The recipe runs as the
+  # recipient, so a legitimate file is owned by the user it names (or by
+  # root, when procmail processed /etc/procmailrc before dropping
+  # privileges). Anything else is spoofed — delete it.
+  local owner claimed
+  owner=$(stat -c %U "$file" 2>/dev/null || echo "")
+  claimed=$(jq -re '.user // empty' "$file" 2>/dev/null) || {
+    echo "[push-spool-drain] dropping malformed signal $(basename "$file")"
+    rm -f "$file"
+    return 0
+  }
+  if [ "$owner" != "root" ] && [ "$owner" != "$claimed" ]; then
+    echo "[push-spool-drain] dropping spoofed signal $(basename "$file"):" \
+         "owner=$owner claims user=$claimed"
+    rm -f "$file"
+    return 0
+  fi
+
+  if aws sqs send-message \
+      --queue-url "$PUSH_QUEUE_URL" \
+      --message-body "$(cat "$file")" \
+      --region "${AWS_REGION:-us-east-1}" \
+      > /dev/null 2>&1; then
+    rm -f "$file"
+    return 0
+  fi
+  # Leave the file for the next pass and stop this pass: if SQS is down,
+  # retrying the rest of the spool right now only burns CPU.
+  echo "[push-spool-drain] send failed for $(basename "$file"); will retry"
+  return 1
+}
+
+echo "[push-spool-drain] Draining $SPOOL_DIR to $PUSH_QUEUE_URL"
+while true; do
+  for file in "$SPOOL_DIR"/sig.*; do
+    [ -e "$file" ] || continue
+    send_one "$file" || break
+  done
+  sleep "$POLL_SECONDS"
+done

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -46,6 +46,10 @@ By default the Terraform state bucket uses SSE-S3, so any principal with `s3:Get
 
 Envelope payloads from `/list_envelopes` and `/search_envelopes` carry the RFC 5322 threading identity (`message_id` / `in_reply_to` / `references`), and the `/save_draft` Lambda gives drafts a server-side lifecycle (save returns UIDPLUS coordinates, save can atomically replace a prior copy, discard removes one — all Drafts-scoped and UIDVALIDITY-guarded). The Apple clients sync compose drafts across devices through that path. See [Draft sync and threading headers](./draft-sync-and-threading.md) for the wire contract, the safety posture, and the client sync loop.
 
+# Push notifications
+
+The Apple clients get new-mail notifications through APNs without Apple's infrastructure ever seeing message content: procmail enqueues a content-free wake signal per delivery, the `push_dispatch` Lambda fans it out to the user's registered devices, and each device enriches the alert locally via `/push_envelope` before display. Push is inert until an APNs auth key is provisioned per environment. See [Push notifications](./push-notifications.md) for the architecture, the key provisioning and rotation runbooks, and the operational notes (DLQ, metrics, token hygiene).
+
 # IMAP full-text search index
 
 The `imap` container ships [dovecot-fts-flatcurve](https://github.com/slusarz/dovecot-fts-flatcurve) (pinned upstream tag and commit baked into `docker/imap/Dockerfile`, licence preserved at `/usr/share/doc/fts-flatcurve/` inside the image). The plugin gives `/search_envelopes` an inverted index instead of a sequential body scan; configuration lives in `docker/imap/configs/dovecot/90-fts.conf`.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -9,7 +9,8 @@ enriches it locally before display.
 
 ```mermaid
 flowchart LR
-    imap["imap container<br/>procmail :0c recipe"] -->|"{user, folder, uid, msg_id}"| sqs["cabal-push-queue"]
+    imap["imap container<br/>procmail :0c recipe"] -->|"spool file"| drain["push-spool-drain<br/>(supervisord)"]
+    drain -->|"{user, folder, uid, msg_id}"| sqs["cabal-push-queue"]
     sqs --> dispatch["push_dispatch Lambda"]
     dispatch --> tokens["cabal-push-tokens"]
     dispatch -->|"content-free alert"| apns["APNs"]
@@ -18,10 +19,13 @@ flowchart LR
 ```
 
 1. Procmail fires a carbon-copy (`:0c`) recipe after each local delivery on
-   the `imap` tier. `push-enqueue.sh` sends one JSON wake signal to the
-   `cabal-push-queue` SQS queue, best-effort: a slow or unreachable queue
-   never blocks or fails mail delivery. Messages the spam rule files away are
-   never enqueued.
+   the `imap` tier. `push-enqueue.sh` writes one JSON wake signal into
+   `/var/spool/cabal-push`; the `push-spool-drain` supervisord program
+   forwards spool files to the `cabal-push-queue` SQS queue and ages out
+   anything it cannot send within an hour. The split keeps the delivery path
+   fast and credential-free: the per-user delivery agents never hold AWS
+   credentials, and a slow or unreachable queue never blocks or fails mail
+   delivery. Messages the spam rule files away are never enqueued.
 2. The `push_dispatch` Lambda consumes the queue, looks up the recipient's
    registered device tokens in the `cabal-push-tokens` DynamoDB table,
    filters by each token's folder opt-in, and sends one APNs request per
@@ -127,8 +131,15 @@ works on real devices:
   `Cabal/Push` namespace via CloudWatch EMF.
 - **Quiesce.** A quiesced environment delivers no mail, so nothing is
   enqueued. Residual signals from before the quiesce age out of the queue
-  within the hour. The Lambda itself costs nothing while idle and is not
-  scaled down.
+  (and the container spool) within the hour. The Lambda itself costs nothing
+  while idle and is not scaled down.
+- **Spool.** `/var/spool/cabal-push` inside the imap container is sticky
+  world-writable (like `/tmp`); the drain daemon authenticates each signal
+  file by comparing its owner to the user it names, drops malformed or
+  stale files, and the enqueue side sheds new signals if the spool backs up
+  past 1000 files. The spool is container-local scratch — it is not on EFS
+  and does not survive a task replacement, which loses at most the last
+  seconds of wake signals, not mail.
 - **Token hygiene.** `last_seen_at` on each `cabal-push-tokens` row is
   updated on every successful push and registration; `last_failure` records
   the most recent APNs rejection reason. Rows for uninstalled devices are

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,0 +1,138 @@
+# Push notifications
+
+The Apple clients receive new-mail notifications via the Apple Push
+Notification service (APNs). The design keeps message content out of Apple's
+infrastructure: the server sends a content-free wake signal, and the device
+enriches it locally before display.
+
+## How it works
+
+```mermaid
+flowchart LR
+    imap["imap container<br/>procmail :0c recipe"] -->|"{user, folder, uid, msg_id}"| sqs["cabal-push-queue"]
+    sqs --> dispatch["push_dispatch Lambda"]
+    dispatch --> tokens["cabal-push-tokens"]
+    dispatch -->|"content-free alert"| apns["APNs"]
+    apns --> device["device NSE"]
+    device -->|"/push_envelope"| api["API Gateway"]
+```
+
+1. Procmail fires a carbon-copy (`:0c`) recipe after each local delivery on
+   the `imap` tier. `push-enqueue.sh` sends one JSON wake signal to the
+   `cabal-push-queue` SQS queue, best-effort: a slow or unreachable queue
+   never blocks or fails mail delivery. Messages the spam rule files away are
+   never enqueued.
+2. The `push_dispatch` Lambda consumes the queue, looks up the recipient's
+   registered device tokens in the `cabal-push-tokens` DynamoDB table,
+   filters by each token's folder opt-in, and sends one APNs request per
+   device. The payload is `"New mail"` plus a message reference — no sender,
+   subject, or body.
+3. On the device, the app's Notification Service Extension calls
+   `/push_envelope` with the user's own Cognito JWT to fetch
+   sender/subject/snippet and rewrites the notification before it is shown.
+   If that fails (offline, token expired, timeout), the generic `"New mail"`
+   alert ships instead.
+4. Devices register tokens through `/push_register` (on every app launch and
+   token rotation) and remove them through `/push_deregister` (sign-out).
+   `push_dispatch` also prunes tokens APNs reports as gone (`410
+   Unregistered`, `BadDeviceToken`), so an uninstalled app stops receiving
+   pushes without operator involvement.
+
+What APNs sees per push: the device token it already knows, the app's bundle
+id, an AWS egress IP, and a payload containing only the alert text `"New
+mail"`, a folder name, a UID integer, and a Message-ID string.
+
+## Provisioning the APNs key
+
+Push is inert until an APNs auth key is provisioned; without one,
+`push_dispatch` logs that it is unconfigured and drops wake signals (they do
+not pile up in the DLQ). Per environment:
+
+1. In [App Store Connect](https://appstoreconnect.apple.com) → Users and
+   Access → Integrations → Keys, create a key with the **Apple Push
+   Notifications service** enabled. Download the `.p8` file (one chance) and
+   note the **Key ID** and your **Team ID**.
+2. Populate the SSM parameters (from CloudShell in the target account):
+
+   ```bash
+   aws ssm put-parameter --name /cabal/apns/team_id --type SecureString \
+     --value 'YOURTEAMID' --overwrite
+   aws ssm put-parameter --name /cabal/apns/key_id --type SecureString \
+     --value 'YOURKEYID' --overwrite
+   aws ssm put-parameter --name /cabal/apns/private_key --type SecureString \
+     --value file://AuthKey_YOURKEYID.p8 --overwrite
+   ```
+
+3. Development-signed builds (Xcode direct installs) register **sandbox**
+   tokens; TestFlight and App Store builds register **production** tokens.
+   The endpoint is per-environment:
+
+   ```bash
+   # only for an environment serving development-signed builds:
+   aws ssm put-parameter --name /cabal/apns/endpoint --type SecureString \
+     --value 'https://api.sandbox.push.apple.com' --overwrite
+   ```
+
+   The default is the production endpoint. A token sent to the wrong
+   endpoint fails with `BadDeviceToken` and is pruned; re-launching the app
+   re-registers it.
+
+One key works for every app under the same team (iOS and macOS); the
+dispatch Lambda selects the APNs topic from each token's registered bundle
+id. The same key can be shared across environments or issued per environment
+— Apple allows two active APNs keys per team, which is also what makes
+rotation possible.
+
+## Rotating the APNs key
+
+The `.p8` key is high-value: whoever holds it can send arbitrary
+notifications to every Cabalmail device. It is stored only in SSM
+(SecureString), readable only by the `push_dispatch` Lambda role. To rotate:
+
+1. Create a second APNs key in App Store Connect (do not revoke the old one
+   yet).
+2. Update `/cabal/apns/key_id` and `/cabal/apns/private_key` in each
+   environment.
+3. Wait for in-flight Lambda containers to recycle (or force it:
+   `aws lambda update-function-configuration --function-name push_dispatch
+   --description "key rotation $(date +%F)"`), and confirm pushes still
+   arrive.
+4. Revoke the old key in App Store Connect.
+
+Revoking first inverts the order of operations and takes push down until the
+new key lands everywhere.
+
+## Client-side manual steps
+
+The iOS/macOS app needs one-time Apple developer setup before registration
+works on real devices:
+
+- Enable the **Push Notifications** capability on the app's App ID (and the
+  Notification Service Extension's App ID) in the developer portal, then
+  regenerate any manual provisioning profiles CI uses — an entitlement change
+  invalidates them.
+- The Notification Service Extension ships as its own bundle id with its own
+  App Store profile; CI expects its profile UUID alongside the app's.
+
+## Operational notes
+
+- **Queue and DLQ.** `cabal-push-queue` retains signals for one hour (a
+  stale "new mail" push is noise, not news) and dead-letters to
+  `cabal-push-dlq` after 5 failed receives. DLQ depth is visible in the SQS
+  console; messages there are safe to purge — the mail itself was delivered
+  normally.
+- **Logs and metrics.** Dispatch logs at `/cabal/lambda/push_dispatch`
+  (CloudWatch), including token prunes and per-send failures. Each
+  invocation emits `Sent` / `Failed` / `LatencyMs` metrics in the
+  `Cabal/Push` namespace via CloudWatch EMF.
+- **Quiesce.** A quiesced environment delivers no mail, so nothing is
+  enqueued. Residual signals from before the quiesce age out of the queue
+  within the hour. The Lambda itself costs nothing while idle and is not
+  scaled down.
+- **Token hygiene.** `last_seen_at` on each `cabal-push-tokens` row is
+  updated on every successful push and registration; `last_failure` records
+  the most recent APNs rejection reason. Rows for uninstalled devices are
+  pruned automatically on the next push attempt.
+- **Enrichment during IMAP rolls.** `/push_envelope` returns 503 while a
+  planned IMAP redeploy is in flight; devices fall back to the generic
+  alert. Nothing needs doing.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -52,10 +52,15 @@ Push is inert until an APNs auth key is provisioned; without one,
 `push_dispatch` logs that it is unconfigured and drops wake signals (they do
 not pile up in the DLQ). Per environment:
 
-1. In [App Store Connect](https://appstoreconnect.apple.com) → Users and
-   Access → Integrations → Keys, create a key with the **Apple Push
-   Notifications service** enabled. Download the `.p8` file (one chance) and
-   note the **Key ID** and your **Team ID**.
+1. In the [Apple Developer portal](https://developer.apple.com/account) →
+   Certificates, Identifiers & Profiles → Keys, create a key with the
+   **Apple Push Notifications service (APNs)** capability checked. This is
+   an APNs *authentication key*, not an App Store Connect API key — if the
+   form asks you to choose a role (Admin/Developer/...), you are on the
+   wrong screen. Download the `.p8` file (one chance) and note the **Key
+   ID** (shown on the key's page) and your **Team ID** (Membership
+   details). The key has no expiry and no role; creating it requires the
+   Admin or Account Holder role on your Apple account.
 2. Populate the SSM parameters (from CloudShell in the target account):
 
    ```bash
@@ -93,15 +98,15 @@ The `.p8` key is high-value: whoever holds it can send arbitrary
 notifications to every Cabalmail device. It is stored only in SSM
 (SecureString), readable only by the `push_dispatch` Lambda role. To rotate:
 
-1. Create a second APNs key in App Store Connect (do not revoke the old one
-   yet).
+1. Create a second APNs key in the Developer portal (do not revoke the old
+   one yet).
 2. Update `/cabal/apns/key_id` and `/cabal/apns/private_key` in each
    environment.
 3. Wait for in-flight Lambda containers to recycle (or force it:
    `aws lambda update-function-configuration --function-name push_dispatch
    --description "key rotation $(date +%F)"`), and confirm pushes still
    arrive.
-4. Revoke the old key in App Store Connect.
+4. Revoke the old key in the Developer portal.
 
 Revoking first inverts the order of operations and takes push down until the
 new key lands everywhere.

--- a/lambda/api/push_deregister/function.py
+++ b/lambda/api/push_deregister/function.py
@@ -1,0 +1,38 @@
+'''Deletes an APNs device-token registration for the calling user.
+
+The Apple clients call this on sign-out (and when the user turns push off in
+the app). Deleting a row that is already gone is a success: the goal state is
+"this device no longer receives pushes". push_dispatch also prunes rows on
+APNs Unregistered/BadDeviceToken, so this endpoint is the polite path, not the
+only one. See docs/0.11.0/push-notifications.md.
+'''
+import json
+import os
+import re
+import boto3  # pylint: disable=import-error
+
+ddb = boto3.resource('dynamodb')
+TABLE_NAME = os.environ.get('PUSH_TOKENS_TABLE_NAME', 'cabal-push-tokens')
+table = ddb.Table(TABLE_NAME)
+
+# Same shape rule as push_register; see the comment there.
+DEVICE_TOKEN_RE = re.compile(r'^[0-9a-f]{16,400}$')
+
+
+def handler(event, _context):
+    '''Deletes the caller's device-token row.'''
+    user = event['requestContext']['authorizer']['claims']['cognito:username']
+    try:
+        body = json.loads(event.get('body') or '{}')
+    except (TypeError, ValueError):
+        return {'statusCode': 400, 'body': json.dumps({'Error': 'Invalid JSON body.'})}
+
+    device_token = str(body.get('device_token', '')).lower()
+    if not DEVICE_TOKEN_RE.match(device_token):
+        return {'statusCode': 400, 'body': json.dumps({'Error': 'Invalid device_token.'})}
+
+    try:
+        table.delete_item(Key={'user': user, 'device_token': device_token})
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        return {'statusCode': 500, 'body': json.dumps({'Error': str(err)})}
+    return {'statusCode': 200, 'body': json.dumps({'status': 'deregistered'})}

--- a/lambda/api/push_deregister/requirements.txt
+++ b/lambda/api/push_deregister/requirements.txt
@@ -1,0 +1,1 @@
+# boto3 only (provided by the Lambda runtime); no bundled dependencies.

--- a/lambda/api/push_dispatch/apns.py
+++ b/lambda/api/push_dispatch/apns.py
@@ -118,7 +118,8 @@ class ApnsClient:  # pylint: disable=too-few-public-methods
             for event in self.conn.receive_data(data):
                 if isinstance(event, h2.events.ResponseReceived) \
                         and event.stream_id == stream_id:
-                    status = int(dict(event.headers)[b':status'])
+                    # h2 yields header names/values as bytes by default.
+                    status = int(dict(event.headers)[b':status'].decode())
                 elif isinstance(event, h2.events.DataReceived) \
                         and event.stream_id == stream_id:
                     chunks.append(event.data)

--- a/lambda/api/push_dispatch/apns.py
+++ b/lambda/api/push_dispatch/apns.py
@@ -89,6 +89,9 @@ class ApnsClient:  # pylint: disable=too-few-public-methods
     def _connect(self):
         '''Opens the TLS socket and performs the HTTP/2 connection preface.'''
         context = ssl.create_default_context()
+        # create_default_context still admits TLS 1.0/1.1; APNs requires 1.2+
+        # (and HTTP/2 forbids anything older), so pin the floor explicitly.
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.set_alpn_protocols(['h2'])
         raw = socket.create_connection((self.host, 443), timeout=REQUEST_TIMEOUT_SECONDS)
         self.sock = context.wrap_socket(raw, server_hostname=self.host)

--- a/lambda/api/push_dispatch/apns.py
+++ b/lambda/api/push_dispatch/apns.py
@@ -1,0 +1,172 @@
+'''Minimal APNs provider-API client.
+
+Two pieces the standard library lacks, built from pure-python wheels (see
+requirements.txt for why no httpx/cryptography):
+
+  * ES256 provider tokens (RFC 7519 JWT signed with the App Store Connect
+    .p8 key) via python-ecdsa.
+  * HTTP/2 request framing via h2 over an ALPN-negotiated TLS socket. APNs
+    speaks HTTP/2 only.
+
+One connection per warm Lambda container, reused across invocations and
+reopened transparently when APNs (or an idle timeout) drops it. The client is
+synchronous and single-stream: push_dispatch handles one wake signal per
+invocation for a handful of device tokens, so pipelining would buy nothing.
+'''
+import base64
+import hashlib
+import json
+import socket
+import ssl
+import time
+
+import ecdsa  # pylint: disable=import-error
+import ecdsa.util  # pylint: disable=import-error
+import h2.connection  # pylint: disable=import-error
+import h2.events  # pylint: disable=import-error
+
+# APNs provider tokens are valid for 20-60 minutes; refresh at 45 so a token
+# is never presented near the edge of the window.
+TOKEN_LIFETIME_SECONDS = 45 * 60
+
+REQUEST_TIMEOUT_SECONDS = 10
+
+
+class ApnsError(Exception):
+    '''A non-2xx APNs response. `permanent` marks token-level rejections the
+    caller should react to by pruning the device token, not by retrying.'''
+
+    def __init__(self, status, reason):
+        super().__init__(f'APNs {status}: {reason}')
+        self.status = status
+        self.reason = reason
+        self.permanent = status == 410 or reason == 'BadDeviceToken'
+
+
+def _b64url(data):
+    '''Base64url without padding, as JWTs require.'''
+    return base64.urlsafe_b64encode(data).rstrip(b'=')
+
+
+class ApnsClient:  # pylint: disable=too-few-public-methods
+    '''Sends alert pushes to one APNs endpoint using provider-token auth.
+    `send` is deliberately the whole surface.'''
+
+    def __init__(self, endpoint, team_id, key_id, private_key_pem):
+        self.host = endpoint.removeprefix('https://').strip('/')
+        self.team_id = team_id
+        self.key_id = key_id
+        self.signing_key = ecdsa.SigningKey.from_pem(private_key_pem)
+        self.token = (None, 0)  # (jwt, issued-at epoch seconds)
+        self.sock = None
+        self.conn = None
+
+    def _provider_token(self):
+        '''Returns a cached ES256 JWT, re-signing after TOKEN_LIFETIME.'''
+        now = int(time.time())
+        jwt, issued_at = self.token
+        if jwt and now - issued_at < TOKEN_LIFETIME_SECONDS:
+            return jwt
+        header = _b64url(json.dumps({'alg': 'ES256', 'kid': self.key_id}).encode())
+        claims = _b64url(json.dumps({'iss': self.team_id, 'iat': now}).encode())
+        signing_input = header + b'.' + claims
+        signature = self.signing_key.sign_deterministic(
+            signing_input,
+            hashfunc=hashlib.sha256,
+            sigencode=ecdsa.util.sigencode_string,  # raw r||s, per JOSE
+        )
+        jwt = (signing_input + b'.' + _b64url(signature)).decode()
+        self.token = (jwt, now)
+        return jwt
+
+    def _connect(self):
+        '''Opens the TLS socket and performs the HTTP/2 connection preface.'''
+        context = ssl.create_default_context()
+        context.set_alpn_protocols(['h2'])
+        raw = socket.create_connection((self.host, 443), timeout=REQUEST_TIMEOUT_SECONDS)
+        self.sock = context.wrap_socket(raw, server_hostname=self.host)
+        self.sock.settimeout(REQUEST_TIMEOUT_SECONDS)
+        self.conn = h2.connection.H2Connection()
+        self.conn.initiate_connection()
+        self.sock.sendall(self.conn.data_to_send())
+
+    def _close(self):
+        if self.sock is not None:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+        self.sock = None
+        self.conn = None
+
+    def _request(self, headers, body):
+        '''Sends one request on the open connection; returns (status, body).'''
+        stream_id = self.conn.get_next_available_stream_id()
+        self.conn.send_headers(stream_id, headers)
+        self.conn.send_data(stream_id, body, end_stream=True)
+        self.sock.sendall(self.conn.data_to_send())
+
+        status = None
+        chunks = []
+        deadline = time.monotonic() + REQUEST_TIMEOUT_SECONDS
+        while True:
+            if time.monotonic() > deadline:
+                raise TimeoutError('timed out waiting for APNs response')
+            data = self.sock.recv(65536)
+            if not data:
+                raise ConnectionError('APNs closed the connection mid-request')
+            for event in self.conn.receive_data(data):
+                if isinstance(event, h2.events.ResponseReceived) \
+                        and event.stream_id == stream_id:
+                    status = int(dict(event.headers)[b':status'])
+                elif isinstance(event, h2.events.DataReceived) \
+                        and event.stream_id == stream_id:
+                    chunks.append(event.data)
+                    self.conn.acknowledge_received_data(
+                        event.flow_controlled_length, stream_id)
+                elif isinstance(event, h2.events.StreamEnded) \
+                        and event.stream_id == stream_id:
+                    self.sock.sendall(self.conn.data_to_send())
+                    return status, b''.join(chunks)
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    raise ConnectionError('APNs terminated the connection')
+            # Flush any acknowledgements/pings h2 queued while processing.
+            self.sock.sendall(self.conn.data_to_send())
+
+    def send(self, device_token, topic, payload, collapse_id):
+        '''Sends one alert push. Returns the apns-id-free None on success and
+        raises ApnsError (permanent or not) on a non-2xx response; transport
+        errors get one transparent reconnect-and-retry before propagating.'''
+        body = json.dumps(payload).encode()
+        headers = [
+            (':method', 'POST'),
+            (':scheme', 'https'),
+            (':authority', self.host),
+            (':path', f'/3/device/{device_token}'),
+            ('authorization', f'bearer {self._provider_token()}'),
+            ('apns-topic', topic),
+            ('apns-push-type', 'alert'),
+            ('apns-priority', '10'),
+            # apns-collapse-id caps at 64 bytes; longer would 400 the request.
+            ('apns-collapse-id', collapse_id[:64]),
+        ]
+        for attempt in (1, 2):
+            try:
+                if self.conn is None:
+                    self._connect()
+                status, response = self._request(headers, body)
+                break
+            except (OSError, ConnectionError, TimeoutError, ssl.SSLError):
+                # A dropped keep-alive connection surfaces here; reconnect
+                # once, then let a genuine outage propagate for SQS retry.
+                self._close()
+                if attempt == 2:
+                    raise
+        if 200 <= status < 300:
+            return
+        reason = ''
+        try:
+            reason = json.loads(response.decode() or '{}').get('reason', '')
+        except ValueError:
+            pass
+        raise ApnsError(status, reason)

--- a/lambda/api/push_dispatch/apns.py
+++ b/lambda/api/push_dispatch/apns.py
@@ -24,6 +24,7 @@ import ecdsa  # pylint: disable=import-error
 import ecdsa.util  # pylint: disable=import-error
 import h2.connection  # pylint: disable=import-error
 import h2.events  # pylint: disable=import-error
+import h2.exceptions  # pylint: disable=import-error
 
 # APNs provider tokens are valid for 20-60 minutes; refresh at 45 so a token
 # is never presented near the edge of the window.
@@ -41,6 +42,12 @@ class ApnsError(Exception):
         self.status = status
         self.reason = reason
         self.permanent = status == 410 or reason == 'BadDeviceToken'
+
+
+class ApnsTransportError(Exception):
+    '''The request never produced an APNs verdict: connect/TLS failure,
+    timeout, dropped connection, or an HTTP/2 protocol violation — after the
+    one transparent reconnect-and-retry. Always worth an SQS redelivery.'''
 
 
 def _b64url(data):
@@ -135,9 +142,10 @@ class ApnsClient:  # pylint: disable=too-few-public-methods
             self.sock.sendall(self.conn.data_to_send())
 
     def send(self, device_token, topic, payload, collapse_id):
-        '''Sends one alert push. Returns the apns-id-free None on success and
-        raises ApnsError (permanent or not) on a non-2xx response; transport
-        errors get one transparent reconnect-and-retry before propagating.'''
+        '''Sends one alert push. Returns None on success, raises ApnsError
+        (permanent or not) on a non-2xx response, and raises
+        ApnsTransportError when no verdict was obtained — after one
+        transparent reconnect-and-retry.'''
         body = json.dumps(payload).encode()
         headers = [
             (':method', 'POST'),
@@ -157,12 +165,16 @@ class ApnsClient:  # pylint: disable=too-few-public-methods
                     self._connect()
                 status, response = self._request(headers, body)
                 break
-            except (OSError, ConnectionError, TimeoutError, ssl.SSLError):
-                # A dropped keep-alive connection surfaces here; reconnect
-                # once, then let a genuine outage propagate for SQS retry.
+            except (OSError, ConnectionError, ssl.SSLError,
+                    h2.exceptions.ProtocolError) as err:
+                # A dropped keep-alive connection (or an h2 state-machine
+                # violation, which poisons the connection object) surfaces
+                # here. Always close — a poisoned self.conn would otherwise
+                # fail every request this warm container ever makes — then
+                # reconnect once, then report a genuine outage.
                 self._close()
                 if attempt == 2:
-                    raise
+                    raise ApnsTransportError(str(err)) from err
         if 200 <= status < 300:
             return
         reason = ''

--- a/lambda/api/push_dispatch/function.py
+++ b/lambda/api/push_dispatch/function.py
@@ -19,6 +19,7 @@ Failure posture:
 
 The event source mapping uses batch_size 1 so a single failing signal retries
 on its own rather than dragging a whole batch with it.'''
+import hashlib
 import json
 import os
 import time
@@ -26,7 +27,7 @@ import time
 import boto3  # pylint: disable=import-error
 from boto3.dynamodb.conditions import Key  # pylint: disable=import-error
 
-from apns import ApnsClient, ApnsError  # pylint: disable=import-error
+from apns import ApnsClient, ApnsError, ApnsTransportError  # pylint: disable=import-error
 
 ddb = boto3.resource('dynamodb')
 TABLE_NAME = os.environ.get('PUSH_TOKENS_TABLE_NAME', 'cabal-push-tokens')
@@ -37,33 +38,49 @@ ssm = boto3.client('ssm')
 # push_dispatch.tf); a value still carrying it means "not configured".
 PLACEHOLDER_PREFIX = 'placeholder-'
 
+# How long a warm container trusts a "not configured" verdict before
+# re-reading SSM. Without the recheck, a container that went warm before the
+# operator provisioned the APNs key would ack-and-drop signals until Lambda
+# happened to recycle it — hours, under steady mail flow.
+NOT_CONFIGURED_TTL_SECONDS = 300
+
+# Skip the per-send last_seen_at write when the row was refreshed this
+# recently; the attribute exists to GC dead tokens, not to timestamp pushes.
+LAST_SEEN_REFRESH_SECONDS = 12 * 3600
+
 # Warm-container caches: the APNs config/connection survive across
 # invocations, which is what makes provider-token reuse worthwhile.
 _APNS_CLIENT = None
-_APNS_CONFIGURED = None
+_APNS_RECHECK_AT = 0.0
 
 
 def _apns_client():
-    '''Returns the shared ApnsClient, or None when APNs is not configured.'''
-    global _APNS_CLIENT, _APNS_CONFIGURED  # pylint: disable=global-statement
-    if _APNS_CONFIGURED is not None:
+    '''Returns the shared ApnsClient, or None when APNs is not configured.
+    A configured client is cached for the container's life; the unconfigured
+    verdict is re-checked after NOT_CONFIGURED_TTL_SECONDS so provisioning
+    the SSM parameters takes effect without waiting out warm containers.'''
+    global _APNS_CLIENT, _APNS_RECHECK_AT  # pylint: disable=global-statement
+    if _APNS_CLIENT is not None:
         return _APNS_CLIENT
+    if time.monotonic() < _APNS_RECHECK_AT:
+        return None
+    response = ssm.get_parameters_by_path(
+        Path='/cabal/apns', WithDecryption=True)
     config = {
-        name: ssm.get_parameter(
-            Name=f'/cabal/apns/{name}', WithDecryption=True
-        )['Parameter']['Value']
-        for name in ('team_id', 'key_id', 'private_key', 'endpoint')
+        param['Name'].rsplit('/', 1)[-1]: param['Value']
+        for param in response['Parameters']
     }
-    if any(value.startswith(PLACEHOLDER_PREFIX) for value in config.values()):
+    required = ('team_id', 'key_id', 'private_key', 'endpoint')
+    if any(config.get(name, PLACEHOLDER_PREFIX).startswith(PLACEHOLDER_PREFIX)
+           for name in required):
         print('[push-dispatch] APNs credentials not provisioned; '
               'wake signals will be dropped')
-        _APNS_CONFIGURED = False
+        _APNS_RECHECK_AT = time.monotonic() + NOT_CONFIGURED_TTL_SECONDS
         return None
     _APNS_CLIENT = ApnsClient(
         config['endpoint'], config['team_id'], config['key_id'],
         config['private_key'],
     )
-    _APNS_CONFIGURED = True
     return _APNS_CLIENT
 
 
@@ -95,6 +112,19 @@ def _emit_metrics(sent, failed, latency_ms):
     }))
 
 
+def _is_stale(last_seen_at, now):
+    '''True when the ISO-8601 last_seen_at is absent, unparseable, or older
+    than LAST_SEEN_REFRESH_SECONDS relative to `now` (same format).'''
+    if not last_seen_at:
+        return True
+    try:
+        then = time.mktime(time.strptime(str(last_seen_at)[:19], '%Y-%m-%dT%H:%M:%S'))
+        current = time.mktime(time.strptime(now[:19], '%Y-%m-%dT%H:%M:%S'))
+    except ValueError:
+        return True
+    return current - then > LAST_SEEN_REFRESH_SECONDS
+
+
 def _mark(user, device_token, attribute, value):
     '''Best-effort bookkeeping write on a token row; never fails a dispatch.'''
     try:
@@ -124,8 +154,12 @@ def _payload(signal):
     }
     # Collapse on message identity so a redelivered signal replaces, rather
     # than stacks on, the notification it already produced. The UID hint can
-    # be 0 (procmail runs before Dovecot assigns one), so fold msg_id in.
-    return payload, f'{folder}:{uid}:{msg_id}'
+    # be 0 (procmail runs before Dovecot assigns one), so fold msg_id in —
+    # hashed, because APNs caps apns-collapse-id at 64 bytes and truncating a
+    # raw Message-ID would collapse distinct messages that share a long
+    # provider prefix (Exchange ids differ only near the end).
+    msg_digest = hashlib.sha256(msg_id.encode()).hexdigest()[:16] if msg_id else ''
+    return payload, f'{folder}:{uid}:{msg_digest}'[:64]
 
 
 def _dispatch(client, signal):
@@ -161,8 +195,21 @@ def _dispatch(client, signal):
                 print(f'[push-dispatch] send failed for {user}: {err}')
                 _mark(user, device_token, 'last_failure', err.reason or str(err.status))
             continue
+        except ApnsTransportError as err:
+            # Caught per token, not per signal: a transport failure on one
+            # send must not abort the loop and strand the remaining devices
+            # (the handler docstring's "raises only when nothing delivered"
+            # depends on this).
+            failed += 1
+            retryable += 1
+            print(f'[push-dispatch] transport failure for {user}: {err}')
+            continue
         sent += 1
-        _mark(user, device_token, 'last_seen_at', now)
+        # Freshness bookkeeping only; skip the write when the row is already
+        # recent so a busy mailbox doesn't pay one UpdateItem per device per
+        # delivered message.
+        if _is_stale(row.get('last_seen_at'), now):
+            _mark(user, device_token, 'last_seen_at', now)
     return sent, failed, retryable
 
 

--- a/lambda/api/push_dispatch/function.py
+++ b/lambda/api/push_dispatch/function.py
@@ -1,0 +1,188 @@
+'''SQS consumer that fans a new-mail wake signal out to APNs.
+
+The imap container's procmail recipe enqueues {user, folder, uid, msg_id} per
+local delivery (docker/shared/push-enqueue.sh); this consumer looks up the
+user's registered device tokens in cabal-push-tokens and sends one
+content-free APNs alert per opted-in token. The payload deliberately carries
+no sender/subject/body — the device's Notification Service Extension calls
+/push_envelope to enrich the alert locally, so Apple's infrastructure never
+sees message content (docs/0.11.0/push-notifications.md).
+
+Failure posture:
+  * APNs not configured (placeholder SSM values): drop the signal cleanly.
+    Environments without an Apple app must not accumulate a DLQ backlog.
+  * Token-level rejection (410 Unregistered / BadDeviceToken): delete the
+    token row; the device is gone or the token rotated.
+  * Transport/auth/5xx errors: raise only when nothing was delivered, so SQS
+    redelivers without double-notifying devices that already got the alert
+    (apns-collapse-id additionally dedups the display on redelivery).
+
+The event source mapping uses batch_size 1 so a single failing signal retries
+on its own rather than dragging a whole batch with it.'''
+import json
+import os
+import time
+
+import boto3  # pylint: disable=import-error
+from boto3.dynamodb.conditions import Key  # pylint: disable=import-error
+
+from apns import ApnsClient, ApnsError  # pylint: disable=import-error
+
+ddb = boto3.resource('dynamodb')
+TABLE_NAME = os.environ.get('PUSH_TOKENS_TABLE_NAME', 'cabal-push-tokens')
+table = ddb.Table(TABLE_NAME)
+ssm = boto3.client('ssm')
+
+# Sentinel prefix Terraform seeds /cabal/apns/* with (modules/app/
+# push_dispatch.tf); a value still carrying it means "not configured".
+PLACEHOLDER_PREFIX = 'placeholder-'
+
+# Warm-container caches: the APNs config/connection survive across
+# invocations, which is what makes provider-token reuse worthwhile.
+_APNS_CLIENT = None
+_APNS_CONFIGURED = None
+
+
+def _apns_client():
+    '''Returns the shared ApnsClient, or None when APNs is not configured.'''
+    global _APNS_CLIENT, _APNS_CONFIGURED  # pylint: disable=global-statement
+    if _APNS_CONFIGURED is not None:
+        return _APNS_CLIENT
+    config = {
+        name: ssm.get_parameter(
+            Name=f'/cabal/apns/{name}', WithDecryption=True
+        )['Parameter']['Value']
+        for name in ('team_id', 'key_id', 'private_key', 'endpoint')
+    }
+    if any(value.startswith(PLACEHOLDER_PREFIX) for value in config.values()):
+        print('[push-dispatch] APNs credentials not provisioned; '
+              'wake signals will be dropped')
+        _APNS_CONFIGURED = False
+        return None
+    _APNS_CLIENT = ApnsClient(
+        config['endpoint'], config['team_id'], config['key_id'],
+        config['private_key'],
+    )
+    _APNS_CONFIGURED = True
+    return _APNS_CLIENT
+
+
+def _wants_folder(row, folder):
+    '''Applies the per-token folder opt-in: no enabled_folders attribute means
+    INBOX only, "*" means everything, otherwise exact membership.'''
+    enabled = row.get('enabled_folders') or {'INBOX'}
+    return '*' in enabled or folder in enabled
+
+
+def _emit_metrics(sent, failed, latency_ms):
+    '''One CloudWatch EMF line per invocation: free metrics, no API calls.'''
+    print(json.dumps({
+        '_aws': {
+            'Timestamp': int(time.time() * 1000),
+            'CloudWatchMetrics': [{
+                'Namespace': 'Cabal/Push',
+                'Dimensions': [[]],
+                'Metrics': [
+                    {'Name': 'Sent', 'Unit': 'Count'},
+                    {'Name': 'Failed', 'Unit': 'Count'},
+                    {'Name': 'LatencyMs', 'Unit': 'Milliseconds'},
+                ],
+            }],
+        },
+        'Sent': sent,
+        'Failed': failed,
+        'LatencyMs': latency_ms,
+    }))
+
+
+def _mark(user, device_token, attribute, value):
+    '''Best-effort bookkeeping write on a token row; never fails a dispatch.'''
+    try:
+        table.update_item(
+            Key={'user': user, 'device_token': device_token},
+            UpdateExpression='SET #a = :v',
+            ExpressionAttributeNames={'#a': attribute},
+            ExpressionAttributeValues={':v': value},
+        )
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        print(f'[push-dispatch] bookkeeping write failed: {err}')
+
+
+def _payload(signal):
+    '''Builds the content-free APNs payload and its collapse id.'''
+    folder = signal['folder']
+    uid = int(signal.get('uid') or 0)
+    msg_id = signal.get('msg_id') or ''
+    payload = {
+        'aps': {
+            'alert': 'New mail',
+            'mutable-content': 1,
+            'category': 'MAIL_MESSAGE',
+            'sound': 'default',
+        },
+        'msgRef': {'folder': folder, 'uid': uid, 'msg_id': msg_id},
+    }
+    # Collapse on message identity so a redelivered signal replaces, rather
+    # than stacks on, the notification it already produced. The UID hint can
+    # be 0 (procmail runs before Dovecot assigns one), so fold msg_id in.
+    return payload, f'{folder}:{uid}:{msg_id}'
+
+
+def _dispatch(client, signal):
+    '''Sends one wake signal to every opted-in token.
+
+    Returns (sent, failed, retryable): `failed` counts every non-delivery,
+    `retryable` only the subset a redelivery could plausibly fix. Transport
+    errors (APNs unreachable) propagate to the caller so the whole record
+    retries.'''
+    user = signal['user']
+    folder = signal['folder']
+    rows = table.query(KeyConditionExpression=Key('user').eq(user))['Items']
+    payload, collapse_id = _payload(signal)
+
+    sent, failed, retryable = 0, 0, 0
+    now = time.strftime('%Y-%m-%dT%H:%M:%S+00:00', time.gmtime())
+    for row in rows:
+        if not _wants_folder(row, folder):
+            continue
+        device_token = row['device_token']
+        try:
+            client.send(device_token, row['bundle_id'], payload, collapse_id)
+        except ApnsError as err:
+            failed += 1
+            if err.permanent:
+                # A pruned token is resolved, not retryable: redelivering the
+                # signal would find the row already gone.
+                print(f'[push-dispatch] pruning token for {user}: {err}')
+                table.delete_item(
+                    Key={'user': user, 'device_token': device_token})
+            else:
+                retryable += 1
+                print(f'[push-dispatch] send failed for {user}: {err}')
+                _mark(user, device_token, 'last_failure', err.reason or str(err.status))
+            continue
+        sent += 1
+        _mark(user, device_token, 'last_seen_at', now)
+    return sent, failed, retryable
+
+
+def handler(event, _context):
+    '''Processes one queue record (batch_size = 1). Raises only when the
+    signal produced no deliveries but should have, so SQS redelivers.'''
+    client = _apns_client()
+    for record in event.get('Records', []):
+        signal = json.loads(record['body'])
+        if not signal.get('user') or not signal.get('folder'):
+            print(f'[push-dispatch] malformed signal dropped: {record["body"][:200]}')
+            continue
+        if client is None:
+            continue
+        received_ms = int(record.get('attributes', {}).get('SentTimestamp', 0))
+        sent, failed, retryable = _dispatch(client, signal)
+        latency_ms = int(time.time() * 1000) - received_ms if received_ms else 0
+        _emit_metrics(sent, failed, latency_ms)
+        if retryable and not sent:
+            raise RuntimeError(
+                f'no deliveries for {signal["user"]}/{signal["folder"]}: '
+                f'{failed} failed')
+    return {'statusCode': 200}

--- a/lambda/api/push_dispatch/requirements.txt
+++ b/lambda/api/push_dispatch/requirements.txt
@@ -1,0 +1,21 @@
+# Pure-python only, on purpose: the APNs provider API requires HTTP/2 and
+# ES256 provider tokens, and the obvious stacks for both (httpx[http2],
+# cryptography) drag in platform-specific binary wheels that the x86_64 CI
+# runner cannot install for this arm64 function. h2 (+hpack/hyperframe) gives
+# HTTP/2 framing and python-ecdsa gives ES256, all as universal wheels — the
+# same trade fetch_bimi made when it kept its pip closure pure. The one ES256
+# signature per ~45 minutes per warm container makes ecdsa's pure-python
+# slowness irrelevant.
+h2==4.2.0 \
+    --hash=sha256:479a53ad425bb29af087f3458a61d30780bc818e4ebcf01f0b536ba916462ed0
+hpack==4.1.0 \
+    --hash=sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496
+hyperframe==6.1.0 \
+    --hash=sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5
+ecdsa==0.19.1 \
+    --hash=sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3
+# six is ecdsa's only runtime dependency; pinned and hashed so
+# pip --require-hashes can resolve the full tree.
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81

--- a/lambda/api/push_envelope/function.py
+++ b/lambda/api/push_envelope/function.py
@@ -1,0 +1,141 @@
+'''Returns the minimal envelope (sender/subject/snippet) for one message.
+
+Called by the Apple clients' Notification Service Extension to enrich a
+content-free APNs wake signal on-device, so Apple's push infrastructure never
+sees message content (docs/0.11.0/push-notifications.md). The NSE runs against
+a hard OS deadline and treats any failure as "show the generic alert", so this
+endpoint favors fast, definite answers over completeness.
+
+The wake signal carries the Message-ID and a best-effort UID hint (procmail
+enqueues before Dovecot assigns the UID). When msg_id is present it is
+authoritative: the folder is searched for it and the resolved UID is returned
+so the client can route "Open" to the right message.
+'''
+import json
+from html.parser import HTMLParser
+
+from helper import get_imap_client  # pylint: disable=import-error
+from helper import get_message  # pylint: disable=import-error
+from helper import maintenance_guard  # pylint: disable=import-error
+from helper import parse_json_body  # pylint: disable=import-error
+from helper import validate_content_id  # pylint: disable=import-error
+from helper import validate_folder_name  # pylint: disable=import-error
+from helper import validate_uid  # pylint: disable=import-error
+
+# The notification preview area is small and iOS truncates aggressively; these
+# just bound the response body, they are not display decisions.
+MAX_FIELD_LENGTH = 256
+MAX_SNIPPET_LENGTH = 240
+
+
+# pylint: disable-next=abstract-method  # ParserBase.error is gone in py3.10+
+class _TextExtractor(HTMLParser):
+    '''Collects the text content of an HTML body, skipping script/style.'''
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.chunks = []
+        self._suppressed = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ('script', 'style'):
+            self._suppressed += 1
+
+    def handle_endtag(self, tag):
+        if tag in ('script', 'style') and self._suppressed:
+            self._suppressed -= 1
+
+    def handle_data(self, data):
+        if not self._suppressed:
+            self.chunks.append(data)
+
+
+def _strip_html(markup):
+    '''Returns the visible text of an HTML fragment, whitespace-normalized.'''
+    extractor = _TextExtractor()
+    try:
+        extractor.feed(markup)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return ''
+    return ' '.join(''.join(extractor.chunks).split())
+
+
+def _decoded_text(part):
+    '''Returns a MIME part's payload as text, or empty string on any failure.'''
+    payload = part.get_payload(decode=True)
+    if payload is None:
+        return ''
+    try:
+        return payload.decode(part.get_content_charset() or 'utf-8', errors='replace')
+    except LookupError:
+        return payload.decode('utf-8', errors='replace')
+
+
+def _snippet(message):
+    '''Extracts a short plain-text preview: first text/plain part, else the
+    tag-stripped first text/html part, else empty (never an error).'''
+    plain, markup = '', ''
+    parts = message.walk() if message.is_multipart() else [message]
+    for part in parts:
+        if 'attachment' in str(part.get('Content-Disposition')):
+            continue
+        content_type = part.get_content_type()
+        if content_type == 'text/plain' and not plain:
+            plain = _decoded_text(part)
+        elif content_type == 'text/html' and not markup:
+            markup = _decoded_text(part)
+        if plain:
+            break
+    text = ' '.join(plain.split()) if plain else _strip_html(markup)
+    return text[:MAX_SNIPPET_LENGTH]
+
+
+def _resolve_uid(user, folder, uid, msg_id):
+    '''Returns the UID to fetch: the Message-ID search result when available
+    (the enqueue-side UID is only a hint), else the caller's hint.'''
+    if not msg_id:
+        return uid
+    client = get_imap_client(None, user, folder, read_only=True)
+    try:
+        matches = client.search(['HEADER', 'Message-ID', msg_id])
+    finally:
+        client.logout()
+    if matches:
+        return max(matches)
+    return uid
+
+
+@maintenance_guard
+def handler(event, _context):
+    '''Returns {from, subject, snippet, uid} for the referenced message.'''
+    user = event['requestContext']['authorizer']['claims']['cognito:username']
+    body, error = parse_json_body(event)
+    if error:
+        return error
+    try:
+        folder = validate_folder_name(str(body.get('folder', ''))).replace('/', '.')
+        uid = validate_uid(body.get('uid')) if body.get('uid') else None
+        msg_id = validate_content_id(body['msg_id']) if body.get('msg_id') else None
+    except ValueError as err:
+        return {'statusCode': 400, 'body': json.dumps({'Error': str(err)})}
+    if uid is None and msg_id is None:
+        return {'statusCode': 400, 'body': json.dumps({'Error': 'uid or msg_id is required'})}
+
+    uid = _resolve_uid(user, folder, uid, msg_id)
+    if uid is None:
+        return {'statusCode': 404, 'body': json.dumps({'Error': 'message not found'})}
+    try:
+        message = get_message(None, user, folder, uid)
+    except KeyError:
+        # client.fetch returned no entry for the UID: expunged or a stale hint.
+        return {'statusCode': 404, 'body': json.dumps({'Error': 'message not found'})}
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps({
+            'from': str(message.get('From', ''))[:MAX_FIELD_LENGTH],
+            'subject': str(message.get('Subject', ''))[:MAX_FIELD_LENGTH],
+            'snippet': _snippet(message),
+            'uid': uid,
+        })
+    }

--- a/lambda/api/push_envelope/function.py
+++ b/lambda/api/push_envelope/function.py
@@ -11,13 +11,19 @@ enqueues before Dovecot assigns the UID). When msg_id is present it is
 authoritative: the folder is searched for it and the resolved UID is returned
 so the client can route "Open" to the right message.
 '''
+import email
 import json
+from email.policy import default
 from html.parser import HTMLParser
 
+from helper import CACHE_BUCKET  # pylint: disable=import-error
 from helper import get_imap_client  # pylint: disable=import-error
 from helper import get_message  # pylint: disable=import-error
+from helper import get_object  # pylint: disable=import-error
+from helper import key_exists  # pylint: disable=import-error
 from helper import maintenance_guard  # pylint: disable=import-error
 from helper import parse_json_body  # pylint: disable=import-error
+from helper import upload_object  # pylint: disable=import-error
 from helper import validate_content_id  # pylint: disable=import-error
 from helper import validate_folder_name  # pylint: disable=import-error
 from helper import validate_uid  # pylint: disable=import-error
@@ -90,19 +96,31 @@ def _snippet(message):
     return text[:MAX_SNIPPET_LENGTH]
 
 
-def _resolve_uid(user, folder, uid, msg_id):
-    '''Returns the UID to fetch: the Message-ID search result when available
-    (the enqueue-side UID is only a hint), else the caller's hint.'''
-    if not msg_id:
-        return uid
+def _load_by_message_id(user, folder, uid_hint, msg_id):
+    '''Resolves the real UID by Message-ID search and loads the message on
+    the SAME connection (the NSE runs against a hard deadline; a second TLS +
+    LOGIN + SELECT handshake is the biggest avoidable cost here), honoring
+    and warming the S3 cache like get_message. Returns (uid, message-or-None).
+    '''
     client = get_imap_client(None, user, folder, read_only=True)
     try:
         matches = client.search(['HEADER', 'Message-ID', msg_id])
+        uid = max(matches) if matches else uid_hint
+        if uid is None:
+            return None, None
+        key = f'{user}/{folder}/{uid}/raw'
+        if key_exists(CACHE_BUCKET, key):
+            raw = get_object(CACHE_BUCKET, key)
+        else:
+            fetched = client.fetch([uid], ['RFC822'])
+            if uid not in fetched:
+                # Expunged, or a stale hint with no Message-ID match.
+                return uid, None
+            raw = fetched[uid][b'RFC822']
+            upload_object(CACHE_BUCKET, key, 'text/plain', raw)
     finally:
         client.logout()
-    if matches:
-        return max(matches)
-    return uid
+    return uid, email.message_from_bytes(raw, policy=default)
 
 
 @maintenance_guard
@@ -115,19 +133,27 @@ def handler(event, _context):
     try:
         folder = validate_folder_name(str(body.get('folder', ''))).replace('/', '.')
         uid = validate_uid(body.get('uid')) if body.get('uid') else None
-        msg_id = validate_content_id(body['msg_id']) if body.get('msg_id') else None
     except ValueError as err:
         return {'statusCode': 400, 'body': json.dumps({'Error': str(err)})}
+    # msg_id is advisory identity, not a gate: validate_content_id caps at a
+    # length real Message-IDs exceed (RFC 5322 allows ~990 chars), and a
+    # rejected msg_id must degrade to the uid hint, not 400 the enrichment.
+    try:
+        msg_id = validate_content_id(body['msg_id']) if body.get('msg_id') else None
+    except ValueError:
+        msg_id = None
     if uid is None and msg_id is None:
         return {'statusCode': 400, 'body': json.dumps({'Error': 'uid or msg_id is required'})}
 
-    uid = _resolve_uid(user, folder, uid, msg_id)
-    if uid is None:
-        return {'statusCode': 404, 'body': json.dumps({'Error': 'message not found'})}
-    try:
-        message = get_message(None, user, folder, uid)
-    except KeyError:
-        # client.fetch returned no entry for the UID: expunged or a stale hint.
+    if msg_id:
+        uid, message = _load_by_message_id(user, folder, uid, msg_id)
+    else:
+        try:
+            message = get_message(None, user, folder, uid)
+        except KeyError:
+            message = None
+    if uid is None or message is None:
+        # No UID resolvable, expunged, or a stale hint.
         return {'statusCode': 404, 'body': json.dumps({'Error': 'message not found'})}
 
     return {

--- a/lambda/api/push_envelope/requirements.txt
+++ b/lambda/api/push_envelope/requirements.txt
@@ -1,0 +1,11 @@
+imapclient==2.3.1 \
+    --hash=sha256:057f28025d2987c63e065afb0e4370b0b850b539b0e1494cea0427e88130108c \
+    --hash=sha256:26ea995664fae3a88b878ebce2aff7402931697b86658b7882043ddb01b0e6ba
+# six is imapclient's only runtime dependency; pinned and hashed so
+# pip --require-hashes can resolve the full tree.
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+dnspython==2.3.0 \
+    --hash=sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46 \
+    --hash=sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9

--- a/lambda/api/push_register/function.py
+++ b/lambda/api/push_register/function.py
@@ -74,18 +74,23 @@ def handler(event, _context):
     if bundle_id not in ALLOWED_BUNDLE_IDS:
         return {'statusCode': 400, 'body': json.dumps({'Error': 'Unknown bundle_id.'})}
 
-    try:
-        enabled_folders = _validate_enabled_folders(body['enabled_folders']) \
-            if body.get('enabled_folders') else []
-    except ValueError as err:
-        return {'statusCode': 400, 'body': json.dumps({'Error': str(err)})}
+    # Tri-state, matching set_preferences' merge semantics: key absent =
+    # leave the row's existing selection alone (the app re-registers on
+    # every launch and must not wipe preferences it isn't sending); key
+    # present but empty = explicit reset to the inbox-only default; key
+    # present with folders = replace.
+    enabled_folders = None
+    if 'enabled_folders' in body:
+        try:
+            enabled_folders = _validate_enabled_folders(body['enabled_folders'] or [])
+        except ValueError as err:
+            return {'statusCode': 400, 'body': json.dumps({'Error': str(err)})}
 
     now = datetime.datetime.now(datetime.timezone.utc).isoformat()
     # Merge-style upsert: created_at survives re-registration, last_seen_at
     # tracks it, and a previous last_failure is cleared by the fresh proof of
-    # life. enabled_folders is REMOVEd when the client sends none, so a reset
-    # back to the inbox-only default actually lands. Every attribute name is
-    # #-aliased: several of them collide with DynamoDB reserved words.
+    # life. Every attribute name is #-aliased: several of them collide with
+    # DynamoDB reserved words.
     sets = [
         '#b = :b', '#p = :p', '#v = :v', '#l = :l',
         '#c = if_not_exists(#c, :now)', '#s = :now',
@@ -106,7 +111,9 @@ def handler(event, _context):
     if enabled_folders:
         sets.append('#ef = :f')
         values[':f'] = set(enabled_folders)
-    else:
+    elif enabled_folders is not None:
+        # Explicit empty list: reset to the inbox-only default (DynamoDB
+        # string sets cannot be empty, so "default" is attribute absence).
         removes.append('#ef')
 
     try:

--- a/lambda/api/push_register/function.py
+++ b/lambda/api/push_register/function.py
@@ -27,7 +27,11 @@ ALLOWED_BUNDLE_IDS = {
 }
 
 MAX_ENABLED_FOLDERS = 100
-FOLDER_RE = re.compile(r'^[A-Za-z0-9 _\-./]{1,255}$')
+# Mirrors helper.validate_folder_name's grammar (charset, 255-byte cap,
+# no ''/'.'/'..' segments) without importing helper: these names are only
+# ever compared against push_dispatch's folder strings, and helper's import
+# would drag imapclient plus an SSM read into this otherwise-tiny zip.
+FOLDER_RE = re.compile(r'^[A-Za-z0-9 _\-./]+$')
 
 MAX_INFO_LENGTH = 64
 
@@ -44,7 +48,9 @@ def _validate_enabled_folders(value):
     for folder in value:
         if folder == '*':
             return ['*']
-        if not isinstance(folder, str) or not FOLDER_RE.match(folder):
+        if not isinstance(folder, str) or not FOLDER_RE.match(folder) \
+                or len(folder.encode('utf-8')) > 255 \
+                or any(seg in ('', '.', '..') for seg in folder.split('/')):
             raise ValueError(f'invalid folder name: {folder!r}')
         cleaned.append(folder.replace('/', '.'))
     return cleaned
@@ -98,7 +104,7 @@ def handler(event, _context):
     names = {
         '#b': 'bundle_id', '#p': 'platform', '#v': 'app_version',
         '#l': 'locale', '#c': 'created_at', '#s': 'last_seen_at',
-        '#lf': 'last_failure', '#ef': 'enabled_folders',
+        '#lf': 'last_failure',
     }
     values = {
         ':b': bundle_id,
@@ -108,12 +114,17 @@ def handler(event, _context):
         ':now': now,
     }
     removes = ['#lf']
+    # '#ef' joins names only when an expression uses it: DynamoDB rejects the
+    # whole update ("Value provided in ExpressionAttributeNames unused") if an
+    # alias appears without a reference, which is the common key-absent case.
     if enabled_folders:
+        names['#ef'] = 'enabled_folders'
         sets.append('#ef = :f')
         values[':f'] = set(enabled_folders)
     elif enabled_folders is not None:
         # Explicit empty list: reset to the inbox-only default (DynamoDB
         # string sets cannot be empty, so "default" is attribute absence).
+        names['#ef'] = 'enabled_folders'
         removes.append('#ef')
 
     try:

--- a/lambda/api/push_register/function.py
+++ b/lambda/api/push_register/function.py
@@ -1,0 +1,121 @@
+'''Registers (upserts) an APNs device token for the calling user.
+
+The Apple clients call this on every launch after sign-in and again whenever
+APNs rotates the token, so the write must be an idempotent upsert. One row per
+(user, device token); push_dispatch fans a wake signal out to every row it
+finds for the recipient. See docs/0.11.0/push-notifications.md.
+'''
+import datetime
+import json
+import os
+import re
+import boto3  # pylint: disable=import-error
+
+ddb = boto3.resource('dynamodb')
+TABLE_NAME = os.environ.get('PUSH_TOKENS_TABLE_NAME', 'cabal-push-tokens')
+table = ddb.Table(TABLE_NAME)
+
+# APNs device tokens are opaque hex; currently 32 bytes (64 hex chars) but
+# Apple documents the length as subject to change, so bound rather than pin.
+DEVICE_TOKEN_RE = re.compile(r'^[0-9a-f]{16,400}$')
+
+# bundle_id doubles as the APNs topic in push_dispatch, so only known app ids
+# are accepted; platform is informational and derived rather than trusted.
+ALLOWED_BUNDLE_IDS = {
+    'com.cabalmail.Cabalmail': 'ios',
+    'com.cabalmail.CabalmailMac': 'macos',
+}
+
+MAX_ENABLED_FOLDERS = 100
+FOLDER_RE = re.compile(r'^[A-Za-z0-9 _\-./]{1,255}$')
+
+MAX_INFO_LENGTH = 64
+
+
+def _validate_enabled_folders(value):
+    '''Returns a cleaned list of folder names (or ["*"]), or raises ValueError.
+
+    Absent/empty means "INBOX only" and is stored as no attribute at all
+    (DynamoDB string sets cannot be empty).
+    '''
+    if not isinstance(value, list) or len(value) > MAX_ENABLED_FOLDERS:
+        raise ValueError('enabled_folders must be a list of folder names')
+    cleaned = []
+    for folder in value:
+        if folder == '*':
+            return ['*']
+        if not isinstance(folder, str) or not FOLDER_RE.match(folder):
+            raise ValueError(f'invalid folder name: {folder!r}')
+        cleaned.append(folder.replace('/', '.'))
+    return cleaned
+
+
+def _info_field(body, key):
+    '''Returns a short informational string field, clipped, never trusted.'''
+    value = body.get(key, '')
+    if not isinstance(value, str):
+        return ''
+    return value[:MAX_INFO_LENGTH]
+
+
+def handler(event, _context):
+    '''Upserts the caller's device-token row.'''
+    user = event['requestContext']['authorizer']['claims']['cognito:username']
+    try:
+        body = json.loads(event.get('body') or '{}')
+    except (TypeError, ValueError):
+        return {'statusCode': 400, 'body': json.dumps({'Error': 'Invalid JSON body.'})}
+
+    device_token = str(body.get('device_token', '')).lower()
+    if not DEVICE_TOKEN_RE.match(device_token):
+        return {'statusCode': 400, 'body': json.dumps({'Error': 'Invalid device_token.'})}
+
+    bundle_id = body.get('bundle_id')
+    if bundle_id not in ALLOWED_BUNDLE_IDS:
+        return {'statusCode': 400, 'body': json.dumps({'Error': 'Unknown bundle_id.'})}
+
+    try:
+        enabled_folders = _validate_enabled_folders(body['enabled_folders']) \
+            if body.get('enabled_folders') else []
+    except ValueError as err:
+        return {'statusCode': 400, 'body': json.dumps({'Error': str(err)})}
+
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    # Merge-style upsert: created_at survives re-registration, last_seen_at
+    # tracks it, and a previous last_failure is cleared by the fresh proof of
+    # life. enabled_folders is REMOVEd when the client sends none, so a reset
+    # back to the inbox-only default actually lands. Every attribute name is
+    # #-aliased: several of them collide with DynamoDB reserved words.
+    sets = [
+        '#b = :b', '#p = :p', '#v = :v', '#l = :l',
+        '#c = if_not_exists(#c, :now)', '#s = :now',
+    ]
+    names = {
+        '#b': 'bundle_id', '#p': 'platform', '#v': 'app_version',
+        '#l': 'locale', '#c': 'created_at', '#s': 'last_seen_at',
+        '#lf': 'last_failure', '#ef': 'enabled_folders',
+    }
+    values = {
+        ':b': bundle_id,
+        ':p': ALLOWED_BUNDLE_IDS[bundle_id],
+        ':v': _info_field(body, 'app_version'),
+        ':l': _info_field(body, 'locale'),
+        ':now': now,
+    }
+    removes = ['#lf']
+    if enabled_folders:
+        sets.append('#ef = :f')
+        values[':f'] = set(enabled_folders)
+    else:
+        removes.append('#ef')
+
+    try:
+        table.update_item(
+            Key={'user': user, 'device_token': device_token},
+            UpdateExpression=f"SET {', '.join(sets)} REMOVE {', '.join(removes)}",
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+    except Exception as err:  # pylint: disable=broad-exception-caught
+        return {'statusCode': 500, 'body': json.dumps({'Error': str(err)})}
+    return {'statusCode': 200, 'body': json.dumps({'status': 'registered'})}

--- a/lambda/api/push_register/requirements.txt
+++ b/lambda/api/push_register/requirements.txt
@@ -1,0 +1,1 @@
+# boto3 only (provided by the Lambda runtime); no bundled dependencies.

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -210,6 +210,7 @@ module "admin" {
   dev_mode            = var.prod ? false : true
 
   address_changed_topic_arn = module.ecs.sns_topic_arn
+  push_queue_arn            = module.ecs.push_queue_arn
   admin_group_name          = module.pool.admin_group_name
 
   dmarc_healthcheck_ping_param = local.hc_ping_dmarc

--- a/terraform/infra/modules/app/locals.tf
+++ b/terraform/infra/modules/app/locals.tf
@@ -368,6 +368,33 @@ locals {
       memory    = 128
       cache     = false
       cache_ttl = 0
+    },
+    push_register = {
+      runtime = "python3.13"
+
+      method    = "POST"
+      memory    = 128
+      cache     = false
+      cache_ttl = 0
+    },
+    push_deregister = {
+      runtime = "python3.13"
+
+      method    = "POST"
+      memory    = 128
+      cache     = false
+      cache_ttl = 0
+    },
+    push_envelope = {
+      runtime = "python3.13"
+
+      method = "POST"
+      # Fetches and MIME-parses the full message on a cache miss (same code
+      # path as fetch_message) to extract the sender/subject/snippet, so it
+      # needs more than the 128 MB floor.
+      memory    = 512
+      cache     = false
+      cache_ttl = 0
     }
   }
 }

--- a/terraform/infra/modules/app/modules/call/lambda.tf
+++ b/terraform/infra/modules/app/modules/call/lambda.tf
@@ -126,7 +126,8 @@ resource "aws_iam_role_policy" "lambda" {
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-caa-reports",
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-user-preferences",
                 "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-user-domain-access",
-                "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-rate-limits"
+                "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-rate-limits",
+                "arn:aws:dynamodb:${var.region}:${var.account}:table/cabal-push-tokens"
             ]
         },
         {
@@ -210,6 +211,7 @@ resource "aws_lambda_function" "api_call" {
       DMARC_TABLE_NAME            = "cabal-dmarc-reports"
       CAA_TABLE_NAME              = "cabal-caa-reports"
       USER_PREFERENCES_TABLE_NAME = "cabal-user-preferences"
+      PUSH_TOKENS_TABLE_NAME      = "cabal-push-tokens"
       IMAP_POOL_ENABLED           = var.imap_pool_enabled ? "true" : "false"
     }
   }

--- a/terraform/infra/modules/app/push_dispatch.tf
+++ b/terraform/infra/modules/app/push_dispatch.tf
@@ -19,11 +19,18 @@
 # drops wake signals instead of retrying them into the DLQ, so environments
 # without an APNs key (or with no Apple app installed) stay quiet.
 
+locals {
+  # The "placeholder-" prefix is load-bearing: push_dispatch's function.py
+  # (PLACEHOLDER_PREFIX) matches on it to decide the environment is not yet
+  # provisioned. Keep the two in sync.
+  apns_placeholder = "placeholder-set-via-aws-ssm-put-parameter"
+}
+
 resource "aws_ssm_parameter" "apns_team_id" {
   name        = "/cabal/apns/team_id"
   description = "Apple Developer Team ID for APNs token auth. Populate via aws ssm put-parameter --overwrite."
   type        = "SecureString"
-  value       = "placeholder-set-via-aws-ssm-put-parameter"
+  value       = local.apns_placeholder
 
   lifecycle {
     ignore_changes = [value]
@@ -34,7 +41,7 @@ resource "aws_ssm_parameter" "apns_key_id" {
   name        = "/cabal/apns/key_id"
   description = "Key ID of the APNs auth key (.p8). Populate via aws ssm put-parameter --overwrite."
   type        = "SecureString"
-  value       = "placeholder-set-via-aws-ssm-put-parameter"
+  value       = local.apns_placeholder
 
   lifecycle {
     ignore_changes = [value]
@@ -45,7 +52,7 @@ resource "aws_ssm_parameter" "apns_private_key" {
   name        = "/cabal/apns/private_key"
   description = "APNs auth key (.p8 PEM content). High-value: rotate via App Store Connect per docs/push-notifications.md. Populate via aws ssm put-parameter --overwrite."
   type        = "SecureString"
-  value       = "placeholder-set-via-aws-ssm-put-parameter"
+  value       = local.apns_placeholder
 
   lifecycle {
     ignore_changes = [value]
@@ -91,9 +98,15 @@ resource "aws_iam_role_policy" "push_dispatch" {
     Version = "2012-10-17"
     Statement = [
       {
+        # GetParametersByPath authorizes against the path itself as well as
+        # the parameters under it, hence both resource forms.
         Effect = "Allow"
-        Action = ["ssm:GetParameter"]
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParametersByPath",
+        ]
         Resource = [
+          "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/cabal/apns",
           "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/cabal/apns/*",
         ]
       },

--- a/terraform/infra/modules/app/push_dispatch.tf
+++ b/terraform/infra/modules/app/push_dispatch.tf
@@ -1,0 +1,190 @@
+# APNs push-notification dispatch pipeline (docs/0.11.0/push-notifications.md):
+# the consumer Lambda for the wake-signal queue, its IAM, the event source
+# mapping, and the SSM parameters holding the APNs credentials.
+#
+# The producer side (cabal-push-queue + DLQ, the imap task-role grant, and the
+# PUSH_QUEUE_URL env var) lives in modules/ecs/push.tf next to the imap task
+# definition. This consumer looks up the user's device tokens in
+# cabal-push-tokens and sends one content-free APNs alert per token; the
+# Notification Service Extension on the device then calls /push_envelope to
+# enrich the alert locally, so Apple's infrastructure never sees message
+# content.
+
+# -- APNs credentials --------------------------------------------
+# Operator-populated after creating an APNs auth key in App Store Connect
+# (see docs/push-notifications.md for the runbook):
+#   aws ssm put-parameter --name /cabal/apns/private_key \
+#     --type SecureString --value file://AuthKey_XXXXXXXXXX.p8 --overwrite
+# The dispatch Lambda treats the placeholder value as "not configured" and
+# drops wake signals instead of retrying them into the DLQ, so environments
+# without an APNs key (or with no Apple app installed) stay quiet.
+
+resource "aws_ssm_parameter" "apns_team_id" {
+  name        = "/cabal/apns/team_id"
+  description = "Apple Developer Team ID for APNs token auth. Populate via aws ssm put-parameter --overwrite."
+  type        = "SecureString"
+  value       = "placeholder-set-via-aws-ssm-put-parameter"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "apns_key_id" {
+  name        = "/cabal/apns/key_id"
+  description = "Key ID of the APNs auth key (.p8). Populate via aws ssm put-parameter --overwrite."
+  type        = "SecureString"
+  value       = "placeholder-set-via-aws-ssm-put-parameter"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "apns_private_key" {
+  name        = "/cabal/apns/private_key"
+  description = "APNs auth key (.p8 PEM content). High-value: rotate via App Store Connect per docs/push-notifications.md. Populate via aws ssm put-parameter --overwrite."
+  type        = "SecureString"
+  value       = "placeholder-set-via-aws-ssm-put-parameter"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# Not a secret, but SecureString keeps the whole /cabal/apns/ namespace on one
+# access pattern (GetParameter WithDecryption) and one Checkov posture.
+resource "aws_ssm_parameter" "apns_endpoint" {
+  name        = "/cabal/apns/endpoint"
+  description = "APNs provider API base URL. Default is production; point non-prod at https://api.sandbox.push.apple.com when testing development-signed builds."
+  type        = "SecureString"
+  value       = "https://api.push.apple.com"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+# -- IAM role for the dispatch Lambda ----------------------------
+
+resource "aws_iam_role" "push_dispatch" {
+  name = "push_dispatch_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Sid       = "pushDispatchSid"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "push_dispatch" {
+  name = "push_dispatch_policy"
+  role = aws_iam_role.push_dispatch.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["ssm:GetParameter"]
+        Resource = [
+          "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter/cabal/apns/*",
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:Query",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+        ]
+        Resource = "arn:aws:dynamodb:${var.region}:${data.aws_caller_identity.current.account_id}:table/cabal-push-tokens"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ]
+        Resource = var.push_queue_arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "${aws_cloudwatch_log_group.push_dispatch.arn}:*"
+      }
+    ]
+  })
+}
+
+# -- Lambda function ---------------------------------------------
+
+resource "aws_cloudwatch_log_group" "push_dispatch" {
+  name              = "/cabal/lambda/push_dispatch"
+  retention_in_days = 365
+}
+
+data "aws_s3_object" "push_dispatch_hash" {
+  bucket = var.bucket
+  key    = "lambda/push_dispatch.zip.base64sha256"
+}
+
+#tfsec:ignore:aws-lambda-enable-tracing
+resource "aws_lambda_function" "push_dispatch" {
+  # Same posture as the append_sent consumer this function mirrors:
+  #checkov:skip=CKV_AWS_115: shared-pool concurrency is the point; a per-function reserve would starve the API lambdas
+  #checkov:skip=CKV_AWS_116: SQS is the trigger, so failed events redeliver and land in cabal-push-dlq; a Lambda-side DLQ is redundant here
+  #checkov:skip=CKV_AWS_117: needs APNs (public internet) and only AWS APIs otherwise; a VPC placement would add a NAT dependency for zero data-plane gain
+  #checkov:skip=CKV_AWS_272: code-signing is not part of this repo's Lambda supply chain (zips are hash-pinned at build; see build-api-one.sh)
+  #checkov:skip=CKV_AWS_50: X-Ray tracing is not used anywhere in this stack (see the tfsec ignore above)
+  s3_bucket        = var.bucket
+  s3_key           = "lambda/push_dispatch.zip"
+  source_code_hash = data.aws_s3_object.push_dispatch_hash.body
+  function_name    = "push_dispatch"
+  role             = aws_iam_role.push_dispatch.arn
+  handler          = "function.handler"
+  runtime          = "python3.13"
+  architectures    = ["arm64"]
+  timeout          = 60
+  memory_size      = 128
+
+  logging_config {
+    log_format = "Text"
+    log_group  = aws_cloudwatch_log_group.push_dispatch.name
+  }
+
+  environment {
+    variables = {
+      PUSH_TOKENS_TABLE_NAME = "cabal-push-tokens"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.push_dispatch]
+
+  # Out-of-band Lambda deploys mutate code via aws lambda update-function-code;
+  # ignore these so a topology-only Terraform apply does not roll the update
+  # back (matches append_sent and the call module).
+  lifecycle {
+    ignore_changes = [s3_key, s3_object_version, source_code_hash]
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "push_dispatch" {
+  event_source_arn = var.push_queue_arn
+  function_name    = aws_lambda_function.push_dispatch.arn
+
+  # One wake signal per invocation: a single failing dispatch (e.g. an APNs
+  # outage mid-batch) retries on its own without re-sending its siblings'
+  # already-delivered notifications.
+  batch_size = 1
+}

--- a/terraform/infra/modules/app/push_dispatch.tf
+++ b/terraform/infra/modules/app/push_dispatch.tf
@@ -11,8 +11,8 @@
 # content.
 
 # -- APNs credentials --------------------------------------------
-# Operator-populated after creating an APNs auth key in App Store Connect
-# (see docs/push-notifications.md for the runbook):
+# Operator-populated after creating an APNs auth key in the Apple Developer
+# portal (see docs/push-notifications.md for the runbook):
 #   aws ssm put-parameter --name /cabal/apns/private_key \
 #     --type SecureString --value file://AuthKey_XXXXXXXXXX.p8 --overwrite
 # The dispatch Lambda treats the placeholder value as "not configured" and
@@ -50,7 +50,7 @@ resource "aws_ssm_parameter" "apns_key_id" {
 
 resource "aws_ssm_parameter" "apns_private_key" {
   name        = "/cabal/apns/private_key"
-  description = "APNs auth key (.p8 PEM content). High-value: rotate via App Store Connect per docs/push-notifications.md. Populate via aws ssm put-parameter --overwrite."
+  description = "APNs auth key (.p8 PEM content). High-value: rotate via the Apple Developer portal per docs/push-notifications.md. Populate via aws ssm put-parameter --overwrite."
   type        = "SecureString"
   value       = local.apns_placeholder
 

--- a/terraform/infra/modules/app/variables.tf
+++ b/terraform/infra/modules/app/variables.tf
@@ -134,3 +134,8 @@ variable "access_logs_bucket" {
   type        = string
   description = "Name of the shared S3 server-access-log target bucket (modules/s3_access_logs) the cache bucket's access logs are delivered to."
 }
+
+variable "push_queue_arn" {
+  type        = string
+  description = "ARN of the push wake-signal SQS queue (modules/ecs). Event source for the push_dispatch Lambda."
+}

--- a/terraform/infra/modules/ecs/iam.tf
+++ b/terraform/infra/modules/ecs/iam.tf
@@ -110,6 +110,14 @@ resource "aws_iam_policy" "ecs_task" {
         Resource = [for q in aws_sqs_queue.tier : q.arn]
       },
       {
+        # The imap container's push-enqueue.sh (procmail side effect) sends
+        # one wake-signal message per local delivery. Shared task role, so
+        # scope to the single push queue; the smtp tiers simply never send.
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.push.arn
+      },
+      {
         Effect = "Allow"
         Action = [
           "ssmmessages:CreateControlChannel",

--- a/terraform/infra/modules/ecs/outputs.tf
+++ b/terraform/infra/modules/ecs/outputs.tf
@@ -18,6 +18,11 @@ output "sns_topic_arn" {
   description = "ARN of the address-changed SNS topic. Lambdas publish here to trigger reconfiguration."
 }
 
+output "push_queue_arn" {
+  value       = aws_sqs_queue.push.arn
+  description = "ARN of the push wake-signal queue. The app module's push_dispatch Lambda consumes it."
+}
+
 output "imap_service_name" {
   value       = aws_ecs_service.imap.name
   description = "Name of the IMAP ECS service."

--- a/terraform/infra/modules/ecs/push.tf
+++ b/terraform/infra/modules/ecs/push.tf
@@ -1,0 +1,34 @@
+/**
+* Push-notification wake-signal queue (docs/0.11.0/push-notifications.md).
+*
+* The imap container's procmail recipe enqueues one small JSON message per
+* local delivery via docker/shared/push-enqueue.sh (best-effort: a failed
+* enqueue never blocks or fails mail delivery). The push_dispatch Lambda in
+* the app module consumes the queue and fans out to APNs. The queue lives
+* here, next to the producer's task role and task definition, mirroring the
+* reconfigure queues; the consumer side (Lambda, event source mapping, APNs
+* SSM parameters) lives in modules/app/push_dispatch.tf.
+*/
+
+resource "aws_sqs_queue" "push_dlq" {
+  name                      = "cabal-push-dlq"
+  message_retention_seconds = 1209600 # 14 days
+  sqs_managed_sse_enabled   = true
+}
+
+resource "aws_sqs_queue" "push" {
+  name = "cabal-push-queue"
+  # >= the dispatch Lambda's 60s function timeout (same rule as append_sent).
+  visibility_timeout_seconds = 120
+  # A push older than an hour is noise, not news: the user's device would
+  # show a stale "New mail" long after the fact. Let undeliverable signals
+  # age out instead of retrying into irrelevance.
+  message_retention_seconds = 3600
+
+  sqs_managed_sse_enabled = true
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.push_dlq.arn
+    maxReceiveCount     = 5
+  })
+}

--- a/terraform/infra/modules/ecs/task-definitions.tf
+++ b/terraform/infra/modules/ecs/task-definitions.tf
@@ -57,8 +57,11 @@ locals {
 # v5 (phase 4 of the same plan): add the LOGIN_TRUSTED_NETWORKS env var (NLB
 # public-subnet CIDRs) the entrypoint needs to keep NLB-forwarded logins
 # working once disable_plaintext_auth = yes lands in the image.
+# v6 (docs/0.11.0/push-notifications.md phase 2): add the PUSH_QUEUE_URL env
+# var so the entrypoint can hand the queue URL + task-role credential URI to
+# procmail's push-enqueue.sh (sendmail sanitizes the delivery agents' env).
 resource "terraform_data" "imap_taskdef_revision_marker" {
-  input = var.healthcheck_ping_param != "" ? "imap-taskdef-v5+hc" : "imap-taskdef-v5"
+  input = var.healthcheck_ping_param != "" ? "imap-taskdef-v6+hc" : "imap-taskdef-v6"
 }
 
 resource "aws_ecs_task_definition" "imap" {
@@ -98,6 +101,7 @@ resource "aws_ecs_task_definition" "imap" {
       { name = "NETWORK_CIDR", value = var.cidr_block },
       { name = "LOGIN_TRUSTED_NETWORKS", value = join(" ", var.login_trusted_cidrs) },
       { name = "SQS_QUEUE_URL", value = aws_sqs_queue.tier["imap"].url },
+      { name = "PUSH_QUEUE_URL", value = aws_sqs_queue.push.url },
     ]
 
     secrets = concat([

--- a/terraform/infra/modules/table/main.tf
+++ b/terraform/infra/modules/table/main.tf
@@ -83,6 +83,40 @@ resource "aws_dynamodb_table" "rate_limits" {
 }
 
 /**
+* APNs device tokens for push notifications (docs/0.11.0/push-notifications.md).
+* One row per (Cognito username, device token); a user with an iPhone and an
+* iPad has two rows. Written by the push_register / push_deregister Lambdas;
+* read (Query on `user`) and pruned (on APNs Unregistered/BadDeviceToken) by
+* push_dispatch. Rows are re-created by the app on every launch, so the data
+* is fully reconstructible and deliberately outside the backup plan (matching
+* cabal-user-preferences).
+*/
+
+#tfsec:ignore:aws-dynamodb-table-customer-key
+resource "aws_dynamodb_table" "push_tokens" {
+  name                        = "cabal-push-tokens"
+  billing_mode                = "PAY_PER_REQUEST"
+  hash_key                    = "user"
+  range_key                   = "device_token"
+  deletion_protection_enabled = true
+
+  attribute {
+    name = "user"
+    type = "S"
+  }
+  attribute {
+    name = "device_token"
+    type = "S"
+  }
+  server_side_encryption {
+    enabled = true
+  }
+  point_in_time_recovery {
+    enabled = true
+  }
+}
+
+/**
 * Per-user, per-domain allow list for address creation. The presence of a
 * (user, domain) row means the user IS permitted to create addresses on that
 * apex domain; the absence of a row defaults to deny. This matches the


### PR DESCRIPTION
Implements [docs/0.11.0/push-notifications.md](docs/0.11.0/push-notifications.md) phases 1–4 end-to-end: token registration, server-side dispatch, on-device enrichment, and notification actions.

## What ships

**Mail side (imap container)**
- Procmail `:0c` recipe spools a content-free wake signal (`{user, folder, uid, msg_id}`) per local delivery; spam-filed messages never notify. The `PUSH_ENQUEUED` guard makes the recipe fire exactly once even though the same file is processed as both `/etc/procmailrc` and `~/.procmailrc`.
- New `push-spool-drain` supervisord program forwards the spool to `cabal-push-queue`. The spool/drain split keeps AWS credentials away from per-user delivery agents (preserving the 0.10.x hardening posture) and keeps SQS latency/outages out of the delivery hot path. The drain authenticates spool files by owner and sheds stale/spoofed/malformed ones.
- Dovecot gains an auto-subscribed `\Archive` mailbox (existing users get it lazily — no backfill needed).

**AWS side**
- `cabal-push-tokens` table; `/push_register` + `/push_deregister` endpoints (per-device upsert/delete; `enabled_folders` is tri-state: absent=preserve, empty=reset, list=replace).
- `cabal-push-queue` + DLQ (modules/ecs, next to the producer); imap task role gets `sqs:SendMessage`; imap task-def marker bumped to v6 for the `PUSH_QUEUE_URL` env var.
- `push_dispatch` Lambda (SQS-triggered, modeled on `append_sent`): pure-python HTTP/2 (`h2`) + ES256 provider tokens (`ecdsa`) — universal wheels, arm64, per the `fetch_bimi` precedent. Content-free payload (`"New mail"` + msgRef); prunes tokens on `410 Unregistered`/`BadDeviceToken`; EMF metrics in `Cabal/Push`; **inert until an operator provisions `/cabal/apns/*`** (placeholder SSM params, dropped signals, no DLQ noise, re-checked every 5 min).
- `push_envelope` endpoint: resolves the real UID by Message-ID (the enqueue-side UID is a pre-delivery hint), returns `{from, subject, snippet, uid}` on one IMAP connection, warms the S3 message cache.

**iOS app**
- Registration lifecycle (permission after sign-in, upsert on every launch/rotation, deregister on sign-out); `MAIL_MESSAGE` category with Open / Mark as Read / Archive running through the wired `ImapClient` protocol (ApiBackedImapClient), incl. a cold-launch client bootstrap for lock-screen actions on a terminated app; foreground pushes are sound-only.
- Notification Service Extension (new target, Foundation+UserNotifications only): enriches the alert via `/push_envelope`, writes the resolved uid back into msgRef so actions target the right message, falls back to generic `"New mail"` on any failure. App Group + shared keychain group carry `api_url` and the Cognito idToken (re-mirrored on every token refresh via a SecureStore decorator).

**Docs**: `docs/push-notifications.md` (architecture, APNs key provisioning + rotation runbooks, ops notes), linked from `docs/operations.md`; changelog fragments.

## Deviations from the plan doc (all deliberate)
- Flat endpoint paths (`/push_register`…) — repo convention; the call module has no nested routes.
- Bundle ids are the real ones (`com.cabalmail.Cabalmail`), not the doc's `com.cabalmail.app` sketch.
- Actions use the wired `ImapClient` protocol, not `LiveImapClient` (per CLAUDE.md, production doesn't use it).
- Table uses AWS-managed SSE + no backup (matches `cabal-user-preferences`; rows are re-created on every app launch).
- The doc's spool-file fallback became the primary transport (see hardening commit for why).
- Deferred: phase 5 settings UI (server side shipped), phase 6 macOS NSE, weekly token GC (dispatch-side pruning covers the common case), monitoring alarms (monitoring is off everywhere).

## Review
An 8-angle multi-agent review ran over the branch; the last commit fixes everything confirmed, including two would-have-been-fatal bugs (a DynamoDB `ExpressionAttributeNames` rejection that 500'd every registration, and an unexported credential URI that killed the enqueue path silently).

## Verification
- pylint 10/10 (all four functions + `apns.py`, now also in the CI lint line)
- Loopback HTTP/2 exchange test against a real h2 TLS server: 200/410/500 classification, provider-token + collapse-id headers, connection reuse, reconnect-then-transport-error
- Folded-Message-ID extraction test; shellcheck clean
- `terraform validate`/`fmt`, Checkov (0 new vs baseline), trivy, suppression + IAM-scope checkers all clean; tflint could not run locally (binary unavailable) — CI will gate it
- iOS/macOS/visionOS builds clean, swiftlint 0 violations, CabalmailKit tests pass (8 new; the 4 AcknowledgementsTests failures are the known vendored-license sync absence in a bare worktree)

## Operator runway (nothing breaks meanwhile)
1. **First infra apply may need a re-run**: the three new API endpoints gate on their zips existing in S3, and `push_dispatch`'s hash data source needs `app.yml`'s build to finish first — same artifact-ordering knot as previous new-Lambda rollouts.
2. **APNs key**: create in App Store Connect, populate `/cabal/apns/*` per docs/push-notifications.md (stage likely wants the sandbox endpoint for dev-signed builds).
3. **Apple portal**: enable Push Notifications + App Groups (`group.com.cabalmail.Cabalmail`) on the app's App ID, register the NSE App ID (`com.cabalmail.Cabalmail.NotificationService`), regenerate **all** profiles (iOS, visionOS, watch — the entitlements changed on the shared target), add the `IOS_NSE_APP_STORE_PROFILE` secret + a `provisioningProfiles` profile for the NSE. **Until that secret exists, both TestFlight upload legs skip with a warning** (deliberate: it doubles as the "signing assets ready" sentinel so neither leg hard-fails codesign against stale profiles). Build/test legs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)