### PR TITLE
Push notifications phases 5+6: settings, macOS parity, token GC

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -630,6 +630,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Verify secrets are present
+        # Skip-not-fail, matching the iOS job: the archive cannot succeed
+        # without every profile the scheme's embedded targets sign with, so
+        # a missing secret must park the upload leg (with a warning) rather
+        # than paint the workflow red until the operator finishes the
+        # portal work. MAC_NSE_APP_STORE_PROFILE is the newest addition —
+        # the macOS Notification Service Extension embeds in the archive —
+        # and doubles as the "macOS push signing assets are ready" sentinel.
+        id: check
         env:
           S1: ${{ secrets.APPLE_TEAM_ID }}
           S2: ${{ secrets.APPLE_DISTRIBUTION_CERT_P12 }}
@@ -640,6 +648,7 @@ jobs:
           S7: ${{ secrets.MAC_APP_STORE_PROFILE }}
           S8: ${{ secrets.MAC_INSTALLER_CERT_P12 }}
           S9: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
+          S10: ${{ secrets.MAC_NSE_APP_STORE_PROFILE }}
         run: |
           MISSING=()
           [ -z "$S1" ] && MISSING+=("APPLE_TEAM_ID")
@@ -651,18 +660,23 @@ jobs:
           [ -z "$S7" ] && MISSING+=("MAC_APP_STORE_PROFILE")
           [ -z "$S8" ] && MISSING+=("MAC_INSTALLER_CERT_P12")
           [ -z "$S9" ] && MISSING+=("MAC_INSTALLER_CERT_PASSWORD")
+          [ -z "$S10" ] && MISSING+=("MAC_NSE_APP_STORE_PROFILE")
           if [ ${#MISSING[@]} -gt 0 ]; then
-            echo "::error::Apple signing secrets missing: ${MISSING[*]}"
-            exit 1
+            echo "::warning::Apple signing secrets missing: ${MISSING[*]}. Skipping upload."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "All required signing secrets present."
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "All nine signing secrets present."
 
       - name: Select Xcode
+        if: steps.check.outputs.enabled == 'true'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Install XcodeGen + xcbeautify
+        if: steps.check.outputs.enabled == 'true'
         # See the kit-test job for the rationale on the per-package check.
         run: |
           for pkg in xcodegen xcbeautify; do
@@ -670,15 +684,18 @@ jobs:
           done
 
       - name: Generate Xcode project
+        if: steps.check.outputs.enabled == 'true'
         working-directory: apple
         run: xcodegen generate
 
       - name: Sync vendored CabalmailKit resources (marked + turndown)
+        if: steps.check.outputs.enabled == 'true'
         # See the kit-test job for the rationale. Same script, same files.
         working-directory: apple
         run: scripts/sync-vendored.sh
 
       - name: Import signing certificates
+        if: steps.check.outputs.enabled == 'true'
         env:
           APPLE_DIST_P12: ${{ secrets.APPLE_DISTRIBUTION_CERT_P12 }}
           APPLE_DIST_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERT_PASSWORD }}
@@ -724,6 +741,7 @@ jobs:
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
       - name: Install App Store Connect API key
+        if: steps.check.outputs.enabled == 'true'
         env:
           ASC_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -745,13 +763,25 @@ jobs:
           echo "ASC_KEY_PATH=$KEY_FILE" >> "$GITHUB_ENV"
 
       - name: Install macOS App Store provisioning profile
+        if: steps.check.outputs.enabled == 'true'
         uses: ./.github/actions/install-provisioning-profile
         with:
           base64: ${{ secrets.MAC_APP_STORE_PROFILE }}
           extension: provisionprofile
           env-name: MAC_APP_STORE_PROFILE_UUID
 
+      - name: Install macOS NSE App Store provisioning profile
+        # The macOS Notification Service Extension embeds in the archive,
+        # same shape as the iOS job's NSE profile step.
+        if: steps.check.outputs.enabled == 'true'
+        uses: ./.github/actions/install-provisioning-profile
+        with:
+          base64: ${{ secrets.MAC_NSE_APP_STORE_PROFILE }}
+          extension: provisionprofile
+          env-name: MAC_NSE_APP_STORE_PROFILE_UUID
+
       - name: Archive CabalmailMac
+        if: steps.check.outputs.enabled == 'true'
         working-directory: apple
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -783,11 +813,13 @@ jobs:
             -archivePath "$RUNNER_TEMP/CabalmailMac.xcarchive" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
             MAC_APP_STORE_PROFILE_UUID="$MAC_APP_STORE_PROFILE_UUID" \
+            MAC_NSE_APP_STORE_PROFILE_UUID="${MAC_NSE_APP_STORE_PROFILE_UUID:-}" \
             MARKETING_VERSION="$MARKETING_VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
             | xcbeautify --renderer github-actions
 
       - name: Export app-store .pkg
+        if: steps.check.outputs.enabled == 'true'
         working-directory: apple
         run: |
           set -o pipefail
@@ -813,6 +845,8 @@ jobs:
               <dict>
                   <key>com.cabalmail.CabalmailMac</key>
                   <string>$MAC_APP_STORE_PROFILE_UUID</string>
+                  <key>com.cabalmail.CabalmailMac.NotificationService</key>
+                  <string>$MAC_NSE_APP_STORE_PROFILE_UUID</string>
               </dict>
           </dict>
           </plist>
@@ -824,6 +858,7 @@ jobs:
             | xcbeautify --renderer github-actions
 
       - name: Summarize macOS upload
+        if: steps.check.outputs.enabled == 'true'
         run: |
           {
             echo "### macOS TestFlight upload"
@@ -834,6 +869,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload macOS to TestFlight
+        if: steps.check.outputs.enabled == 'true'
         env:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -864,14 +900,19 @@ jobs:
           echo "::notice::altool upload completed cleanly."
 
       - name: Check for Developer ID certificate and profile
+        if: steps.check.outputs.enabled == 'true'
         id: devid
         env:
           DEVID_P12: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
           DEVID_PROFILE: ${{ secrets.MAC_DEVID_PROFILE }}
+          DEVID_NSE_PROFILE: ${{ secrets.MAC_NSE_DEVID_PROFILE }}
         run: |
           MISSING=()
           [ -z "$DEVID_P12" ] && MISSING+=("DEVELOPER_ID_CERT_P12")
           [ -z "$DEVID_PROFILE" ] && MISSING+=("MAC_DEVID_PROFILE")
+          # The embedded Notification Service Extension needs its own
+          # Developer ID profile for the developer-id export method.
+          [ -z "$DEVID_NSE_PROFILE" ] && MISSING+=("MAC_NSE_DEVID_PROFILE")
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "::notice::Developer-ID secrets missing (${MISSING[*]}); skipping notarized .app artifact. TestFlight upload already completed."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
@@ -907,6 +948,14 @@ jobs:
           extension: provisionprofile
           env-name: MAC_DEVID_PROFILE_UUID
 
+      - name: Install macOS NSE Developer ID provisioning profile
+        if: steps.devid.outputs.enabled == 'true'
+        uses: ./.github/actions/install-provisioning-profile
+        with:
+          base64: ${{ secrets.MAC_NSE_DEVID_PROFILE }}
+          extension: provisionprofile
+          env-name: MAC_NSE_DEVID_PROFILE_UUID
+
       - name: Export developer-id build for notarization
         if: steps.devid.outputs.enabled == 'true'
         working-directory: apple
@@ -934,6 +983,8 @@ jobs:
               <dict>
                   <key>com.cabalmail.CabalmailMac</key>
                   <string>$MAC_DEVID_PROFILE_UUID</string>
+                  <key>com.cabalmail.CabalmailMac.NotificationService</key>
+                  <string>$MAC_NSE_DEVID_PROFILE_UUID</string>
               </dict>
           </dict>
           </plist>
@@ -975,7 +1026,7 @@ jobs:
       # - and never blocks it on the up-to-20-minute processing poll.
       - name: Set TestFlight "What to Test" notes (prod only)
         # Prod releases only. Best-effort - see the iOS job for rationale.
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'main' && steps.check.outputs.enabled == 'true'
         env:
           ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -988,6 +1039,7 @@ jobs:
           "$RUNNER_TEMP/ascvenv/bin/python" "$GITHUB_WORKSPACE/.github/scripts/set-testflight-notes.py"
 
       - name: Clean up keychain and API key
+        if: always() && steps.check.outputs.enabled == 'true'
         if: always()
         run: |
           security delete-keychain "${KEYCHAIN_PATH:-}" || true

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -1040,7 +1040,6 @@ jobs:
 
       - name: Clean up keychain and API key
         if: always() && steps.check.outputs.enabled == 'true'
-        if: always()
         run: |
           security delete-keychain "${KEYCHAIN_PATH:-}" || true
           rm -f "$RUNNER_TEMP/keychain-password"

--- a/apple/Cabalmail/AppDelegate.swift
+++ b/apple/Cabalmail/AppDelegate.swift
@@ -1,8 +1,17 @@
+// Push notifications ship on iOS and macOS; visionOS is deliberately
+// excluded (project.yml destination-filters the NSE the same way), so the
+// guards are explicit `os(...)` checks rather than `canImport(...)` — the
+// visionOS build of the shared Cabalmail target must not compile this.
+#if os(iOS) || os(macOS)
 #if os(iOS)
 import UIKit
+#else
+import AppKit
+#endif
 import UserNotifications
 import CabalmailKit
 
+#if os(iOS)
 /// UIKit app delegate for the iOS target, installed via
 /// `@UIApplicationDelegateAdaptor` in `CabalmailApp`. Exists solely for the
 /// push-notification surface — APNs token callbacks land here (there is no
@@ -23,8 +32,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        let tokenHex = deviceToken.map { String(format: "%02x", $0) }.joined()
-        PushRegistrar.shared.deviceTokenDidChange(tokenHex)
+        PushRegistrar.shared.deviceTokenDidChange(Self.hexToken(deviceToken))
     }
 
     func application(
@@ -37,13 +45,53 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         CabalmailLog.warn("Push", "remote-notification registration failed: \(error)")
     }
 }
