### PR TITLE
Enrich Mac notifications from the running app (usernoted defect workaround)

### DIFF
--- a/apple/Cabalmail/AppDelegate.swift
+++ b/apple/Cabalmail/AppDelegate.swift
@@ -93,13 +93,40 @@ extension AppDelegate {
 // cross into an isolated witness). Sendable values are extracted up front;
 // only those hop to the main actor. Shared verbatim by iOS and macOS.
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    /// Foreground delivery: the IDLE-driven UI already shows the new
-    /// message, so a banner would double-notify — play the sound only.
+    /// Foreground delivery. On iOS (and while the Mac app is frontmost) the
+    /// polling-driven UI already shows the new message, so a banner would
+    /// double-notify — play the sound only.
+    ///
+    /// The macOS branch additionally works around usernoted killing our
+    /// Notification Service Extension before it runs (see
+    /// `PushRegistrar.presentEnrichedNotification`): while the app is
+    /// running but *not* active, the app enriches the push itself — it posts
+    /// an enriched local notification and suppresses the generic remote one.
+    /// Any failure presents the generic original instead, so nothing is ever
+    /// dropped silently.
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        [.sound]
+        #if os(macOS)
+        // Sendable extraction up front (see the extension comment); only
+        // these value types hop to the main actor below.
+        let isRemote = notification.request.trigger is UNPushNotificationTrigger
+        let ref = PushMessageRef(userInfo: notification.request.content.userInfo)
+        let isActive = await MainActor.run { NSApp.isActive }
+        if isActive { return [.sound] }
+        // Only a remote push with a parseable msgRef takes the enrichment
+        // path. Everything else — including the enriched local notification
+        // this very path posts, whose trigger is nil — presents as-is.
+        guard isRemote, let ref else { return [.banner, .sound] }
+        if await PushRegistrar.shared.presentEnrichedNotification(for: ref) {
+            // The enriched local copy is on its way; drop the generic one.
+            return []
+        }
+        return [.banner, .sound]
+        #else
+        return [.sound]
+        #endif
     }
 
     /// Action dispatch (notification buttons and the default tap). The async

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -431,6 +431,63 @@ extension PushRegistrar {
     }
 }
 
+// MARK: - Foreground enrichment workaround (macOS)
+
+#if os(macOS)
+extension PushRegistrar {
+    /// Enriches a remote push while the app runs unfocused. macOS's
+    /// notification daemon kills our Notification Service Extension before
+    /// `didReceive` ever runs (the long-standing "sluggish startup" platform
+    /// defect — Apple forums threads 693011 / 806789), so a remote push can
+    /// only show the generic "New mail" once it leaves APNs. While the app
+    /// itself is running it can do the NSE's job instead: fetch the envelope
+    /// through the session client, post an enriched *local* notification,
+    /// and let `willPresent` suppress the generic original. Returns false on
+    /// any failure so the caller presents the original instead — a generic
+    /// banner beats a silent drop. The NSE stays shipped as-is; if Apple
+    /// fixes the platform it takes over the app-not-running case.
+    func presentEnrichedNotification(for ref: PushMessageRef) async -> Bool {
+        guard let client = await activeClient() else {
+            CabalmailLog.warn("Push", "foreground enrichment skipped: no signed-in session")
+            return false
+        }
+        do {
+            let envelope = try await client.apiClient.fetchPushEnvelope(
+                folder: ref.folder,
+                uid: ref.uid,
+                messageID: ref.messageID
+            )
+            let content = UNMutableNotificationContent()
+            content.title = envelope.from
+            content.body = envelope.subject + "\n" + envelope.snippet
+            content.sound = .default
+            content.categoryIdentifier = "MAIL_MESSAGE"
+            // Same msgRef contract as the dispatch payload, carrying the
+            // server-resolved uid (the push's was a pre-delivery hint; 0
+            // is the "unresolved" sentinel, and a missing resolution keeps
+            // the original hint) so Mark as Read / Archive / Open act on
+            // the message this notification shows.
+            var msgRef: [String: Any] = ["folder": ref.folder]
+            let resolvedUid = envelope.uid.flatMap { $0 == 0 ? nil : $0 } ?? ref.uid
+            if let resolvedUid { msgRef["uid"] = Int(resolvedUid) }
+            if let messageID = ref.messageID { msgRef["msg_id"] = messageID }
+            content.userInfo = ["msgRef": msgRef]
+            try await UNUserNotificationCenter.current().add(
+                UNNotificationRequest(
+                    identifier: UUID().uuidString,
+                    content: content,
+                    trigger: nil
+                )
+            )
+            return true
+        } catch {
+            CabalmailLog.warn("Push", "foreground enrichment failed: \(error)")
+            return false
+        }
+    }
+}
+#endif
+
 // MARK: - Background execution plumbing
 
 extension PushRegistrar {

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
@@ -139,6 +139,19 @@ public protocol ApiClient: Sendable {
     /// intervention.
     func deregisterPushDevice(token: String) async throws
 
+    /// Resolves a pushed message reference into its display envelope via
+    /// `/push_envelope` — the same Lambda the Notification Service Extension
+    /// calls (the NSE deliberately keeps its own CabalmailKit-free copy of
+    /// this wire code). Used by the macOS app to enrich notifications while
+    /// it is running, working around the platform defect that kills the NSE
+    /// before it can. `uid` is a best-effort hint, `messageID` the durable
+    /// identity; the Lambda resolves the real uid server-side and returns it.
+    func fetchPushEnvelope(
+        folder: String,
+        uid: UInt32?,
+        messageID: String?
+    ) async throws -> PushEnvelope
+
     // MARK: Send
     /// Submits an outgoing message via the Lambda send pipeline (Outbox
     /// APPEND -> SMTP -> Sent move). Mirrors `react/admin/src/ApiClient.js
@@ -456,6 +469,27 @@ public struct PushDeviceRegistration: Sendable, Hashable {
         self.appVersion = appVersion
         self.locale = locale
         self.enabledFolders = enabledFolders
+    }
+}
+
+/// Decoded `/push_envelope` response: the sender / subject / snippet the
+/// dispatch payload deliberately omits. `uid` is the server-resolved UID
+/// (the payload's was a pre-delivery hint); callers stamp it back into the
+/// notification's msgRef so Mark as Read / Archive / Open act on the message
+/// the notification shows. Mirrors the NSE's private twin in
+/// `CabalmailNotificationService/NotificationService.swift` — keep the wire
+/// shapes in sync.
+public struct PushEnvelope: Decodable, Sendable {
+    public let from: String
+    public let subject: String
+    public let snippet: String
+    public let uid: UInt32?
+
+    public init(from: String, subject: String, snippet: String, uid: UInt32?) {
+        self.from = from
+        self.subject = subject
+        self.snippet = snippet
+        self.uid = uid
     }
 }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Push.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Push.swift
@@ -32,4 +32,20 @@ extension URLSessionApiClient {
         ])
         _ = try await send(request, expectedStatuses: 200..<300)
     }
