### PR TITLE
Send Macs silent pushes; the running app enriches and posts locally

### DIFF
--- a/apple/Cabalmail/AppDelegate.swift
+++ b/apple/Cabalmail/AppDelegate.swift
@@ -75,6 +75,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // way the app works fine without push, so log and move on.
         CabalmailLog.warn("Push", "remote-notification registration failed: \(error)")
     }
+
+    /// Silent-push entry point. The server sends Macs a background push
+    /// (`content-available: 1` plus `msgRef`, no alert) because alert
+    /// pushes could not be enriched: the NSE is killed by usernoted before
+    /// it runs, and `willPresent` — the previous in-app fallback — is only
+    /// called while the app is frontmost. A *running* app (any focus)
+    /// receives the silent push here, fetches the envelope, and posts an
+    /// enriched local notification; macOS's normal foreground rule then
+    /// handles presentation via `willPresent` below. A quit app receives
+    /// nothing — the accepted trade; iOS covers that case.
+    ///
+    /// The class is main-actor isolated, so this hops off via `Task` for
+    /// the network work; `PushRegistrar` is itself @MainActor.
+    func application(
+        _ application: NSApplication,
+        didReceiveRemoteNotification userInfo: [String: Any]
+    ) {
+        guard let ref = PushMessageRef(userInfo: userInfo) else {
+            CabalmailLog.warn("Push", "silent push without a parseable msgRef; ignored")
+            return
+        }
+        Task {
+            if await !PushRegistrar.shared.presentEnrichedNotification(for: ref) {
+                // Enrichment failed (no session, fetch error): degrade to
+                // the generic "New mail" a legacy alert push would have
+                // shown, rather than dropping the notification silently.
+                await PushRegistrar.shared.presentGenericNotification(for: ref)
+            }
+        }
+    }
 }
 #endif
 
@@ -97,33 +127,23 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     /// polling-driven UI already shows the new message, so a banner would
     /// double-notify — play the sound only.
     ///
-    /// The macOS branch additionally works around usernoted killing our
-    /// Notification Service Extension before it runs (see
-    /// `PushRegistrar.presentEnrichedNotification`): while the app is
-    /// running but *not* active, the app enriches the push itself — it posts
-    /// an enriched local notification and suppresses the generic remote one.
-    /// Any failure presents the generic original instead, so nothing is ever
-    /// dropped silently.
+    /// No enrichment happens here anymore: macOS only calls `willPresent`
+    /// while the app is frontmost, so the #654 enrich-on-present branch was
+    /// unreachable exactly when it mattered (running but unfocused).
+    /// Enrichment moved to `didReceiveRemoteNotification` above, which fires
+    /// for a running app regardless of focus; what lands here is the enriched
+    /// local notification it posts (or a legacy alert push from an old server
+    /// during rollout, which presents generically).
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
         #if os(macOS)
-        // Sendable extraction up front (see the extension comment); only
-        // these value types hop to the main actor below.
-        let isRemote = notification.request.trigger is UNPushNotificationTrigger
-        let ref = PushMessageRef(userInfo: notification.request.content.userInfo)
+        // Active: the UI already shows the mail, so sound only. Inactive:
+        // full banner — this is what presents our own local notifications
+        // while the app runs unfocused.
         let isActive = await MainActor.run { NSApp.isActive }
-        if isActive { return [.sound] }
-        // Only a remote push with a parseable msgRef takes the enrichment
-        // path. Everything else — including the enriched local notification
-        // this very path posts, whose trigger is nil — presents as-is.
-        guard isRemote, let ref else { return [.banner, .sound] }
-        if await PushRegistrar.shared.presentEnrichedNotification(for: ref) {
-            // The enriched local copy is on its way; drop the generic one.
-            return []
-        }
-        return [.banner, .sound]
+        return isActive ? [.sound] : [.banner, .sound]
         #else
         return [.sound]
         #endif

--- a/apple/Cabalmail/PushRegistrar.swift
+++ b/apple/Cabalmail/PushRegistrar.swift
@@ -431,24 +431,27 @@ extension PushRegistrar {
     }
 }
 