+#else
+/// AppKit app delegate for the macOS target, installed via
+/// `@NSApplicationDelegateAdaptor` in `CabalmailMacApp` — the AppKit twin
+/// of the iOS class above, existing for the same reason: APNs token
+/// callbacks land on `NSApplicationDelegate` and the notification-center
+/// delegate must be wired before launch finishes, so
+/// `applicationWillFinishLaunching` (the earliest AppKit hook) does the
+/// wiring. Everything else stays in SwiftUI land.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationWillFinishLaunching(_ notification: Notification) {
+        UNUserNotificationCenter.current().delegate = self
+        PushRegistrar.registerNotificationCategories()
+    }
+
+    func application(
+        _ application: NSApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        PushRegistrar.shared.deviceTokenDidChange(Self.hexToken(deviceToken))
+    }
+
+    func application(
+        _ application: NSApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        // Unsigned / entitlement-less local builds land here on every
+        // launch; signed builds only on APNs connectivity trouble. Either
+        // way the app works fine without push, so log and move on.
+        CabalmailLog.warn("Push", "remote-notification registration failed: \(error)")
+    }
+}
+#endif
+
+extension AppDelegate {
+    /// Hex-encodes the raw APNs token, the wire format `/push_register`
+    /// stores. Shared by both platform delegates above.
+    static func hexToken(_ deviceToken: Data) -> String {
+        deviceToken.map { String(format: "%02x", $0) }.joined()
+    }
+}
 
 // The UN delegate methods are called on an arbitrary queue, and the
 // protocol declares them nonisolated — without the explicit `nonisolated`
-// they'd inherit the class's UIApplicationDelegate-inferred @MainActor
+// they'd inherit the class's application-delegate-inferred @MainActor
 // isolation and trip strict concurrency (non-Sendable UN* parameters can't
 // cross into an isolated witness). Sendable values are extracted up front;
-// only those hop to the main actor.
+// only those hop to the main actor. Shared verbatim by iOS and macOS.
 extension AppDelegate: UNUserNotificationCenterDelegate {
     /// Foreground delivery: the IDLE-driven UI already shows the new
     /// message, so a banner would double-notify — play the sound only.
@@ -54,7 +102,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         [.sound]
     }
 
-    /// Action dispatch (lock-screen buttons and the default tap). The async
+    /// Action dispatch (notification buttons and the default tap). The async
     /// variant's return *is* the completion handler, so returning only after
     /// `handleNotificationAction` resolves keeps the system's background
     /// budget honest for MARK_READ / ARCHIVE.