+
+    public func fetchPushEnvelope(
+        folder: String,
+        uid: UInt32?,
+        messageID: String?
+    ) async throws -> PushEnvelope {
+        var body: [String: Any] = ["folder": folder]
+        // Omitted (not null) when unset — same posture as the NSE's
+        // `EnvelopeQuery.requestBody`; the Lambda resolves by whichever
+        // coordinates it receives (msg_id authoritative, uid a hint).
+        if let uid { body["uid"] = Int(uid) }
+        if let messageID { body["msg_id"] = messageID }
+        let request = try await post("/push_envelope", json: body)
+        let data = try await send(request, expectedStatuses: 200..<300)
+        return try JSONDecoder().decode(PushEnvelope.self, from: data)
+    }
 }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientPushTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientPushTests.swift
@@ -87,6 +87,85 @@ final class ApiClientPushTests: XCTestCase {
         XCTAssertEqual(payload?["device_token"] as? String, "ab12cd34")
     }
 
+    func testFetchPushEnvelopePostsFolderOnlyWhenHintsAreNil() async throws {
+        let response = """
+        {"from": "Ada Lovelace <ada@example.com>", "subject": "Hello", \
+        "snippet": "First line", "uid": 4271}
+        """
+        let http = RecordingHTTPTransport(responses: [(Data(response.utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        let envelope = try await client.fetchPushEnvelope(
+            folder: "INBOX",
+            uid: nil,
+            messageID: nil
+        )
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].httpMethod, "POST")
+        XCTAssertEqual(
+            requests[0].url?.absoluteString,
+            "https://api.cabalmail.example/prod/push_envelope"
+        )
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Authorization"), "idtoken")
+        let payload = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(payload?["folder"] as? String, "INBOX")
+        // Nil hints are OMITTED (not null) so the Lambda resolves purely by
+        // whichever coordinates the payload actually carried.
+        XCTAssertEqual(payload?.count, 1)
+        XCTAssertEqual(envelope.from, "Ada Lovelace <ada@example.com>")
+        XCTAssertEqual(envelope.subject, "Hello")
+        XCTAssertEqual(envelope.snippet, "First line")
+        XCTAssertEqual(envelope.uid, 4271)
+    }
+
+    func testFetchPushEnvelopeForwardsUidAndMessageID() async throws {
+        let response = """
+        {"from": "Ada <ada@example.com>", "subject": "Hi", "snippet": ""}
+        """
+        let http = RecordingHTTPTransport(responses: [(Data(response.utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        let envelope = try await client.fetchPushEnvelope(
+            folder: "INBOX",
+            uid: 4271,
+            messageID: "<abc@mx.example>"
+        )
+        let requests = await http.requests
+        let payload = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        XCTAssertEqual(payload?["folder"] as? String, "INBOX")
+        XCTAssertEqual(payload?["uid"] as? Int, 4271)
+        XCTAssertEqual(payload?["msg_id"] as? String, "<abc@mx.example>")
+        XCTAssertEqual(payload?.count, 3)
+        // A response without `uid` decodes with a nil resolved uid — callers
+        // then keep the original hint for the notification's msgRef.
+        XCTAssertNil(envelope.uid)
+    }
+
+    func testFetchPushEnvelopeSurfacesServerError() async throws {
+        let http = RecordingHTTPTransport(responses: [(Data("boom".utf8), 500)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        do {
+            _ = try await client.fetchPushEnvelope(folder: "INBOX", uid: nil, messageID: nil)
+            XCTFail("Expected server error")
+        } catch let error as CabalmailError {
+            guard case .server(let code, _) = error else {
+                return XCTFail("Expected .server, got \(error)")
+            }
+            XCTAssertEqual(code, "500")
+        }
+    }
+
     func testRegisterPushDeviceSurfacesServerError() async throws {
         let http = RecordingHTTPTransport(responses: [(Data("boom".utf8), 500)])
         let client = URLSessionApiClient(

--- a/changelog.d/mac-foreground-enrichment.fixed.md
+++ b/changelog.d/mac-foreground-enrichment.fixed.md
@@ -1,0 +1,9 @@
+- Apple: **Enriched Mac notifications while the app is running.** macOS
+  kills notification service extensions before they run (a long-standing
+  platform defect), so Mac pushes only ever showed the generic "New mail".
+  The Mac app now does the enrichment itself while it is open but not
+  focused — sender, subject, and snippet, with Open / Mark as Read /
+  Archive acting on the right message — and while it is focused no banner
+  shows (the app already displays the mail). Notifications still show the
+  generic "New mail" when the app is quit; the extension stays shipped so
+  a future macOS fix restores enrichment there too.

--- a/changelog.d/mac-nse-enrichment.fixed.md
+++ b/changelog.d/mac-nse-enrichment.fixed.md
@@ -1,7 +1,7 @@
-- Apple: **macOS notifications now show message content.** The Mac
-  notification extension could not read the mirrored sign-in token from the
-  shared keychain (a macOS/iOS platform difference in group-less keychain
-  searches), so every notification fell back to the generic "New mail";
-  it now names the shared group explicitly. Mark as Read and Archive from
-  a notification also update the open app immediately instead of waiting
-  for the next refresh.
+- Apple: **Notification actions update the open app immediately.** Mark as
+  Read and Archive from a notification now refresh the running app's views
+  right away instead of waiting for the next poll. (Also fixed the Mac
+  notification extension's shared-keychain read — a macOS/iOS platform
+  difference in group-less keychain searches — so extension-side enrichment
+  works the moment macOS stops killing the extension at startup; see the
+  companion entry for how Mac notifications get their content today.)

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -162,6 +162,16 @@ team):
   sentinel). The optional notarized-artifact leg additionally needs
   `MAC_NSE_DEVID_PROFILE` alongside the existing Developer ID pair.
 
+On macOS the extension rarely gets to run: the system notification daemon
+kills service extensions before they receive the notification (a
+long-standing, unresolved platform defect). The Mac app compensates while
+it is running — when it is open but not focused, the app itself fetches the
+envelope and posts the enriched notification in place of the generic one;
+when it is focused, no banner shows at all (the app already displays the
+mail). Only when the Mac app is quit do notifications fall back to the
+generic "New mail". The extension ships regardless, so a future macOS fix
+restores full enrichment without an app change.
+
 ## Operational notes
 
 - **Queue and DLQ.** `cabal-push-queue` retains signals for one hour (a


### PR DESCRIPTION
macOS's `usernoted` kills notification service extensions before `didReceive` runs ("Extension will be killed due to sluggish startup" — a long-standing unresolved platform defect: Apple forums [693011](https://developer.apple.com/forums/thread/693011)/[806789](https://developer.apple.com/forums/thread/806789); our identical extension works on iOS). Diagnosed live from the daemon logs after #653's keychain fix didn't change the on-device behavior.

**Maintainer-approved policy** (macOS `willPresent`):

| Mac app state | Behavior |
|---|---|
| Frontmost | No banner, sound only (unchanged) |
| Running, not active | App fetches the envelope itself via a new `ApiClient.fetchPushEnvelope` and posts an **enriched local notification** (same actions, server-resolved uid in msgRef); generic remote banner suppressed. Any failure → generic original shows |
| Quit | Generic "New mail" — unfixable from our side today |

The extension stays shipped (keychain fix included): if Apple ever fixes `usernoted`, full enrichment — including app-quit — lights up automatically. A monthly cloud routine now watches Apple forums/release notes for exactly that and files an issue when something actionable appears.

Also reconciles #653's pending changelog fragment, whose "macOS notifications now show message content" claim the platform defect falsified.

Verified: iOS/macOS/visionOS builds clean · swiftlint 0 · kit tests pass (3 new `fetchPushEnvelope` tests) · enrichment loop guard excludes our own local notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)