-// MARK: - Foreground enrichment workaround (macOS)
+// MARK: - Silent-push enrichment (macOS)
 
 #if os(macOS)
 extension PushRegistrar {
-    /// Enriches a remote push while the app runs unfocused. macOS's
+    /// Enriches a silent push while the app is running. macOS's
     /// notification daemon kills our Notification Service Extension before
     /// `didReceive` ever runs (the long-standing "sluggish startup" platform
-    /// defect — Apple forums threads 693011 / 806789), so a remote push can
-    /// only show the generic "New mail" once it leaves APNs. While the app
-    /// itself is running it can do the NSE's job instead: fetch the envelope
-    /// through the session client, post an enriched *local* notification,
-    /// and let `willPresent` suppress the generic original. Returns false on
-    /// any failure so the caller presents the original instead — a generic
+    /// defect — Apple forums threads 693011 / 806789), so the server sends
+    /// Macs a background push instead of an alert and the running app does
+    /// the NSE's job itself: fetch the envelope through the session client
+    /// and post an enriched *local* notification, whose presentation then
+    /// follows the app's `willPresent` policy (sound only while active, full
+    /// banner otherwise). Called from `AppDelegate`'s
+    /// `didReceiveRemoteNotification`, which fires for a running app
+    /// regardless of focus. Returns false on any failure so the caller can
+    /// post the generic fallback (`presentGenericNotification`) — a generic
     /// banner beats a silent drop. The NSE stays shipped as-is; if Apple
     /// fixes the platform it takes over the app-not-running case.
     func presentEnrichedNotification(for ref: PushMessageRef) async -> Bool {
         guard let client = await activeClient() else {
-            CabalmailLog.warn("Push", "foreground enrichment skipped: no signed-in session")
+            CabalmailLog.warn("Push", "silent-push enrichment skipped: no signed-in session")
             return false
         }
         do {
@@ -481,8 +484,34 @@ extension PushRegistrar {
             )
             return true
         } catch {
-            CabalmailLog.warn("Push", "foreground enrichment failed: \(error)")
+            CabalmailLog.warn("Push", "silent-push enrichment failed: \(error)")
             return false
+        }
+    }
+
+    /// Fallback for a failed enrichment: posts the same generic "New mail"
+    /// notification an alert push used to show, carrying the silent push's
+    /// msgRef so the notification actions still work. Without this a fetch
+    /// failure would turn the silent push into no notification at all.
+    func presentGenericNotification(for ref: PushMessageRef) async {
+        let content = UNMutableNotificationContent()
+        content.title = "New mail"
+        content.sound = .default
+        content.categoryIdentifier = "MAIL_MESSAGE"
+        var msgRef: [String: Any] = ["folder": ref.folder]
+        if let uid = ref.uid { msgRef["uid"] = Int(uid) }
+        if let messageID = ref.messageID { msgRef["msg_id"] = messageID }
+        content.userInfo = ["msgRef": msgRef]
+        do {
+            try await UNUserNotificationCenter.current().add(
+                UNNotificationRequest(
+                    identifier: UUID().uuidString,
+                    content: content,
+                    trigger: nil
+                )
+            )
+        } catch {
+            CabalmailLog.warn("Push", "generic fallback notification failed: \(error)")
         }
     }
 }

--- a/changelog.d/mac-foreground-enrichment.fixed.md
+++ b/changelog.d/mac-foreground-enrichment.fixed.md
@@ -1,9 +1,0 @@
-- Apple: **Enriched Mac notifications while the app is running.** macOS
-  kills notification service extensions before they run (a long-standing
-  platform defect), so Mac pushes only ever showed the generic "New mail".
-  The Mac app now does the enrichment itself while it is open but not
-  focused — sender, subject, and snippet, with Open / Mark as Read /
-  Archive acting on the right message — and while it is focused no banner
-  shows (the app already displays the mail). Notifications still show the
-  generic "New mail" when the app is quit; the extension stays shipped so
-  a future macOS fix restores enrichment there too.

--- a/changelog.d/mac-silent-push.changed.md
+++ b/changelog.d/mac-silent-push.changed.md
@@ -1,0 +1,11 @@
+- Apple: **Mac notifications are enriched whenever the app is running.**
+  The server sends Macs a silent wake instead of a visible alert; the
+  running app (focused or not) fetches the envelope and posts the
+  sender/subject/snippet notification itself — no banner while the app is
+  frontmost (it already shows the mail), and a generic "New mail" if the
+  fetch fails. macOS kills notification service extensions before they run
+  (a long-standing platform defect), so extension-side enrichment — the
+  iOS approach — cannot work there; the extension stays shipped so a
+  future macOS fix restores it, including for the one case this design
+  cannot cover: a quit Mac app receives no notification (a paired iPhone
+  shows the fully enriched banner regardless).