--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -296,7 +296,7 @@ final class AppState {
     func signOut() async {
         stopInboxBadgePolling()
         guard let client else { status = .signedOut; return }
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         // Deregister the APNs token while the Cognito session still works —
         // `/push_deregister` is an authenticated call like every other, and
         // `authService.signOut()` below wipes the tokens.
@@ -501,15 +501,15 @@ extension AppState {
 extension AppState {
     /// Shared tail of `signIn` and `restoreIfPossible`: installs the client,
     /// flips to `.signedIn`, and kicks off the session-scoped side flows —
-    /// badge polling, the contacts prompt, push registration (iOS), and the
-    /// watch hand-off.
+    /// badge polling, the contacts prompt, push registration (iOS/macOS),
+    /// and the watch hand-off.
     private func wireSession(client newClient: CabalmailClient, username: String) async {
         self.client = newClient
         self.navCoordinator = NavStateCoordinator(client: newClient)
         self.status = .signedIn
         startInboxBadgePolling()
         requestContactsAccessIfNeeded()
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         // Runs on both entry paths, so every launch re-registers the APNs
         // token — `/push_register` upserts, making this a cheap refresh of
         // the row's `last_seen_at`.
@@ -523,13 +523,13 @@ extension AppState {
 
 extension AppState {
     /// The keychain store the session client persists Cognito tokens
-    /// through. On iOS it's wrapped in `PushMirroringSecureStore` so every
-    /// token write — sign-in and each silent refresh — also lands in the
-    /// shared containers the Notification Service Extension reads (see
-    /// `PushEnrichmentStore`). Static (and non-private) so the push
+    /// through. On iOS and macOS it's wrapped in `PushMirroringSecureStore`
+    /// so every token write — sign-in and each silent refresh — also lands
+    /// in the shared containers the Notification Service Extension reads
+    /// (see `PushEnrichmentStore`). Static (and non-private) so the push
     /// action-handler's cold-launch bootstrap builds an identical stack.
     static func makeSecureStore() -> SecureStore {
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         return PushMirroringSecureStore(base: KeychainSecureStore())
         #else
         return KeychainSecureStore()

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -249,6 +249,16 @@ final class PushRegistrar {
         Task {
             do {
                 try await client.apiClient.registerPushDevice(registration)
+                // The user can flip the master toggle off while this
+                // round trip is in flight; its upsert would then resurrect
+                // the row disablePush just deleted — and with the disabled
+                // flag set, no later launch would ever clean it up. This
+                // Task is main-actor (class isolation), so the flag read is
+                // ordered after any toggle that landed during the await.
+                if PushSettings.isUserDisabled {
+                    try? await client.apiClient.deregisterPushDevice(token: tokenHex)
+                    return
+                }
                 UserDefaults.standard.set(tokenHex, forKey: Self.lastTokenKey)
             } catch {
                 // Best-effort: a failed registration means no pushes until

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -42,6 +42,71 @@ struct PushMessageRef: Sendable {
     }
 }
 
+/// The user's folder-scope choice for new-mail pushes (Notifications
+/// settings, phase 5). Raw values are the UserDefaults wire format — don't
+/// rename cases without migrating `PushSettings.folderScopeKey`.
+enum PushFolderScope: String, CaseIterable {
+    case inboxOnly
+    case all
+    case custom
+}
+
+/// Per-device push preferences, persisted in UserDefaults. Deliberately a
+/// nonisolated enum (not state on `PushRegistrar`, which is @MainActor) so
+/// SwiftUI property initializers can read the stored values synchronously.
+///
+/// This state is per *device* by design: the server keeps the resolved
+/// folder list on this device's token row (`cabal-push-tokens`), so there is
+/// no cross-device mirror in get/set_preferences — that would add a second
+/// source of truth for something inherently device-scoped.
+enum PushSettings {
+    /// True once the user flips the master toggle off. Launches must then
+    /// neither re-prompt for permission nor re-register the token until the
+    /// user turns the toggle back on (`PushRegistrar.enablePush`).
+    static let disabledKey = "cabalmail.push.userDisabled"
+    /// Raw `PushFolderScope` value; absent means `.inboxOnly`.
+    static let folderScopeKey = "cabalmail.push.folderScope"
+    /// `/`-delimited folder paths for the `.custom` scope.
+    static let chosenFoldersKey = "cabalmail.push.chosenFolders"
+
+    static var isUserDisabled: Bool {
+        UserDefaults.standard.bool(forKey: disabledKey)
+    }
+
+    static func setUserDisabled(_ disabled: Bool) {
+        UserDefaults.standard.set(disabled, forKey: disabledKey)
+    }
+
+    static var folderScope: PushFolderScope {
+        UserDefaults.standard.string(forKey: folderScopeKey)
+            .flatMap(PushFolderScope.init(rawValue:)) ?? .inboxOnly
+    }
+
+    /// Defaults to INBOX so the "Choose folders" list opens with the one
+    /// folder everyone expects preselected.
+    static var chosenFolders: [String] {
+        UserDefaults.standard.stringArray(forKey: chosenFoldersKey) ?? ["INBOX"]
+    }
+
+    static func setScope(_ scope: PushFolderScope, chosenFolders: [String]) {
+        UserDefaults.standard.set(scope.rawValue, forKey: folderScopeKey)
+        UserDefaults.standard.set(chosenFolders, forKey: chosenFoldersKey)
+    }
+
+    /// The explicit `enabled_folders` value every `/push_register` call
+    /// sends. Always explicit — never nil/omitted — so the server row is
+    /// deterministic after each registration rather than relying on the
+    /// Lambda's preserve-stored-value behavior. `[]` is the server's
+    /// "inbox only" reset; `["*"]` is all folders.
+    static var enabledFolders: [String] {
+        switch folderScope {
+        case .inboxOnly: return []
+        case .all: return ["*"]
+        case .custom: return chosenFolders
+        }
+    }
+}
+
 /// Owns the APNs registration lifecycle and the notification-action
 /// handlers for the iOS and macOS apps (docs/0.11.0/push-notifications.md,
 /// phases 1/3/4; macOS parity is phase 6). `AppState` drives the session
@@ -134,13 +199,18 @@ final class PushRegistrar {
         self.appState = appState
         self.client = client
         PushEnrichmentStore().updateAPIURL(client.configuration.invokeUrl)
-        Task {
-            let center = UNUserNotificationCenter.current()
-            let granted = (try? await center.requestAuthorization(
-                options: [.alert, .badge, .sound]
-            )) ?? false
-            guard granted else { return }
-            Platform.registerForRemoteNotifications()
+        // Honor the user's master toggle: once notifications are off, a
+        // launch neither re-prompts nor re-registers — only `enablePush`
+        // (the Settings toggle) restarts the pipeline.
+        if !PushSettings.isUserDisabled {
+            Task {
+                let center = UNUserNotificationCenter.current()
+                let granted = (try? await center.requestAuthorization(
+                    options: [.alert, .badge, .sound]
+                )) ?? false
+                guard granted else { return }
+                Platform.registerForRemoteNotifications()
+            }
         }
         if let token = pendingToken {
             pendingToken = nil
@@ -153,8 +223,15 @@ final class PushRegistrar {
     }
 
     /// Called with the hex-encoded APNs token — on every launch (the
-    /// system re-delivers it) and whenever APNs rotates it.
+    /// system re-delivers it) and whenever APNs rotates it. Every
+    /// registration carries the explicit current folder scope
+    /// (`PushSettings.enabledFolders`), so the server row always reflects
+    /// this device's latest choice.
     func deviceTokenDidChange(_ tokenHex: String) {
+        // The system can re-deliver a token after the user flipped the
+        // master toggle off (e.g. a rotation callback racing the toggle);
+        // registering it would silently re-enable pushes.
+        guard !PushSettings.isUserDisabled else { return }
         guard let client else {
             pendingToken = tokenHex
             return
@@ -166,7 +243,8 @@ final class PushRegistrar {
             appVersion: Bundle.main.object(
                 forInfoDictionaryKey: "CFBundleShortVersionString"
             ) as? String ?? "0",
-            locale: Locale.current.identifier
+            locale: Locale.current.identifier,
+            enabledFolders: PushSettings.enabledFolders
         )
         Task {
             do {
@@ -205,6 +283,61 @@ final class PushRegistrar {
             // reinstall / re-sign-in upserts over it.
             CabalmailLog.warn("Push", "push_deregister failed: \(error)")
         }
+    }
+}
+
+// MARK: - Notifications settings (phase 5)
+
+extension PushRegistrar {
+    /// Master toggle ON. Requests notification permission (a no-op prompt
+    /// if already determined) and, when granted, clears the user-disabled
+    /// flag and re-registers for remote notifications — the token callback
+    /// then upserts the server row with the current folder scope. Returns
+    /// false when the OS permission is (or just was) denied, so the toggle
+    /// can reflect the real system state instead of lying.
+    func enablePush() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        let granted = (try? await center.requestAuthorization(
+            options: [.alert, .badge, .sound]
+        )) ?? false
+        guard granted else { return false }
+        PushSettings.setUserDisabled(false)
+        Platform.registerForRemoteNotifications()
+        return true
+    }
+
+    /// Master toggle OFF. Sets the user-disabled flag first — that alone
+    /// stops `sessionDidStart` / `deviceTokenDidChange` from re-registering
+    /// on future launches — then best-effort deregisters the stored token so
+    /// the server stops dispatching immediately rather than at next APNs
+    /// rejection.
+    func disablePush() async {
+        PushSettings.setUserDisabled(true)
+        pendingToken = nil
+        guard
+            let client = await activeClient(),
+            let token = UserDefaults.standard.string(forKey: Self.lastTokenKey)
+        else { return }
+        do {
+            try await client.apiClient.deregisterPushDevice(token: token)
+            UserDefaults.standard.removeObject(forKey: Self.lastTokenKey)
+        } catch {
+            // Best-effort, same posture as sessionWillEnd: a row we fail to
+            // remove is pruned by push_dispatch on the next APNs rejection.
+            CabalmailLog.warn("Push", "push_deregister failed: \(error)")
+        }
+    }
+
+    /// Persists a folder-scope change and, while registered, immediately
+    /// re-registers the stored token so the server row picks it up without
+    /// waiting for the next launch (the `/push_register` upsert is cheap).
+    func updateFolderScope(_ scope: PushFolderScope, chosenFolders: [String]) {
+        PushSettings.setScope(scope, chosenFolders: chosenFolders)
+        guard
+            !PushSettings.isUserDisabled,
+            let token = UserDefaults.standard.string(forKey: Self.lastTokenKey)
+        else { return }
+        deviceTokenDidChange(token)
     }
 }
 

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -1,6 +1,13 @@
-#if os(iOS)
+// See AppDelegate.swift for why these are explicit `os(...)` guards:
+// push ships on iOS and macOS; the visionOS build of the shared
+// Cabalmail target must not compile this.
+#if os(iOS) || os(macOS)
 import Foundation
+#if os(iOS)
 import UIKit
+#else
+import AppKit
+#endif
 import UserNotifications
 import CabalmailKit
 
@@ -36,17 +43,47 @@ struct PushMessageRef: Sendable {
 }
 
 /// Owns the APNs registration lifecycle and the notification-action
-/// handlers for the iOS app (docs/0.11.0/push-notifications.md, phases
-/// 1/3/4). `AppState` drives the session edges (`sessionDidStart` /
-/// `sessionWillEnd`), `AppDelegate` feeds it token and action callbacks.
+/// handlers for the iOS and macOS apps (docs/0.11.0/push-notifications.md,
+/// phases 1/3/4; macOS parity is phase 6). `AppState` drives the session
+/// edges (`sessionDidStart` / `sessionWillEnd`), `AppDelegate` feeds it
+/// token and action callbacks. One implementation for both platforms —
+/// the UIKit/AppKit divergences live in small shims (`Platform` below and
+/// `BackgroundTaskToken` at the bottom of the file).
 ///
 /// A singleton (rather than something hung off `AppState`) because the
-/// UIKit delegate callbacks it services — token registration, background
-/// notification actions — can fire before SwiftUI has built any state,
-/// e.g. on a cold background launch from a lock-screen action.
+/// application-delegate callbacks it services — token registration,
+/// background notification actions — can fire before SwiftUI has built any
+/// state, e.g. on a cold background launch from a lock-screen action.
 @MainActor
 final class PushRegistrar {
     static let shared = PushRegistrar()
+
+    /// The two values `/push_register` derives the APNs topic from. The
+    /// Lambda validates the pair (`com.cabalmail.Cabalmail` -> `ios`,
+    /// `com.cabalmail.CabalmailMac` -> `macos`); `platform` itself is
+    /// informational — `bundle_id` is authoritative server-side.
+    private enum Platform {
+        #if os(iOS)
+        static let name = "ios"
+        static let fallbackBundleId = "com.cabalmail.Cabalmail"
+        #else
+        static let name = "macos"
+        static let fallbackBundleId = "com.cabalmail.CabalmailMac"
+        #endif
+
+        /// One seam over UIKit/AppKit's identically-named registration
+        /// call. Both must run on the main thread; the explicit @MainActor
+        /// is required because nested types don't inherit the enclosing
+        /// class's isolation.
+        @MainActor
+        static func registerForRemoteNotifications() {
+            #if os(iOS)
+            UIApplication.shared.registerForRemoteNotifications()
+            #else
+            NSApplication.shared.registerForRemoteNotifications()
+            #endif
+        }
+    }
 
     /// Set by `sessionDidStart`; navigation targets (`navCoordinator`)
     /// hang off it. Weak — the registrar outlives any session.
@@ -56,9 +93,10 @@ final class PushRegistrar {
     /// built for a background action on a terminated app (`activeClient()`).
     private var client: CabalmailClient?
 
-    /// APNs token that arrived before a session was wired (iOS re-delivers
-    /// the token on every `registerForRemoteNotifications`, which can beat
-    /// the launch restore). Registered as soon as the session starts.
+    /// APNs token that arrived before a session was wired (the system
+    /// re-delivers the token on every `registerForRemoteNotifications`,
+    /// which can beat the launch restore). Registered as soon as the
+    /// session starts.
     private var pendingToken: String?
 
     /// A tapped notification that arrived before sign-in / restore
@@ -90,8 +128,8 @@ final class PushRegistrar {
 
     /// Wires a signed-in session: mirrors the API URL for the NSE, asks for
     /// notification permission, and (re-)registers for remote notifications.
-    /// iOS re-delivers the device token on every registration, so each
-    /// launch refreshes the server row — a cheap upsert by design.
+    /// The system re-delivers the device token on every registration, so
+    /// each launch refreshes the server row — a cheap upsert by design.
     func sessionDidStart(appState: AppState, client: CabalmailClient) {
         self.appState = appState
         self.client = client
@@ -102,7 +140,7 @@ final class PushRegistrar {
                 options: [.alert, .badge, .sound]
             )) ?? false
             guard granted else { return }
-            UIApplication.shared.registerForRemoteNotifications()
+            Platform.registerForRemoteNotifications()
         }
         if let token = pendingToken {
             pendingToken = nil
@@ -114,8 +152,8 @@ final class PushRegistrar {
         }
     }
 
-    /// Called with the hex-encoded APNs token — on every launch (iOS
-    /// re-delivers it) and whenever APNs rotates it.
+    /// Called with the hex-encoded APNs token — on every launch (the
+    /// system re-delivers it) and whenever APNs rotates it.
     func deviceTokenDidChange(_ tokenHex: String) {
         guard let client else {
             pendingToken = tokenHex
@@ -123,7 +161,8 @@ final class PushRegistrar {
         }
         let registration = PushDeviceRegistration(
             deviceToken: tokenHex,
-            bundleId: Bundle.main.bundleIdentifier ?? "com.cabalmail.Cabalmail",
+            bundleId: Bundle.main.bundleIdentifier ?? Platform.fallbackBundleId,
+            platform: Platform.name,
             appVersion: Bundle.main.object(
                 forInfoDictionaryKey: "CFBundleShortVersionString"
             ) as? String ?? "0",
@@ -173,8 +212,9 @@ final class PushRegistrar {
 
 extension PushRegistrar {
     /// Dispatches a notification response. Runs the IMAP work inside a
-    /// UIKit background task and returns only once the operation resolves,
-    /// so `AppDelegate` can end the system's action budget truthfully.
+    /// background task (a real UIKit one on iOS, a no-op shim on macOS)
+    /// and returns only once the operation resolves, so `AppDelegate` can
+    /// end the system's action budget truthfully.
     func handleNotificationAction(identifier: String, ref: PushMessageRef?) async {
         switch identifier {
         case "MARK_READ":
@@ -251,10 +291,10 @@ extension PushRegistrar {
 // MARK: - Background execution plumbing
 
 extension PushRegistrar {
-    /// Runs `work` with an active session client inside a UIKit background
-    /// task, so a lock-screen action started with the app suspended isn't
-    /// killed mid-flight. Errors are logged, not surfaced — there is no UI
-    /// to surface them to.
+    /// Runs `work` with an active session client inside a background task
+    /// (see `BackgroundTaskToken`), so an iOS lock-screen action started
+    /// with the app suspended isn't killed mid-flight. Errors are logged,
+    /// not surfaced — there is no UI to surface them to.
     private func withBackgroundTask(
         named name: String,
         _ work: (CabalmailClient) async throws -> Void
@@ -301,6 +341,7 @@ extension PushRegistrar {
     }
 }
 
+#if os(iOS)
 /// Minimal RAII-ish wrapper around `beginBackgroundTask` /
 /// `endBackgroundTask`. Class (not struct) so the expiration handler can
 /// reach back and end the task if the system calls time first.
@@ -320,4 +361,15 @@ private final class BackgroundTaskToken {
         id = .invalid
     }
 }
+#else
+/// macOS has no `beginBackgroundTask` equivalent and doesn't need one:
+/// mac apps aren't suspended mid-notification-action, so the work in
+/// `withBackgroundTask` runs to completion on its own. A no-op shim (same
+/// shape as the iOS class) keeps the call site platform-neutral.
+@MainActor
+private final class BackgroundTaskToken {
+    func begin(named name: String) {}
+    func end() {}
+}
+#endif
 #endif

--- a/apple/Cabalmail/Views/NotificationSettingsSection.swift
+++ b/apple/Cabalmail/Views/NotificationSettingsSection.swift
@@ -253,6 +253,12 @@ struct NotificationFolderPickerView: View {
 
     private func toggle(_ path: String) {
         if selection.contains(path) {
+            // Never allow an empty selection: the wire format has no "no
+            // folders" value — an empty enabled_folders list is the server's
+            // "reset to inbox only", which would contradict what this screen
+            // shows. Turning notifications off entirely is the master
+            // toggle's job, so the last selected folder stays put.
+            guard selection.count > 1 else { return }
             selection.remove(path)
         } else {
             selection.insert(path)

--- a/apple/Cabalmail/Views/NotificationSettingsSection.swift
+++ b/apple/Cabalmail/Views/NotificationSettingsSection.swift
@@ -1,0 +1,310 @@
+// Push notifications ship on iOS and macOS only (see PushRegistrar.swift);
+// the visionOS build of the shared Cabalmail target must not compile this,
+// so the Settings form on visionOS simply has no Notifications section.
+#if os(iOS) || os(macOS)
+import SwiftUI
+import UserNotifications
+import CabalmailKit
+
+/// "Notifications" section of the Settings form (push phase 5).
+///
+/// The master toggle drives `PushRegistrar.enablePush` / `disablePush`; the
+/// scope picker and folder list persist through
+/// `PushRegistrar.updateFolderScope`, which re-registers the stored token
+/// immediately so the server row tracks the choice without waiting for the
+/// next launch. All of this state is per device by design — the server keeps
+/// the folder list on this device's token row, so there is no
+/// get/set_preferences mirror.
+///
+/// Every row is always present (disabled, never removed) and the checkmark
+/// in the folder picker reserves its space when unselected, so no state
+/// change shifts a control's position or size.
+struct NotificationSettingsSection: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.scenePhase) private var scenePhase
+
+    /// The user's intent (inverse of `PushSettings.isUserDisabled`). When
+    /// the OS-level permission is denied the toggle *displays* off and
+    /// disabled regardless, but the stored intent is kept so re-granting
+    /// permission in Settings restores the previous choice.
+    @State private var pushEnabled = !PushSettings.isUserDisabled
+    @State private var scope = PushSettings.folderScope
+    @State private var chosenFolders = Set(PushSettings.chosenFolders)
+    @State private var systemDenied = false
+    #if os(macOS)
+    // The macOS Settings scene has no NavigationStack (by design — see
+    // SettingsView's top comment), so a NavigationLink would render
+    // permanently disabled. Present the folder picker as a sheet instead,
+    // same pattern as the Acknowledgements row.
+    @State private var showingFolderPicker = false
+    #endif
+
+    var body: some View {
+        Section {
+            Toggle("New-mail notifications", isOn: enabledBinding)
+                .disabled(systemDenied)
+                .task { await refreshSystemPermission() }
+                .onChange(of: scenePhase) { _, phase in
+                    // Re-check after a round trip to Settings/System
+                    // Settings, where the user may have (un)denied us.
+                    guard phase == .active else { return }
+                    Task { await refreshSystemPermission() }
+                }
+            Picker("Notify for", selection: scopeBinding) {
+                Text("Inbox only").tag(PushFolderScope.inboxOnly)
+                Text("All folders").tag(PushFolderScope.all)
+                Text("Chosen folders").tag(PushFolderScope.custom)
+            }
+            .disabled(!controlsEnabled)
+            chooseFoldersRow
+                .disabled(!controlsEnabled || scope != .custom)
+                .onChange(of: chosenFolders) { _, newValue in
+                    PushRegistrar.shared.updateFolderScope(
+                        scope,
+                        chosenFolders: newValue.sorted()
+                    )
+                }
+        } header: {
+            Text("Notifications")
+        } footer: {
+            // Always present (content swaps, structure doesn't) so the
+            // sections below never reflow when the permission state changes.
+            Text(footerText)
+        }
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder
+    private var chooseFoldersRow: some View {
+        #if os(macOS)
+        Button {
+            showingFolderPicker = true
+        } label: {
+            folderRowLabel
+        }
+        .sheet(isPresented: $showingFolderPicker) {
+            NavigationStack {
+                NotificationFolderPickerView(selection: $chosenFolders)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { showingFolderPicker = false }
+                        }
+                    }
+            }
+            .frame(minWidth: 360, minHeight: 420)
+        }
+        #else
+        NavigationLink {
+            NotificationFolderPickerView(selection: $chosenFolders)
+        } label: {
+            folderRowLabel
+        }
+        #endif
+    }
+
+    private var folderRowLabel: some View {
+        LabeledContent("Choose Folders") {
+            Text("\(chosenFolders.count) selected")
+        }
+    }
+
+    // MARK: - Bindings and state
+
+    /// The toggle, scope picker, and folder row are enabled together: all
+    /// three are inert while notifications are off or denied at OS level.
+    private var controlsEnabled: Bool {
+        pushEnabled && !systemDenied
+    }
+
+    private var enabledBinding: Binding<Bool> {
+        Binding(
+            get: { pushEnabled && !systemDenied },
+            set: { newValue in
+                pushEnabled = newValue
+                Task {
+                    if newValue {
+                        let granted = await PushRegistrar.shared.enablePush()
+                        if !granted {
+                            // The OS said no (fresh denial or an earlier
+                            // one): show that honestly instead of a lying
+                            // "on" toggle.
+                            pushEnabled = false
+                            await refreshSystemPermission()
+                        }
+                    } else {
+                        await PushRegistrar.shared.disablePush()
+                    }
+                }
+            }
+        )
+    }
+
+    private var scopeBinding: Binding<PushFolderScope> {
+        Binding(
+            get: { scope },
+            set: { newValue in
+                scope = newValue
+                PushRegistrar.shared.updateFolderScope(
+                    newValue,
+                    chosenFolders: chosenFolders.sorted()
+                )
+            }
+        )
+    }
+
+    private var footerText: String {
+        if systemDenied {
+            #if os(macOS)
+            return "Notifications for Cabalmail are turned off in System Settings > Notifications."
+            #else
+            return "Notifications for Cabalmail are turned off in Settings > Notifications."
+            #endif
+        }
+        return "Notifies about new mail in the selected folders, even when Cabalmail isn't running."
+    }
+
+    private func refreshSystemPermission() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        systemDenied = settings.authorizationStatus == .denied
+    }
+}
+
+/// Multi-select folder list backing the "Chosen folders" scope. Loads every
+/// folder (subscribed or not — a notification scope is orthogonal to sidebar
+/// subscription), sorted like the sidebar: INBOX first, user folders in tree
+/// order, system folders last. Selection writes through the binding; the
+/// owning section persists and re-registers on each change.
+struct NotificationFolderPickerView: View {
+    @Environment(AppState.self) private var appState
+    @Binding var selection: Set<String>
+
+    @State private var folders: [Folder] = []
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        content
+            .navigationTitle("Notification Folders")
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .task { await load() }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isLoading {
+            ProgressView("Loading folders…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let errorMessage {
+            VStack(spacing: 12) {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                Button("Retry") {
+                    Task { await load() }
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(folders) { folder in
+                Button {
+                    toggle(folder.path)
+                } label: {
+                    row(for: folder)
+                }
+                .buttonStyle(.plain)
+            }
+            #if os(iOS)
+            .listStyle(.plain)
+            #endif
+        }
+    }
+
+    @ViewBuilder
+    private func row(for folder: Folder) -> some View {
+        let depth = FolderTree.depth(for: folder)
+        HStack(spacing: 8) {
+            Image(systemName: icon(for: folder))
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(folder.name)
+                    .font(.body)
+                if depth > 0 {
+                    Text(folder.path)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+            // Opacity, not conditional presence: the checkmark keeps its
+            // slot so rows don't shift as folders are (de)selected.
+            Image(systemName: "checkmark")
+                .foregroundStyle(.tint)
+                .opacity(selection.contains(folder.path) ? 1 : 0)
+        }
+        .padding(.leading, CGFloat(depth) * 16)
+        .contentShape(Rectangle())
+    }
+
+    private func toggle(_ path: String) {
+        if selection.contains(path) {
+            selection.remove(path)
+        } else {
+            selection.insert(path)
+        }
+    }
+
+    private func icon(for folder: Folder) -> String {
+        switch folder.path {
+        case "INBOX":   return "tray"
+        case "Sent":    return "paperplane"
+        case "Drafts":  return "pencil.line"
+        case "Trash":   return "trash"
+        case "Junk":    return "exclamationmark.shield"
+        case "Archive": return "archivebox"
+        default:        return "folder"
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard let client = appState.client else {
+            isLoading = false
+            errorMessage = "Sign in to load folders."
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        do {
+            try await client.imapClient.connectAndAuthenticate()
+            let all = try await client.imapClient.listFolders()
+            folders = sortForPicker(all)
+        } catch {
+            errorMessage = "Couldn't load folders: \(error.localizedDescription)"
+        }
+    }
+
+    /// Same visible order as the sidebar and MoveToFolderSheet — INBOX
+    /// pinned first, user folders in tree order, system folders last — but
+    /// nothing is filtered out: any folder can be a notification source.
+    private func sortForPicker(_ input: [Folder]) -> [Folder] {
+        let systemNames: Set<String> = ["Sent", "Drafts", "Trash", "Junk", "Archive"]
+        let inbox = input.filter { folder in
+            folder.path.caseInsensitiveCompare("INBOX") == .orderedSame
+        }
+        let system = input
+            .filter { systemNames.contains($0.path) }
+            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+        let userFolders = input.filter { folder in
+            !inbox.contains(folder) && !system.contains(folder)
+        }
+        return inbox + FolderTree.sortUserTree(userFolders) + system
+    }
+}
+#endif

--- a/apple/Cabalmail/Views/SettingsView.swift
+++ b/apple/Cabalmail/Views/SettingsView.swift
@@ -70,6 +70,11 @@ struct SettingsView: View {
             readingSection(bindable: preferences)
             composingSection(bindable: preferences)
             actionsSection(bindable: preferences)
+            // Push ships on iOS and macOS only; the visionOS build has no
+            // PushRegistrar, so the section is compiled out with it.
+            #if os(iOS) || os(macOS)
+            NotificationSettingsSection()
+            #endif
             appearanceSection(bindable: preferences)
             diagnosticsSection(bindable: preferences)
             AboutSettingsSection()

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
@@ -435,9 +435,11 @@ public struct PushDeviceRegistration: Sendable, Hashable {
     public let platform: String
     public let appVersion: String
     public let locale: String
-    /// Folders to push for (`["*"]` = all). Nil omits the field so the
-    /// server keeps its stored / default value — the per-folder picker is
-    /// a later phase.
+    /// Folders to push for. `["*"]` = all folders, `[]` = explicit reset
+    /// to the server's inbox-only default, a list = exactly those folders
+    /// (display-form `/` paths are fine; the Lambda normalizes). Nil omits
+    /// the field so the server keeps its stored value — the apps always
+    /// send an explicit value (see `PushSettings.enabledFolders`).
     public let enabledFolders: [String]?
 
     public init(

--- a/apple/CabalmailMac/CabalmailMac.entitlements
+++ b/apple/CabalmailMac/CabalmailMac.entitlements
@@ -10,5 +10,41 @@
     <true/>
     <key>com.apple.security.personal-information.addressbook</key>
     <true/>
+
+    <!--
+        Push notifications (docs/0.11.0/push-notifications.md, phase 6).
+        NOTE: macOS uses the `com.apple.developer.`-prefixed key here,
+        unlike iOS's bare `aps-environment` — a real platform difference,
+        not a typo (compare Cabalmail/Cabalmail.entitlements). As on iOS,
+        the value is always `development`; a distribution provisioning
+        profile rewrites it to `production` at signing time, so no
+        per-config switching is needed.
+    -->
+    <key>com.apple.developer.aps-environment</key>
+    <string>development</string>
+
+    <!--
+        App Group shared with the Notification Service Extension. Carries
+        the API Gateway URL via `UserDefaults(suiteName:)` so the NSE can
+        call `/push_envelope` without linking CabalmailKit. Same group as
+        the iOS pair — macOS accepts `group.`-prefixed App Group IDs.
+    -->
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.cabalmail.Cabalmail</string>
+    </array>
+
+    <!--
+        Keychain sharing with the NSE. The app's own identifier stays FIRST:
+        items stored without an explicit access group default to the first
+        entry, so existing Cognito-token / IMAP-password items keep landing
+        in the app-private group exactly as before this entitlement existed.
+        Only `PushEnrichmentStore` targets the shared group, explicitly.
+    -->
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.cabalmail.CabalmailMac</string>
+        <string>$(AppIdentifierPrefix)com.cabalmail.shared</string>
+    </array>
 </dict>
 </plist>

--- a/apple/CabalmailMac/CabalmailMacApp.swift
+++ b/apple/CabalmailMac/CabalmailMacApp.swift
@@ -11,6 +11,11 @@ import CabalmailKit
 /// carries the full request/revoke and create/delete affordances.
 @main
 struct CabalmailMacApp: App {
+    // Push notifications: APNs token callbacks and the notification-center
+    // delegate have no SwiftUI-native surface, so the macOS build carries a
+    // minimal AppKit delegate — the same AppDelegate.swift source the iOS
+    // target compiles, with an NSApplicationDelegate branch (see that file).
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var appState = AppState()
     @State private var preferences = Preferences(store: UbiquitousPreferenceStore())
 

--- a/apple/CabalmailMacNotificationService/CabalmailMacNotificationService.entitlements
+++ b/apple/CabalmailMacNotificationService/CabalmailMacNotificationService.entitlements
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Wired via `apple/project.yml` (CODE_SIGN_ENTITLEMENTS on the
+        CabalmailMacNotificationService target). macOS twin of the iOS
+        NSE's entitlements: the extension reads two values the main app
+        mirrors for it (see CabalmailKit's `PushEnrichmentStore`):
+
+          - the API Gateway URL, from the App Group `UserDefaults`, and
+          - the Cognito ID token, from the shared keychain access group.
+
+        The NSE never registers for push itself, so no aps-environment
+        here — only the containers it reads from, plus the two macOS-only
+        sandbox keys below (iOS is implicitly sandboxed and grants
+        outbound network by default; a sandboxed mac process gets neither
+        implicitly).
+    -->
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <!--
+        The enrichment call to `/push_envelope` is an outbound HTTPS
+        request; without this the sandboxed extension's URLSession fails
+        and every notification degrades to the "New mail" fallback.
+    -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.cabalmail.Cabalmail</string>
+    </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>$(AppIdentifierPrefix)com.cabalmail.CabalmailMac.NotificationService</string>
+        <string>$(AppIdentifierPrefix)com.cabalmail.shared</string>
+    </array>
+</dict>
+</plist>

--- a/apple/CabalmailMacNotificationService/Info.plist
+++ b/apple/CabalmailMacNotificationService/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Cabalmail Notification Service</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/apple/README.md
+++ b/apple/README.md
@@ -167,7 +167,8 @@ are expanded in the sections further down.
    | `com.cabalmail.Cabalmail` | `Cabalmail` | **Push Notifications**; **App Groups** (configure → tick `group.com.cabalmail.Cabalmail`) |
    | `com.cabalmail.Cabalmail.NotificationService` | `Cabalmail Notification Service` | **App Groups** (same group). Not Push Notifications — the extension never registers for push itself; it only reads the shared containers |
    | `com.cabalmail.Cabalmail.watchkitapp` | `Cabalmail Watch` | none |
-   | `com.cabalmail.CabalmailMac` | `Cabalmail Mac` | none |
+   | `com.cabalmail.CabalmailMac` | `Cabalmail Mac` | **Push Notifications**; **App Groups** (same group) |
+   | `com.cabalmail.CabalmailMac.NotificationService` | `Cabalmail Mac Notification Service` | **App Groups** (same group), same rationale as the iOS extension |
 
    Keychain sharing (the app and the extension share a keychain access
    group) needs no portal capability — profiles honor the
@@ -283,6 +284,7 @@ Environments → `stage` / `prod`).
 | Secret | What it is |
 |---|---|
 | `MAC_APP_STORE_PROFILE` | base64 of the `.provisionprofile` for `com.cabalmail.CabalmailMac` (App Store distribution). |
+| `MAC_NSE_APP_STORE_PROFILE` | base64 of the `.provisionprofile` for `com.cabalmail.CabalmailMac.NotificationService` (App Store distribution), the push Notification Service Extension embedded in the macOS archive. The macOS upload leg skips (with a warning) until this secret exists — it doubles as the "macOS push signing assets are ready" sentinel. |
 | `MAC_INSTALLER_CERT_P12` | base64 of a **Mac Installer Distribution** `.p12`. The outer `.pkg` that wraps the macOS `.app` is signed with this cert (distinct from `Apple Distribution`, which signs the `.app` bundle itself). See [Exporting the Mac Installer certificate](#exporting-the-mac-installer-certificate). |
 | `MAC_INSTALLER_CERT_PASSWORD` | Password used when exporting the `.p12`. Must be non-empty. |
 
@@ -292,7 +294,8 @@ Environments → `stage` / `prod`).
 |---|---|
 | `DEVELOPER_ID_CERT_P12` | base64 of your **Developer ID Application** `.p12` (different cert type from Apple Distribution) |
 | `DEVELOPER_ID_CERT_PASSWORD` | Password you set when exporting the `.p12` |
-| `MAC_DEVID_PROFILE` | base64 of the `.provisionprofile` for `com.cabalmail.CabalmailMac` (Developer ID distribution). Both `DEVELOPER_ID_CERT_P12` and this must be set to produce the notarized artifact; either missing one and the job completes after the TestFlight upload and skips notarization. |
+| `MAC_DEVID_PROFILE` | base64 of the `.provisionprofile` for `com.cabalmail.CabalmailMac` (Developer ID distribution). All three Developer-ID secrets (cert + this + the NSE profile below) must be set to produce the notarized artifact; missing any one and the job completes after the TestFlight upload and skips notarization. |
+| `MAC_NSE_DEVID_PROFILE` | base64 of the `.provisionprofile` for `com.cabalmail.CabalmailMac.NotificationService` (Developer ID distribution) — the embedded extension needs its own profile under the developer-id export method. |
 
 The App Store Connect API key triple (`KEY_ID` + `ISSUER_ID` + `P8`) is used
 for `altool` uploads and macOS `notarytool` submission. Under manual signing
@@ -408,7 +411,9 @@ distribution cert you just exported. Recreate them whenever the cert rolls
    | Cabalmail NSE App Store | App Store | `com.cabalmail.Cabalmail.NotificationService` | Apple Distribution | `.mobileprovision` |
    | Cabalmail Watch App Store | App Store | `com.cabalmail.Cabalmail.watchkitapp` | Apple Distribution | `.mobileprovision` |
    | Cabalmail macOS App Store | App Store | `com.cabalmail.CabalmailMac` | Apple Distribution | `.provisionprofile` |
+   | Cabalmail macOS NSE App Store | App Store | `com.cabalmail.CabalmailMac.NotificationService` | Apple Distribution | `.provisionprofile` |
    | Cabalmail macOS Developer ID *(optional)* | Developer ID | `com.cabalmail.CabalmailMac` | Developer ID Application | `.provisionprofile` |
+   | Cabalmail macOS NSE Developer ID *(optional)* | Developer ID | `com.cabalmail.CabalmailMac.NotificationService` | Developer ID Application | `.provisionprofile` |
 
    Profile names are arbitrary — CI matches by the UUID embedded in the
    file, not the name. All profiles share the same Apple Distribution
@@ -426,7 +431,9 @@ distribution cert you just exported. Recreate them whenever the cert rolls
    | NSE `.mobileprovision` | `IOS_NSE_APP_STORE_PROFILE` |
    | Watch `.mobileprovision` | `WATCHOS_APP_STORE_PROFILE` |
    | macOS App Store `.provisionprofile` | `MAC_APP_STORE_PROFILE` |
+   | macOS NSE App Store `.provisionprofile` | `MAC_NSE_APP_STORE_PROFILE` |
    | macOS Developer ID `.provisionprofile` | `MAC_DEVID_PROFILE` |
+   | macOS NSE Developer ID `.provisionprofile` | `MAC_NSE_DEVID_PROFILE` |
 
    Stray whitespace — a trailing newline from the paste, or a `base64`
    build that wraps its output — is harmless: the workflow strips all

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -212,10 +212,19 @@ targets:
       # Shared with AppState.swift: the no-op stub branch compiles here
       # (WatchConnectivity is iOS-only). See WatchSessionBridge.swift.
       - path: Cabalmail/WatchSessionBridge.swift
+      # Push notifications (phase 6, macOS parity): one implementation for
+      # both platforms — each file carries an `#if os(iOS)` / `#else`
+      # (AppKit) branch around the small platform seams.
+      - path: Cabalmail/AppDelegate.swift
+      - path: Cabalmail/PushRegistrar.swift
       - path: Cabalmail/Views
       - path: Cabalmail/ViewModels
     dependencies:
       - package: CabalmailKit
+      # Notification Service Extension, macOS flavor: same enrichment
+      # source as the iOS target's extension, compiled into a separate
+      # macOS appex (see the CabalmailMacNotificationService target).
+      - target: CabalmailMacNotificationService
     info:
       path: CabalmailMac/Info.plist
       properties:
@@ -251,6 +260,11 @@ targets:
           and name next to mail you receive, and to add senders to
           your contacts when you choose. Your contacts stay on
           this device.
+        # See the Cabalmail target's equivalent comment: read at runtime by
+        # `PushEnrichmentStore` to compose the fully-qualified shared
+        # keychain access group. Without it the mac app never mirrors the
+        # ID token and every notification stays "New mail".
+        AppIdentifierPrefix: "$(AppIdentifierPrefix)"
         # See the Cabalmail target's equivalent comment — XcodeGen defaults
         # these to "1" / "1.0" unless explicitly plumbed through to the
         # build settings.
@@ -402,6 +416,61 @@ targets:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "Apple Distribution"
           PROVISIONING_PROFILE_SPECIFIER: "$(IOS_NSE_APP_STORE_PROFILE_UUID)"
+
+  # macOS twin of CabalmailNotificationService (push phase 6). Compiles the
+  # SAME Swift source — the NSE is Foundation + UserNotifications + Security
+  # only, with nothing platform-conditional in it — into a separate macOS
+  # appex product with its own bundle id, Info.plist, and entitlements
+  # (sandboxed mac processes need explicit network.client; see the
+  # entitlements file). Embedded in CabalmailMac, never in the iOS/visionOS
+  # app.
+  CabalmailMacNotificationService:
+    type: app-extension
+    platform: macOS
+    sources:
+      - path: CabalmailNotificationService/NotificationService.swift
+    info:
+      path: CabalmailMacNotificationService/Info.plist
+      properties:
+        CFBundleDisplayName: Cabalmail Notification Service
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.usernotifications.service
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService"
+        # See the Cabalmail target's equivalent comment — XcodeGen defaults
+        # these to "1" / "1.0" unless explicitly plumbed through to the
+        # build settings. App Store validation additionally requires an
+        # extension's versions to match its host app exactly; CI passes both
+        # on the xcodebuild command line, reaching every target at once.
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+    settings:
+      base:
+        # Apple's convention for app extensions: the host app's bundle id
+        # plus a suffix. The push-dispatch Lambda targets the *host* topic
+        # (com.cabalmail.CabalmailMac, already in push_register's
+        # allowlist); this id only matters for embedding and provisioning.
+        PRODUCT_BUNDLE_IDENTIFIER: com.cabalmail.CabalmailMac.NotificationService
+        # Keep in lockstep with the CabalmailMac target above (host/extension
+        # version match is enforced at App Store validation).
+        MARKETING_VERSION: "0.6.0"
+        CURRENT_PROJECT_VERSION: "1"
+        GENERATE_INFOPLIST_FILE: NO
+        # Same requirement as the host app: hardened runtime is mandatory
+        # for notarized / App Store macOS code, extensions included.
+        ENABLE_HARDENED_RUNTIME: YES
+        # App Group (shared UserDefaults for api_url), shared keychain
+        # access group (Cognito ID token), sandbox + outbound network.
+        # Mirrors the host app's additions in CabalmailMac.entitlements.
+        CODE_SIGN_ENTITLEMENTS: CabalmailMacNotificationService/CabalmailMacNotificationService.entitlements
+      configs:
+        # See the Cabalmail target's matching block for why manual-signing
+        # settings live per-target instead of on the xcodebuild command
+        # line. CI injects MAC_NSE_APP_STORE_PROFILE_UUID as a user-defined
+        # setting when archiving the mac app (which embeds this target).
+        Release:
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "$(MAC_NSE_APP_STORE_PROFILE_UUID)"
 
 schemes:
   Cabalmail:

--- a/changelog.d/push-phase5-6-apple.added.md
+++ b/changelog.d/push-phase5-6-apple.added.md
@@ -1,0 +1,8 @@
+- Apple: **Notification settings and macOS push.** The Mac app now gets the
+  same new-mail notifications as iOS — enriched on-device, with the Open /
+  Mark as Read / Archive actions — and both platforms gain a Notifications
+  section in Settings: a master toggle (honest about the system-level
+  permission state, with a pointer to Settings/System Settings when denied
+  there) and a folder scope — Inbox only, All folders, or a hand-picked
+  folder list. Scope changes take effect immediately; turning the toggle
+  off deregisters the device and stays off across launches.

--- a/changelog.d/push-token-gc.added.md
+++ b/changelog.d/push-token-gc.added.md
@@ -1,0 +1,5 @@
+- **Weekly push-token garbage collection.** A scheduled Lambda
+  (`push_token_gc`) reaps device-token rows idle for 90+ days — the backstop
+  for tokens that neither APNs-rejection pruning nor sign-out deregistration
+  can reach (a device that stopped launching the app whose user receives no
+  mail). A reaped device transparently re-registers on its next app launch.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -144,11 +144,20 @@ push-specific portal work, in order:
    are ready" sentinel, so neither leg can fail codesign against a stale
    profile.
 
-The macOS app carries none of the push entitlements and no extension, so
-its App ID and profiles need no changes until a macOS Notification Service
-Extension ships; the backend is already multi-app (the dispatch Lambda
-selects the APNs topic per registered token, and the same APNs key covers
-every app on the team).
+The macOS app repeats the same shape with its own identifiers — the
+backend needs nothing either way (the dispatch Lambda selects the APNs
+topic per registered token, and the same APNs key covers every app on the
+team):
+
+- App Group: the same `group.com.cabalmail.Cabalmail`.
+- `com.cabalmail.CabalmailMac`: **Push Notifications** + **App Groups**;
+  re-issue its App Store profile afterwards.
+- `com.cabalmail.CabalmailMac.NotificationService`: **App Groups only**,
+  plus its own App Store profile.
+- Secrets: refresh `MAC_APP_STORE_PROFILE`, add
+  `MAC_NSE_APP_STORE_PROFILE` (the macOS upload leg's skip-gate
+  sentinel). The optional notarized-artifact leg additionally needs
+  `MAC_NSE_DEVID_PROFILE` alongside the existing Developer ID pair.
 
 ## Operational notes
 
@@ -173,9 +182,12 @@ every app on the team).
   and does not survive a task replacement, which loses at most the last
   seconds of wake signals, not mail.
 - **Token hygiene.** `last_seen_at` on each `cabal-push-tokens` row is
-  updated on every successful push and registration; `last_failure` records
-  the most recent APNs rejection reason. Rows for uninstalled devices are
-  pruned automatically on the next push attempt.
+  updated on registration and refreshed by successful pushes;
+  `last_failure` records the most recent APNs rejection reason. Rows for
+  uninstalled devices are pruned automatically on the next push attempt,
+  and the weekly `push_token_gc` Lambda reaps rows idle for 90+ days as
+  the backstop for devices no rejection ever surfaces (logs at
+  `/cabal/lambda/push_token_gc`).
 - **Enrichment during IMAP rolls.** `/push_envelope` returns 503 while a
   planned IMAP redeploy is in flight; devices fall back to the generic
   alert. Nothing needs doing.

--- a/lambda/api/push_token_gc/function.py
+++ b/lambda/api/push_token_gc/function.py
@@ -1,0 +1,63 @@
+'''Weekly garbage collection for stale APNs device-token rows.
+
+push_dispatch prunes tokens the moment APNs rejects them (410 Unregistered /
+BadDeviceToken), and push_deregister removes them on sign-out — so this is
+the backstop for the rows neither path can reach: a device that stopped
+launching the app (no re-registration refreshing last_seen_at) whose user
+receives no mail (no send ever surfaces an APNs rejection). Without mail
+there is no push, so nothing is lost by reaping; a device that comes back
+re-registers on its next launch. See docs/0.11.0/push-notifications.md.
+
+Scheduled weekly via EventBridge Scheduler
+(terraform/infra/modules/app/push_token_gc.tf).'''
+import datetime
+import os
+
+import boto3  # pylint: disable=import-error
+
+ddb = boto3.resource('dynamodb')
+TABLE_NAME = os.environ.get('PUSH_TOKENS_TABLE_NAME', 'cabal-push-tokens')
+table = ddb.Table(TABLE_NAME)
+
+MAX_IDLE_DAYS = 90
+
+
+def _is_stale(row, cutoff):
+    '''True when the row's freshest timestamp is older than the cutoff.
+    Registration always stamps both fields, so a row with neither is
+    malformed and reaped too.'''
+    freshest = max(
+        str(row.get('last_seen_at') or ''),
+        str(row.get('created_at') or ''),
+    )
+    return freshest < cutoff
+
+
+def handler(_event, _context):
+    '''Scans the token table and deletes rows idle past MAX_IDLE_DAYS.'''
+    cutoff = (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(days=MAX_IDLE_DAYS)
+    ).isoformat()
+
+    scanned, reaped = 0, 0
+    scan_kwargs = {
+        'ProjectionExpression': '#u, device_token, last_seen_at, created_at',
+        'ExpressionAttributeNames': {'#u': 'user'},
+    }
+    while True:
+        page = table.scan(**scan_kwargs)
+        for row in page.get('Items', []):
+            scanned += 1
+            if _is_stale(row, cutoff):
+                table.delete_item(
+                    Key={'user': row['user'], 'device_token': row['device_token']})
+                reaped += 1
+                print(f"[push-token-gc] reaped token for {row['user']} "
+                      f"(last seen {row.get('last_seen_at') or 'never'})")
+        if 'LastEvaluatedKey' not in page:
+            break
+        scan_kwargs['ExclusiveStartKey'] = page['LastEvaluatedKey']
+
+    print(f'[push-token-gc] scanned {scanned}, reaped {reaped}')
+    return {'statusCode': 200, 'body': f'{{"scanned": {scanned}, "reaped": {reaped}}}'}

--- a/lambda/api/push_token_gc/requirements.txt
+++ b/lambda/api/push_token_gc/requirements.txt
@@ -1,0 +1,1 @@
+# boto3 only (provided by the Lambda runtime); no bundled dependencies.

--- a/terraform/infra/modules/app/push_token_gc.tf
+++ b/terraform/infra/modules/app/push_token_gc.tf
@@ -1,0 +1,154 @@
+# Weekly garbage collection for stale push device tokens
+# (docs/0.11.0/push-notifications.md): the backstop for token rows that
+# neither push_dispatch's APNs-rejection pruning nor push_deregister's
+# sign-out path can reach. Scheduled Lambda modeled on process_dmarc's
+# EventBridge Scheduler wiring.
+
+# -- IAM role for the GC Lambda ----------------------------------
+
+resource "aws_iam_role" "push_token_gc" {
+  name = "push_token_gc_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Sid       = "pushTokenGcSid"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "push_token_gc" {
+  name = "push_token_gc_policy"
+  role = aws_iam_role.push_token_gc.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:Scan",
+          "dynamodb:DeleteItem",
+        ]
+        Resource = "arn:aws:dynamodb:${var.region}:${data.aws_caller_identity.current.account_id}:table/cabal-push-tokens"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "${aws_cloudwatch_log_group.push_token_gc.arn}:*"
+      }
+    ]
+  })
+}
+
+# -- Lambda function ---------------------------------------------
+
+resource "aws_cloudwatch_log_group" "push_token_gc" {
+  name              = "/cabal/lambda/push_token_gc"
+  retention_in_days = 365
+}
+
+data "aws_s3_object" "push_token_gc_hash" {
+  bucket = var.bucket
+  key    = "lambda/push_token_gc.zip.base64sha256"
+}
+
+#tfsec:ignore:aws-lambda-enable-tracing
+resource "aws_lambda_function" "push_token_gc" {
+  # Same posture as push_dispatch / append_sent:
+  #checkov:skip=CKV_AWS_115: shared-pool concurrency is the point; a per-function reserve would starve the API lambdas
+  #checkov:skip=CKV_AWS_116: scheduler-invoked housekeeping; a missed weekly run is retried next week, a DLQ would only collect noise
+  #checkov:skip=CKV_AWS_117: touches only AWS APIs; a VPC placement would add a NAT dependency for zero data-plane gain
+  #checkov:skip=CKV_AWS_272: code-signing is not part of this repo's Lambda supply chain (zips are hash-pinned at build; see build-api-one.sh)
+  #checkov:skip=CKV_AWS_50: X-Ray tracing is not used anywhere in this stack (see the tfsec ignore above)
+  s3_bucket        = var.bucket
+  s3_key           = "lambda/push_token_gc.zip"
+  source_code_hash = data.aws_s3_object.push_token_gc_hash.body
+  function_name    = "push_token_gc"
+  role             = aws_iam_role.push_token_gc.arn
+  handler          = "function.handler"
+  runtime          = "python3.13"
+  architectures    = ["arm64"]
+  # A full-table scan of a small table; generous headroom over the 29s
+  # API-lambda convention because nothing user-facing waits on this.
+  timeout     = 120
+  memory_size = 128
+
+  logging_config {
+    log_format = "Text"
+    log_group  = aws_cloudwatch_log_group.push_token_gc.name
+  }
+
+  environment {
+    variables = {
+      PUSH_TOKENS_TABLE_NAME = "cabal-push-tokens"
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.push_token_gc]
+
+  # Out-of-band Lambda deploys mutate code via aws lambda update-function-code;
+  # ignore these so a topology-only Terraform apply does not roll the update
+  # back (matches push_dispatch and the call module).
+  lifecycle {
+    ignore_changes = [s3_key, s3_object_version, source_code_hash]
+  }
+}
+
+# -- Weekly schedule ---------------------------------------------
+
+resource "aws_iam_role" "push_token_gc_scheduler" {
+  name = "cabal-push-token-gc-scheduler"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "push_token_gc_scheduler_invoke" {
+  name = "cabal-push-token-gc-scheduler-invoke"
+  role = aws_iam_role.push_token_gc_scheduler.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = aws_lambda_function.push_token_gc.arn
+      }
+    ]
+  })
+}
+
+resource "aws_scheduler_schedule" "push_token_gc" {
+  name        = "cabal-push-token-gc"
+  description = "Reap push device tokens idle for 90+ days (weekly backstop)"
+
+  flexible_time_window {
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 60
+  }
+
+  schedule_expression = "rate(7 days)"
+
+  target {
+    arn      = aws_lambda_function.push_token_gc.arn
+    role_arn = aws_iam_role.push_token_gc_scheduler.arn
+  }
+}


### PR DESCRIPTION
Completes the push-notification plan (docs/0.11.0/push-notifications.md): phase 5 (per-folder opt-out) and phase 6 (macOS parity), plus the token-GC backstop.

## Phase 5 — Notification settings (iOS + macOS)
- New **Notifications** section in Settings: master toggle + folder scope (Inbox only / All folders / Chosen folders with a multi-select picker, INBOX preselected, minimum one selection).
- The toggle reflects the real OS permission state (re-checked when the scene activates; footer points at Settings/System Settings when denied there); all states keep a stable footprint. OFF deregisters and sets a user-disabled flag that launches honor — no re-prompt, no silent re-registration, including a token-rotation callback or an in-flight registration racing the toggle (compensating deregister).
- Every registration now sends the **explicit** current scope (`[]` inbox-only / `["*"]` all / chosen paths), so the server row is deterministic per device. Deliberately not built: per-address muting, and a get/set_preferences mirror (the token row is the single source of truth for per-device state).

## Phase 6 — macOS parity + GC
- `CabalmailMacNotificationService` extension target compiling the same NSE source; mac app gains `com.apple.developer.aps-environment` (the macOS-prefixed key), the App Group, keychain sharing, and the `AppIdentifierPrefix` plumbing. One cross-platform `PushRegistrar`/`AppDelegate` behind a small Platform shim (NSApplication registration; no background-task API on macOS). Backend needed nothing — bundle-id allowlist and per-token APNs topic were ready.
- **`push_token_gc`** Lambda, weekly via EventBridge Scheduler: reaps token rows idle 90+ days — the case neither APNs-rejection pruning nor sign-out deregistration reaches.
- **apple.yml `upload-mac`**: converted from fail-on-missing-secrets to the iOS job's skip pattern, gated on the new `MAC_NSE_APP_STORE_PROFILE` sentinel; NSE profile install/archive/ExportOptions wiring on the App Store leg; the optional Developer ID leg's self-gate now also requires `MAC_NSE_DEVID_PROFILE`.
- Docs: README capability/profile/secret tables and the runbook's macOS walkthrough.

## Review
A three-angle review over the diff found (and this PR fixes): a duplicate `if:` key my skip-guard conversion introduced that GitHub's parser would have rejected — taking down the whole Apple workflow; the empty-custom-selection wire mismatch; and the disable-while-registering race.

## Verification
iOS/macOS/visionOS builds clean (mac app embeds the .appex; visionOS embeds neither NSE) · swiftlint --strict 0 · kit tests pass (known-environmental AcknowledgementsTests aside) · pylint 10/10 · terraform validate/fmt, Checkov (0 new), trivy, suppression + IAM-scope checkers clean · strict dup-key YAML validation on both changed workflows.

## Operator steps (all safe to do before merge; details in apple/README.md + docs/push-notifications.md)
1. Portal: Push + App Groups on `com.cabalmail.CabalmailMac`; new `com.cabalmail.CabalmailMac.NotificationService` App ID (App Groups only); re-issue the Mac App Store profile; create the mac NSE profile.
2. Secrets (stage + prod): refresh `MAC_APP_STORE_PROFILE`, add `MAC_NSE_APP_STORE_PROFILE` (until it exists the mac upload leg skips with a warning — by design). Only if you use the notarized-artifact leg: `MAC_NSE_DEVID_PROFILE`.
3. Nothing AWS-side beyond the normal deploy; no new SSM parameters (the team-wide APNs key already covers macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)