### PR TITLE
Correct and detail the push-notification portal setup docs

### DIFF
--- a/apple/README.md
+++ b/apple/README.md
@@ -150,21 +150,43 @@ are expanded in the sections further down.
    its own cert — `Apple Distribution` signs the `.app`, Mac Installer
    Distribution signs the `.pkg`. See [Exporting the Mac Installer
    certificate](#exporting-the-mac-installer-certificate).
-4. **Register the bundle identifiers** in the Developer portal at
-   [developer.apple.com](https://developer.apple.com/account) →
-   Certificates, Identifiers & Profiles → **Identifiers** → **+**:
-   - App ID `com.cabalmail.Cabalmail` (description: `Cabalmail`)
-   - App ID `com.cabalmail.Cabalmail.watchkitapp` (description:
-     `Cabalmail Watch`) — the watch companion app embedded in the iOS
-     archive
-   - App ID `com.cabalmail.CabalmailMac` (description: `Cabalmail Mac`)
+4. **Register the App Group and bundle identifiers** in the Developer
+   portal at [developer.apple.com](https://developer.apple.com/account) →
+   Certificates, Identifiers & Profiles → **Identifiers** → **+**.
+
+   First the App Group (the shared container the push Notification
+   Service Extension reads; select **App Groups** on the + screen):
+   - `group.com.cabalmail.Cabalmail` (description: `Cabalmail`)
+
+   Then the App IDs, with the capabilities each one needs checked at
+   registration time (capabilities added later invalidate any profiles
+   already issued against the App ID):
+
+   | App ID | Description | Capabilities |
+   |---|---|---|
+   | `com.cabalmail.Cabalmail` | `Cabalmail` | **Push Notifications**; **App Groups** (configure → tick `group.com.cabalmail.Cabalmail`) |
+   | `com.cabalmail.Cabalmail.NotificationService` | `Cabalmail Notification Service` | **App Groups** (same group). Not Push Notifications — the extension never registers for push itself; it only reads the shared containers |
+   | `com.cabalmail.Cabalmail.watchkitapp` | `Cabalmail Watch` | none |
+   | `com.cabalmail.CabalmailMac` | `Cabalmail Mac` | none |
+
+   Keychain sharing (the app and the extension share a keychain access
+   group) needs no portal capability — profiles honor the
+   `keychain-access-groups` entitlement for any team-prefixed group
+   automatically.
+
+   The APNs **authentication key** that the server's `push_dispatch`
+   Lambda signs with is a separate, CI-unrelated credential (Keys →
+   **+**, no role, one per team covers every app); see
+   [docs/push-notifications.md](../docs/push-notifications.md) for
+   creating and seeding it.
 
    CI uses **manual code signing**, so App IDs must exist before you
    create the matching provisioning profiles in the next step.
 5. **Create the provisioning profiles** for each App ID. See
    [Creating provisioning profiles](#creating-provisioning-profiles) —
-   produces the `IOS_APP_STORE_PROFILE` / `WATCHOS_APP_STORE_PROFILE` /
-   `MAC_APP_STORE_PROFILE` / (optional) `MAC_DEVID_PROFILE` secrets.
+   produces the `IOS_APP_STORE_PROFILE` / `IOS_NSE_APP_STORE_PROFILE` /
+   `WATCHOS_APP_STORE_PROFILE` / `MAC_APP_STORE_PROFILE` / (optional)
+   `MAC_DEVID_PROFILE` secrets.
 6. **Create an App Store Connect API key** with the **App Manager** role. See
    [Creating the App Store Connect API key](#creating-the-app-store-connect-api-key)
    — produces the `APP_STORE_CONNECT_API_KEY_ID` /
@@ -252,8 +274,9 @@ Environments → `stage` / `prod`).
 
 | Secret | What it is |
 |---|---|
-| `IOS_APP_STORE_PROFILE` | base64 of the `.mobileprovision` for `com.cabalmail.Cabalmail` (App Store distribution). See [Creating provisioning profiles](#creating-provisioning-profiles) below. |
+| `IOS_APP_STORE_PROFILE` | base64 of the `.mobileprovision` for `com.cabalmail.Cabalmail` (App Store distribution). See [Creating provisioning profiles](#creating-provisioning-profiles) below. One profile covers both the iOS and visionOS upload legs — modern App Store profiles list both platforms. |
 | `WATCHOS_APP_STORE_PROFILE` | base64 of the `.mobileprovision` for `com.cabalmail.Cabalmail.watchkitapp` (App Store distribution). The iOS archive embeds the watch app, so the iOS upload leg skips (with a warning) until this secret exists; the visionOS leg is unaffected. |
+| `IOS_NSE_APP_STORE_PROFILE` | base64 of the `.mobileprovision` for `com.cabalmail.Cabalmail.NotificationService` (App Store distribution), the push Notification Service Extension embedded in the iOS archive. Gates **both** the iOS and visionOS upload legs: the push entitlements live on the shared app target, so every leg's archive needs profiles issued against the capability-bearing App ID — this secret doubles as the "push signing assets are ready" sentinel, and both legs skip (with a warning) until it exists. |
 
 **Required (macOS job only):**
 
@@ -354,13 +377,26 @@ macOS Developer ID — and each lives in App Store Connect referencing the
 distribution cert you just exported. Recreate them whenever the cert rolls
 (typically once a year); otherwise nothing to do.
 
-1. **Register the App IDs** (one-time) at
+1. **Register the App Group and App IDs** (one-time) at
    [developer.apple.com → Identifiers](https://developer.apple.com/account/resources/identifiers/list)
-   → **+**, if you haven't already:
+   → **+**, if you haven't already — with the capabilities listed in
+   step 4 of [Signing prerequisites](#signing-prerequisites):
+   - App Group `group.com.cabalmail.Cabalmail`
    - `com.cabalmail.Cabalmail` (App IDs → iOS, tvOS, watchOS, visionOS)
+     — Push Notifications + App Groups
+   - `com.cabalmail.Cabalmail.NotificationService` (App IDs → iOS, tvOS,
+     watchOS, visionOS) — App Groups only; the push Notification Service
+     Extension embedded in the iOS archive
    - `com.cabalmail.Cabalmail.watchkitapp` (App IDs → iOS, tvOS, watchOS,
      visionOS) — the embedded watch companion app
    - `com.cabalmail.CabalmailMac` (App IDs → macOS)
+
+   Capabilities must be on the App ID **before** its profiles are
+   created: editing an App ID's capabilities flips every existing
+   profile for it to **Invalid**, and each must then be re-issued
+   (click the profile → Edit → Save/Generate → Download) and its
+   GitHub secret refreshed. Profiles for *other* App IDs are
+   unaffected.
 
 2. **Create the profiles** at
    [developer.apple.com → Profiles](https://developer.apple.com/account/resources/profiles/list)
@@ -369,12 +405,14 @@ distribution cert you just exported. Recreate them whenever the cert rolls
    | Profile | Distribution type | App ID | Certificate | Filename extension |
    |---|---|---|---|---|
    | Cabalmail iOS App Store | App Store | `com.cabalmail.Cabalmail` | Apple Distribution | `.mobileprovision` |
+   | Cabalmail NSE App Store | App Store | `com.cabalmail.Cabalmail.NotificationService` | Apple Distribution | `.mobileprovision` |
    | Cabalmail Watch App Store | App Store | `com.cabalmail.Cabalmail.watchkitapp` | Apple Distribution | `.mobileprovision` |
    | Cabalmail macOS App Store | App Store | `com.cabalmail.CabalmailMac` | Apple Distribution | `.provisionprofile` |
    | Cabalmail macOS Developer ID *(optional)* | Developer ID | `com.cabalmail.CabalmailMac` | Developer ID Application | `.provisionprofile` |
 
    Profile names are arbitrary — CI matches by the UUID embedded in the
-   file, not the name.
+   file, not the name. All profiles share the same Apple Distribution
+   certificate.
 
 3. **Download each profile** (click the profile → **Download**).
 
@@ -385,9 +423,15 @@ distribution cert you just exported. Recreate them whenever the cert rolls
    | Downloaded file | GitHub secret |
    |---|---|
    | iOS `.mobileprovision` | `IOS_APP_STORE_PROFILE` |
+   | NSE `.mobileprovision` | `IOS_NSE_APP_STORE_PROFILE` |
    | Watch `.mobileprovision` | `WATCHOS_APP_STORE_PROFILE` |
    | macOS App Store `.provisionprofile` | `MAC_APP_STORE_PROFILE` |
    | macOS Developer ID `.provisionprofile` | `MAC_DEVID_PROFILE` |
+
+   Stray whitespace — a trailing newline from the paste, or a `base64`
+   build that wraps its output — is harmless: the workflow strips all
+   whitespace before decoding, and the very next step fails loudly if
+   the decoded bytes aren't a valid signed profile.
 
 5. **Delete the downloaded files** — they embed the team's distribution
    cert public key and the App ID's capabilities, and can be re-created

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -72,9 +72,12 @@ not pile up in the DLQ). Per environment:
      --value file://AuthKey_YOURKEYID.p8 --overwrite
    ```
 
-3. Development-signed builds (Xcode direct installs) register **sandbox**
-   tokens; TestFlight and App Store builds register **production** tokens.
-   The endpoint is per-environment:
+3. Check the endpoint matches how the app reaches devices. TestFlight and
+   App Store builds register **production** tokens, so a deployment whose
+   every environment installs from TestFlight keeps the default
+   (production) endpoint everywhere and skips this step. Only
+   development-signed builds (Xcode direct installs) register **sandbox**
+   tokens:
 
    ```bash
    # only for an environment serving development-signed builds:
@@ -82,9 +85,8 @@ not pile up in the DLQ). Per environment:
      --value 'https://api.sandbox.push.apple.com' --overwrite
    ```
 
-   The default is the production endpoint. A token sent to the wrong
-   endpoint fails with `BadDeviceToken` and is pruned; re-launching the app
-   re-registers it.
+   A token sent to the wrong endpoint fails with `BadDeviceToken` and is
+   pruned; re-launching the app re-registers it.
 
 One key works for every app under the same team (iOS and macOS); the
 dispatch Lambda selects the APNs topic from each token's registered bundle
@@ -113,15 +115,40 @@ new key lands everywhere.
 
 ## Client-side manual steps
 
-The iOS/macOS app needs one-time Apple developer setup before registration
-works on real devices:
+The iOS app needs one-time Apple developer setup before push registration
+works on real devices. The generic signing mechanics (certificates, profile
+creation, secret encoding) live in
+[apple/README.md](../apple/README.md#creating-provisioning-profiles); the
+push-specific portal work, in order:
 
-- Enable the **Push Notifications** capability on the app's App ID (and the
-  Notification Service Extension's App ID) in the developer portal, then
-  regenerate any manual provisioning profiles CI uses — an entitlement change
-  invalidates them.
-- The Notification Service Extension ships as its own bundle id with its own
-  App Store profile; CI expects its profile UUID alongside the app's.
+1. **Register the App Group** (Identifiers → ➕ → App Groups):
+   `group.com.cabalmail.Cabalmail`. It carries the API URL and the mirrored
+   Cognito token from the app to the Notification Service Extension.
+2. **Add capabilities to the app's App ID** (`com.cabalmail.Cabalmail`):
+   **Push Notifications**, and **App Groups** configured with the group
+   above. Saving this warns that existing profiles are invalidated — that
+   is step 4. Keychain sharing needs no portal capability.
+3. **Register the NSE App ID** (`com.cabalmail.Cabalmail.NotificationService`,
+   explicit) with **App Groups only** — the extension never registers for
+   push itself, so it does not get the Push Notifications capability.
+4. **Re-issue the app's App Store profile** (it turned Invalid in step 2:
+   Profiles → click it → Edit → Save → Download) and **create the NSE's App
+   Store profile** against the same Apple Distribution certificate. The one
+   app profile covers both the iOS and visionOS upload legs; the watch
+   profile belongs to an untouched App ID and is unaffected.
+5. **Update the GitHub environment secrets** per environment: refresh
+   `IOS_APP_STORE_PROFILE` with the re-issued profile and add
+   `IOS_NSE_APP_STORE_PROFILE` (base64 each; stray whitespace is stripped
+   by the workflow). Until the NSE secret exists, **both** TestFlight
+   upload legs skip with a warning — it doubles as the "push signing assets
+   are ready" sentinel, so neither leg can fail codesign against a stale
+   profile.
+
+The macOS app carries none of the push entitlements and no extension, so
+its App ID and profiles need no changes until a macOS Notification Service
+Extension ships; the backend is already multi-app (the dispatch Lambda
+selects the APNs topic per registered token, and the same APNs key covers
+every app on the team).
 
 ## Operational notes
 


### PR DESCRIPTION
Documentation-only follow-up to #645, folding in everything clarified while walking the stage rollout:

- **Fixes a wrong instruction**: the runbook told the operator to enable Push Notifications on the NSE App ID — the extension never registers for push; it needs **App Groups only**.
- **apple/README.md** signing prerequisites now cover the App Group, the NSE App ID, a per-App-ID capabilities table, the capability-edit → profile-invalidation behavior (watch profile unaffected), the NSE profile row + `IOS_NSE_APP_STORE_PROFILE` secret (documented as the both-legs "signing assets ready" sentinel), and the whitespace-tolerant base64 step.
- **docs/push-notifications.md** client-side section is now a numbered portal walkthrough (App Group → app App ID capabilities → NSE App ID → profile re-issue/creation → secrets), cross-linked with the README instead of duplicating it; the endpoint step leads with the TestFlight/production-token common case; macOS explicitly needs nothing until phase 6.

No code changes. `no-changelog` label per the apple-changelog gate's opt-out for non-user-facing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)