--- a/changelog.d/push-phase5-6-apple.added.md
+++ b/changelog.d/push-phase5-6-apple.added.md
@@ -1,7 +1,7 @@
-- Apple: **Notification settings and macOS push.** The Mac app now gets the
-  same new-mail notifications as iOS — enriched on-device, with the Open /
-  Mark as Read / Archive actions — and both platforms gain a Notifications
-  section in Settings: a master toggle (honest about the system-level
+- Apple: **Notification settings and macOS push.** The Mac app now gets
+  new-mail notifications with the Open / Mark as Read / Archive actions
+  (see the companion entry for how and when they are enriched), and both
+  platforms gain a Notifications section in Settings: a master toggle (honest about the system-level
   permission state, with a pointer to Settings/System Settings when denied
   there) and a folder scope — Inbox only, All folders, or a hand-picked
   folder list. Scope changes take effect immediately; turning the toggle

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -164,13 +164,18 @@ team):
 
 On macOS the extension rarely gets to run: the system notification daemon
 kills service extensions before they receive the notification (a
-long-standing, unresolved platform defect). The Mac app compensates while
-it is running — when it is open but not focused, the app itself fetches the
-envelope and posts the enriched notification in place of the generic one;
-when it is focused, no banner shows at all (the app already displays the
-mail). Only when the Mac app is quit do notifications fall back to the
-generic "New mail". The extension ships regardless, so a future macOS fix
-restores full enrichment without an app change.
+long-standing, unresolved platform defect). The dispatch Lambda therefore
+sends Macs a *silent* push (`content-available: 1` with the `msgRef`, no
+alert) instead of an alert push. A running Mac app — focused or not —
+receives it, fetches the envelope, and posts an enriched local
+notification itself: a full banner when the app is unfocused, sound only
+(no banner) when it is frontmost, since the app already displays the mail.
+If the fetch fails, the app posts a generic "New mail" notification
+instead, so nothing is dropped silently. A quit Mac app receives no
+notification at all — a deliberate trade, since the paired iPhone covers
+that case with a fully enriched banner. The extension ships regardless
+(a monthly automated check watches for the macOS fix that would let it
+take over the quit-app case without an app change).
 
 ## Operational notes
 

--- a/lambda/api/push_dispatch/apns.py
+++ b/lambda/api/push_dispatch/apns.py
@@ -144,11 +144,19 @@ class ApnsClient:  # pylint: disable=too-few-public-methods
             # Flush any acknowledgements/pings h2 queued while processing.
             self.sock.sendall(self.conn.data_to_send())
 
-    def send(self, device_token, topic, payload, collapse_id):
-        '''Sends one alert push. Returns None on success, raises ApnsError
+    # One argument over the cap, but a boolean mode beats duplicating the
+    # whole retry/verdict body into a second method.
+    def send(self, device_token, topic, payload, collapse_id, *,  # pylint: disable=too-many-arguments
+             background=False):
+        '''Sends one push. Returns None on success, raises ApnsError
         (permanent or not) on a non-2xx response, and raises
         ApnsTransportError when no verdict was obtained — after one
-        transparent reconnect-and-retry.'''
+        transparent reconnect-and-retry.
+
+        `background` sends a content-available wake instead of an alert:
+        push-type `background` with the priority-5 APNs mandates for it
+        (priority 10 on a background push is rejected). No collapse id —
+        it only affects displayed notifications.'''
         body = json.dumps(payload).encode()
         headers = [
             (':method', 'POST'),
@@ -157,11 +165,12 @@ class ApnsClient:  # pylint: disable=too-few-public-methods
             (':path', f'/3/device/{device_token}'),
             ('authorization', f'bearer {self._provider_token()}'),
             ('apns-topic', topic),
-            ('apns-push-type', 'alert'),
-            ('apns-priority', '10'),
-            # apns-collapse-id caps at 64 bytes; longer would 400 the request.
-            ('apns-collapse-id', collapse_id[:64]),
+            ('apns-push-type', 'background' if background else 'alert'),
+            ('apns-priority', '5' if background else '10'),
         ]
+        if not background:
+            # apns-collapse-id caps at 64 bytes; longer would 400 the request.
+            headers.append(('apns-collapse-id', collapse_id[:64]))
         for attempt in (1, 2):
             try:
                 if self.conn is None:

--- a/lambda/api/push_dispatch/function.py
+++ b/lambda/api/push_dispatch/function.py
@@ -48,6 +48,10 @@ NOT_CONFIGURED_TTL_SECONDS = 300
 # recently; the attribute exists to GC dead tokens, not to timestamp pushes.
 LAST_SEEN_REFRESH_SECONDS = 12 * 3600
 
+# Bundle ids that receive silent (content-available) pushes instead of
+# alerts; see _payload's docstring for the macOS rationale.
+SILENT_BUNDLE_IDS = frozenset({'com.cabalmail.CabalmailMac'})
+
 # Warm-container caches: the APNs config/connection survive across
 # invocations, which is what makes provider-token reuse worthwhile.
 _APNS_CLIENT = None
