### PR TITLE
Fix macOS notification enrichment; refresh open views after actions

### DIFF
--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -451,6 +451,11 @@ extension PushRegistrar {
         }
         do {
             try await work(client)
+            // The action just mutated a folder server-side; if the app is
+            // running, its open views only learn of external changes on the
+            // next poll — nudge the shared refresh tick so Mark as Read /
+            // Archive appear immediately instead of at the poll boundary.
+            appState?.requestRefresh()
         } catch {
             CabalmailLog.warn("Push", "\(name) failed: \(error)")
         }

--- a/apple/CabalmailMacNotificationService/Info.plist
+++ b/apple/CabalmailMacNotificationService/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppIdentifierPrefix</key>
+	<string>$(AppIdentifierPrefix)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/apple/CabalmailNotificationService/NotificationService.swift
+++ b/apple/CabalmailNotificationService/NotificationService.swift
@@ -1,6 +1,14 @@
 import Foundation
+import os
 import Security
 import UserNotifications
+
+/// Fallback-path diagnostics. The *user-facing* posture stays silent (any
+/// failure ships the generic "New mail"), but each bail-out logs its reason
+/// so a `log show --predicate 'subsystem == "com.cabalmail.nse"'` names the
+/// failing guard instead of requiring elimination — the macOS keychain gap
+/// that motivated this took a whole debugging session to localize without it.
+let nseLog = Logger(subsystem: "com.cabalmail.nse", category: "enrich")
 
 /// Notification Service Extension: enriches the wake-signal push.
 ///
@@ -28,11 +36,18 @@ final class NotificationService: UNNotificationServiceExtension {
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
         state.begin(content: request.content, handler: contentHandler)
-        guard
-            let query = EnvelopeQuery(userInfo: request.content.userInfo),
-            let endpoint = PushHandoff.enrichmentEndpoint(),
-            let token = PushHandoff.currentIdToken()
-        else {
+        guard let query = EnvelopeQuery(userInfo: request.content.userInfo) else {
+            nseLog.error("fallback: no parseable msgRef in payload")
+            state.deliverFallback()
+            return
+        }
+        guard let endpoint = PushHandoff.enrichmentEndpoint() else {
+            nseLog.error("fallback: no api_url in the App Group container")
+            state.deliverFallback()
+            return
+        }
+        guard let token = PushHandoff.currentIdToken() else {
+            nseLog.error("fallback: no usable ID token in the shared keychain")
             state.deliverFallback()
             return
         }
@@ -72,12 +87,21 @@ final class NotificationService: UNNotificationServiceExtension {
             return nil
         }
         request.httpBody = body
-        guard
-            let (data, response) = try? await URLSession.shared.data(for: request),
-            let http = response as? HTTPURLResponse,
-            (200..<300).contains(http.statusCode)
-        else { return nil }
-        return try? JSONDecoder().decode(PushEnvelope.self, from: data)
+        guard let (data, response) = try? await URLSession.shared.data(for: request) else {
+            nseLog.error("fallback: /push_envelope request failed (network)")
+            return nil
+        }
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            nseLog.error("fallback: /push_envelope returned \(status)")
+            return nil
+        }
+        guard let envelope = try? JSONDecoder().decode(PushEnvelope.self, from: data) else {
+            nseLog.error("fallback: /push_envelope response failed to decode")
+            return nil
+        }
+        return envelope
     }
 }
 