@@ -138,20 +142,34 @@ def _mark(user, device_token, attribute, value):
         print(f'[push-dispatch] bookkeeping write failed: {err}')
 
 
-def _payload(signal):
-    '''Builds the content-free APNs payload and its collapse id.'''
+def _payload(signal, silent):
+    '''Builds the content-free APNs payload and its collapse id.
+
+    `silent` selects a background (content-available) push with no alert:
+    macOS's notification daemon kills service extensions before they run
+    ("sluggish startup", an unresolved platform defect) AND only consults
+    willPresent while the app is frontmost, so an alert push to a Mac could
+    never be enriched. The Mac app instead receives this silent wake while
+    running (any focus state) and posts its own enriched local notification;
+    a quit Mac app gets nothing, a trade the maintainer chose over a
+    permanently generic banner. iOS keeps the alert form — its extension
+    works.'''
     folder = signal['folder']
     uid = int(signal.get('uid') or 0)
     msg_id = signal.get('msg_id') or ''
-    payload = {
-        'aps': {
-            'alert': 'New mail',
-            'mutable-content': 1,
-            'category': 'MAIL_MESSAGE',
-            'sound': 'default',
-        },
-        'msgRef': {'folder': folder, 'uid': uid, 'msg_id': msg_id},
-    }
+    ref = {'folder': folder, 'uid': uid, 'msg_id': msg_id}
+    if silent:
+        payload = {'aps': {'content-available': 1}, 'msgRef': ref}
+    else:
+        payload = {
+            'aps': {
+                'alert': 'New mail',
+                'mutable-content': 1,
+                'category': 'MAIL_MESSAGE',
+                'sound': 'default',
+            },
+            'msgRef': ref,
+        }
     # Collapse on message identity so a redelivered signal replaces, rather
     # than stacks on, the notification it already produced. The UID hint can
     # be 0 (procmail runs before Dovecot assigns one), so fold msg_id in —
@@ -172,7 +190,8 @@ def _dispatch(client, signal):
     user = signal['user']
     folder = signal['folder']
     rows = table.query(KeyConditionExpression=Key('user').eq(user))['Items']
-    payload, collapse_id = _payload(signal)
+    payloads = {silent: _payload(signal, silent)[0] for silent in (False, True)}
+    collapse_id = _payload(signal, silent=False)[1]
 
     sent, failed, retryable = 0, 0, 0
     now = time.strftime('%Y-%m-%dT%H:%M:%S+00:00', time.gmtime())
@@ -180,8 +199,10 @@ def _dispatch(client, signal):
         if not _wants_folder(row, folder):
             continue
         device_token = row['device_token']
+        silent = row['bundle_id'] in SILENT_BUNDLE_IDS
         try:
-            client.send(device_token, row['bundle_id'], payload, collapse_id)
+            client.send(device_token, row['bundle_id'], payloads[silent],
+                        collapse_id, background=silent)
         except ApnsError as err:
             failed += 1
             if err.permanent:


### PR DESCRIPTION
Option E from the macOS enrichment saga, replacing #654's unreachable mechanism.

**Why #654 didn't work**: `willPresent` is only consulted while the app is frontmost — on macOS as on iOS — which is exactly the state where we suppress banners. Running-unfocused Macs got the system's generic banner with no delegate involvement (confirmed on-device: current build, zero `/push_envelope` invocations).

**What this does**
- `push_dispatch` sends `com.cabalmail.CabalmailMac` tokens a **background push** (`content-available: 1`, push-type `background`, priority 5 per APNs rules) instead of an alert. iOS payloads unchanged.
- The Mac app receives it in **any focus state** via `didReceiveRemoteNotification`, fetches the envelope, and posts an enriched local notification. macOS's own foreground rule then presents: frontmost → sound only; unfocused → full banner with working actions. Fetch failure → generic local "New mail".
- The trade (maintainer-approved): a **quit** Mac app now receives nothing — silent pushes don't launch macOS apps. A paired iPhone covers it; the shipped NSE + the monthly fix-watch routine cover the future. Next PR (queued) shrinks this gap further: launch-at-login + MenuBarExtra residency.
- Rollout note: old server + new client, or new server + old client, both degrade gracefully (generic banner while running; the old-client/new-server window shows nothing on Macs until TestFlight updates).
- Changelog reconciled: #654's superseded fragment deleted (no-blind-alleys rule); net behavior described once.

Verified: pylint 10/10 · iOS/macOS/visionOS builds clean · swiftlint 0 · kit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)