@@ -198,7 +222,7 @@ private enum PushHandoff {
     /// `kSecAttrAccessGroup` in the query: a read searches every group this
     /// extension can access, which avoids re-deriving the team-ID prefix.
     static func currentIdToken() -> String? {
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
             kSecAttrAccount as String: keychainAccount,
@@ -207,14 +231,36 @@ private enum PushHandoff {
             kSecMatchLimit as String: kSecMatchLimitOne,
         ]
         var item: CFTypeRef?
-        guard
-            SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-            let data = item as? Data,
-            let payload = try? JSONDecoder().decode(TokenPayload.self, from: data)
+        var status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status != errSecSuccess {
+            // iOS resolves a group-less search across every entitled access
+            // group; macOS does not reliably include the shared group, so
+            // retry with it named explicitly. The team prefix comes from the
+            // Info.plist AppIdentifierPrefix key (project.yml routes the
+            // build setting through; empty in unsigned builds).
+            guard
+                let prefix = Bundle.main.object(
+                    forInfoDictionaryKey: "AppIdentifierPrefix") as? String,
+                !prefix.isEmpty
+            else {
+                nseLog.error("keychain: group-less read failed (\(status)) and no AppIdentifierPrefix for the explicit retry")
+                return nil
+            }
+            query[kSecAttrAccessGroup as String] = prefix + "com.cabalmail.shared"
+            status = SecItemCopyMatching(query as CFDictionary, &item)
+        }
+        guard status == errSecSuccess, let data = item as? Data else {
+            nseLog.error("keychain: shared-group read failed (\(status))")
+            return nil
+        }
+        guard let payload = try? JSONDecoder().decode(TokenPayload.self, from: data)
         else { return nil }
         // 60s of leeway: a token the API would reject mid-flight isn't
         // worth the round trip; clock skew smaller than that still tries.
-        guard payload.expiresAt.timeIntervalSinceNow > -60 else { return nil }
+        guard payload.expiresAt.timeIntervalSinceNow > -60 else {
+            nseLog.error("keychain: mirrored token expired; enrichment skipped")
+            return nil
+        }
         return payload.idToken
     }
 

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -385,6 +385,11 @@ targets:
         NSExtension:
           NSExtensionPointIdentifier: com.apple.usernotifications.service
           NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService"
+        # Runtime team-prefix for the explicit-group keychain read (macOS
+        # resolves group-less data-protection-keychain searches differently
+        # from iOS; see PushHandoff.currentIdToken). Same expansion
+        # caveat as the app targets: empty in unsigned builds.
+        AppIdentifierPrefix: "$(AppIdentifierPrefix)"
         # See the Cabalmail target's equivalent comment — XcodeGen defaults
         # these to "1" / "1.0" unless explicitly plumbed through to the
         # build settings. App Store validation additionally requires an
@@ -436,6 +441,11 @@ targets:
         NSExtension:
           NSExtensionPointIdentifier: com.apple.usernotifications.service
           NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService"
+        # Runtime team-prefix for the explicit-group keychain read (macOS
+        # resolves group-less data-protection-keychain searches differently
+        # from iOS; see PushHandoff.currentIdToken). Same expansion
+        # caveat as the app targets: empty in unsigned builds.
+        AppIdentifierPrefix: "$(AppIdentifierPrefix)"
         # See the Cabalmail target's equivalent comment — XcodeGen defaults
         # these to "1" / "1.0" unless explicitly plumbed through to the
         # build settings. App Store validation additionally requires an

--- a/changelog.d/mac-nse-enrichment.fixed.md
+++ b/changelog.d/mac-nse-enrichment.fixed.md
@@ -1,0 +1,7 @@
+- Apple: **macOS notifications now show message content.** The Mac
+  notification extension could not read the mirrored sign-in token from the
+  shared keychain (a macOS/iOS platform difference in group-less keychain
+  searches), so every notification fell back to the generic "New mail";
+  it now names the shared group explicitly. Mark as Read and Archive from
+  a notification also update the open app immediately instead of waiting
+  for the next refresh.


### PR DESCRIPTION
Field-debugging follow-up to #651, diagnosed live on a Mac:

**The bug**: mac notifications showed bare "New mail". Server logs proved dispatch delivered (`Sent: 1`) while `/push_envelope` had zero invocations; on-device `pluginkit`/`log show`/Group-Container checks proved the NSE launched with `api_url` readable — leaving exactly one guard: the shared-keychain token read. iOS resolves group-less data-protection-keychain searches across all entitled groups; macOS doesn't reliably include the shared group. The read now retries with `<TEAMID>.com.cabalmail.shared` named explicitly (team prefix via a new `AppIdentifierPrefix` key in both NSE Info.plists), keeping the group-less path first so proven iOS behavior is untouched.

**Earned along the way**:
- NSE fallbacks stay silent for users but now log their reason under subsystem `com.cabalmail.nse` (failing guard / HTTP status / keychain OSStatus / expired token) — the next diagnosis is one `log show` instead of an elimination hunt.
- Mark as Read / Archive from a notification now nudge `AppState.requestRefresh()` on success, so a running app reflects the change immediately rather than at the next poll (as reported during mac testing).

Verified: iOS/macOS/visionOS builds clean, swiftlint 0 violations. One TestFlight round-trip validates on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)