### PR TITLE
Add Mac residency: launch at login and a menu-bar presence

### DIFF
--- a/apple/Cabalmail/Views/NotificationSettingsSection.swift
+++ b/apple/Cabalmail/Views/NotificationSettingsSection.swift
@@ -5,6 +5,10 @@
 import SwiftUI
 import UserNotifications
 import CabalmailKit
+#if os(macOS)
+import OSLog
+import ServiceManagement
+#endif
 
 /// "Notifications" section of the Settings form (push phase 5).
 ///
@@ -37,6 +41,18 @@ struct NotificationSettingsSection: View {
     // permanently disabled. Present the folder picker as a sheet instead,
     // same pattern as the Acknowledgements row.
     @State private var showingFolderPicker = false
+    // Mac residency: Macs get silent pushes and the running app enriches
+    // them, so a quit app gets no notification — these two rows exist to
+    // make "quit" rare. The login-item toggle reflects the system's
+    // actual `SMAppService` status (default: unregistered until the user
+    // opts in); the menu-bar toggle is the `isInserted` binding for the
+    // status item `CabalmailMacApp` declares.
+    @State private var loginItemStatus = SMAppService.mainApp.status
+    @AppStorage(menuBarExtraDefaultsKey) private var showInMenuBar = true
+    private let residencyLog = Logger(
+        subsystem: "com.cabalmail.Cabalmail",
+        category: "login-item"
+    )
     #endif
 
     var body: some View {
@@ -64,12 +80,26 @@ struct NotificationSettingsSection: View {
                         chosenFolders: newValue.sorted()
                     )
                 }
+            #if os(macOS)
+            // Deliberately not gated on `controlsEnabled`: residency is
+            // motivated by notification coverage but useful without it
+            // (menu-bar unread count, background mail polling).
+            Toggle("Launch at login", isOn: launchAtLoginBinding)
+            Toggle("Show in menu bar", isOn: $showInMenuBar)
+            #endif
         } header: {
             Text("Notifications")
         } footer: {
             // Always present (content swaps, structure doesn't) so the
             // sections below never reflow when the permission state changes.
+            #if os(macOS)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(footerText)
+                Text(residencyFooterText)
+            }
+            #else
             Text(footerText)
+            #endif
         }
     }
 
@@ -153,6 +183,41 @@ struct NotificationSettingsSection: View {
         )
     }
 
+    #if os(macOS)
+    /// Honest launch-at-login toggle: registration is attempted, then the
+    /// displayed state is re-read from the system rather than assumed —
+    /// a denied or approval-gated registration reverts the toggle instead
+    /// of lying "on".
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { loginItemStatus == .enabled },
+            set: { newValue in
+                do {
+                    if newValue {
+                        try SMAppService.mainApp.register()
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                    }
+                } catch {
+                    let verb = newValue ? "register" : "unregister"
+                    let reason = error.localizedDescription
+                    residencyLog.error(
+                        "Login item \(verb, privacy: .public) failed: \(reason, privacy: .public)"
+                    )
+                }
+                loginItemStatus = SMAppService.mainApp.status
+            }
+        )
+    }
+
+    private var residencyFooterText: String {
+        if loginItemStatus == .requiresApproval {
+            return "Login item waiting for approval — allow Cabalmail in System Settings > General > Login Items."
+        }
+        return "Launching at login keeps new-mail notifications working without opening Cabalmail."
+    }
+    #endif
+
     private var footerText: String {
         if systemDenied {
             #if os(macOS)
@@ -167,6 +232,11 @@ struct NotificationSettingsSection: View {
     private func refreshSystemPermission() async {
         let settings = await UNUserNotificationCenter.current().notificationSettings()
         systemDenied = settings.authorizationStatus == .denied
+        #if os(macOS)
+        // Same round-trip logic as the permission: the user may have
+        // approved (or removed) the login item in System Settings.
+        loginItemStatus = SMAppService.mainApp.status
+        #endif
     }
 }
 

--- a/apple/CabalmailMac/CabalmailMacApp.swift
+++ b/apple/CabalmailMac/CabalmailMacApp.swift
@@ -1,14 +1,20 @@
 import SwiftUI
 import CabalmailKit
 
+/// Stable identifier for the main mail window's `WindowGroup`, shared
+/// with the menu-bar extra's "Open Cabalmail" item so both target the
+/// same scene group.
+let mainWindowID = "main"
+
 /// App entry point for the native macOS target.
 ///
 /// Shares the same observable roots as the iOS/iPadOS/visionOS target
 /// (`AppState`, `Preferences`) so every scene binds the same backing
-/// state. macOS gets two scenes: the main mail window and a General-only
-/// Settings window (⌘,). Address and folder management lives in the main
-/// window's mailbox sidebar (`AddressListView` / `FolderListView`), which
-/// carries the full request/revoke and create/delete affordances.
+/// state. macOS gets the main mail window, the standalone compose scene,
+/// a Settings window (⌘,), and an optional menu-bar extra (Mac
+/// residency). Address and folder management lives in the main window's
+/// mailbox sidebar (`AddressListView` / `FolderListView`), which carries
+/// the full request/revoke and create/delete affordances.
 @main
 struct CabalmailMacApp: App {
     // Push notifications: APNs token callbacks and the notification-center
@@ -18,9 +24,13 @@ struct CabalmailMacApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var appState = AppState()
     @State private var preferences = Preferences(store: UbiquitousPreferenceStore())
+    // Mac residency: whether the status-item menu is installed. Backed by
+    // UserDefaults so the "Show in menu bar" toggle in Settings >
+    // Notifications inserts/removes the item live via `isInserted`.
+    @AppStorage(menuBarExtraDefaultsKey) private var showMenuBarExtra = true
 
     var body: some Scene {
-        WindowGroup("Cabalmail", id: "main") {
+        WindowGroup("Cabalmail", id: mainWindowID) {
             ContentView()
                 .environment(appState)
                 .environment(preferences)
@@ -61,6 +71,21 @@ struct CabalmailMacApp: App {
                 .preferredColorScheme(colorScheme(for: preferences.theme))
                 .frame(minWidth: 560, minHeight: 640)
         }
+        // Menu-bar presence (Mac residency). Enriched notifications need
+        // the app process alive (silent-push design, see
+        // docs/push-notifications.md); the status item keeps that
+        // residency legible and useful. `.menu` style: plain menu items,
+        // no custom panel. The brand mark's canvas is 1024pt, so the
+        // status item uses an SF Symbol sized for the menu bar instead.
+        MenuBarExtra(
+            "Cabalmail",
+            systemImage: "envelope",
+            isInserted: $showMenuBarExtra
+        ) {
+            MenuBarExtraMenu()
+                .environment(appState)
+        }
+        .menuBarExtraStyle(.menu)
     }
 
     private func colorScheme(for theme: AppTheme) -> ColorScheme? {

--- a/apple/CabalmailMac/MenuBarExtraMenu.swift
+++ b/apple/CabalmailMac/MenuBarExtraMenu.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import CabalmailKit
+
+/// UserDefaults key backing the "Show in menu bar" toggle (default on).
+/// Written by the Notifications settings section and read by
+/// `CabalmailMacApp` through its `MenuBarExtra(isInserted:)` binding, so
+/// flipping the toggle inserts or removes the status item immediately.
+let menuBarExtraDefaultsKey = "showMenuBarExtra"
+
+/// Content of the Cabalmail status-item menu (Mac residency).
+///
+/// Macs receive *silent* pushes and the running app enriches them into
+/// local notifications (see docs/push-notifications.md) — a quit app gets
+/// no notification at all. The menu-bar presence exists to make "quit"
+/// rare: it keeps the app legibly resident even with every window closed,
+/// and gives that residency a small use — the Inbox unread count plus
+/// Open / New Message / Quit.
+///
+/// Deliberately minimal (`.menu` style, plain menu items): the unread
+/// line mirrors the dock badge's `AppState.inboxUnreadCount` (refreshed
+/// by the existing badge poller), and both window actions route through
+/// the scenes the app already declares. No new data paths — a recent-
+/// messages list waits until envelopes are exposed app-wide.
+struct MenuBarExtraMenu: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        // A Text in a .menu-style extra renders as a disabled menu item:
+        // a status line, not an action.
+        Text(statusLine)
+        Divider()
+        Button("Open Cabalmail") {
+            openWindow(id: mainWindowID)
+            NSApp.activate()
+        }
+        Button("New Message") {
+            // Same route as the File menu / toolbar: the compose window
+            // scene both app targets install. If the user is signed out
+            // the scene shows its own "Sign in required" placeholder.
+            openWindow(id: composeWindowID, value: Draft())
+            NSApp.activate()
+        }
+        Divider()
+        Button("Quit Cabalmail") {
+            NSApp.terminate(nil)
+        }
+    }
+
+    private var statusLine: String {
+        guard appState.client != nil else { return "Not signed in" }
+        switch appState.inboxUnreadCount {
+        case 0: return "No unread mail"
+        case 1: return "1 unread message"
+        case let count: return "\(count) unread messages"
+        }
+    }
+}

--- a/changelog.d/mac-residency.added.md
+++ b/changelog.d/mac-residency.added.md
@@ -1,0 +1,9 @@
+- Apple: **Menu-bar presence and launch at login for the Mac app.** Mac
+  notifications are enriched by the running app (see the silent-push
+  entry), so a quit app hears nothing; these two residency affordances
+  make quitting rare. A status-item menu — on by default, removable in
+  Settings > Notifications — shows the Inbox unread count with Open /
+  New Message / Quit actions, and an opt-in launch-at-login toggle (off
+  until the user enables it, honest about the system's approval state)
+  starts Cabalmail at login so new-mail notifications keep working
+  without opening the app.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -173,9 +173,17 @@ notification itself: a full banner when the app is unfocused, sound only
 If the fetch fails, the app posts a generic "New mail" notification
 instead, so nothing is dropped silently. A quit Mac app receives no
 notification at all — a deliberate trade, since the paired iPhone covers
-that case with a fully enriched banner. The extension ships regardless
-(a monthly automated check watches for the macOS fix that would let it
-take over the quit-app case without an app change).
+that case with a fully enriched banner. That gap only opens when the
+user quits explicitly, and two residency affordances (Settings >
+Notifications) exist to make that rare: an opt-in launch-at-login item
+(off until the user enables it; the toggle mirrors the system's
+`SMAppService` status, pointing at System Settings > General > Login
+Items when approval is pending) and a menu-bar presence (on by default)
+whose status-item menu shows the Inbox unread count with Open / New
+Message / Quit actions, keeping the app legibly alive with every window
+closed. The extension ships regardless (a monthly automated check
+watches for the macOS fix that would let it take over the quit-app case
+without an app change).
 
 ## Operational notes
 


### PR DESCRIPTION
Follow-on to #655 (task approved in-session): silent pushes only reach a running app, so residency shrinks the one remaining macOS notification gap by making "quit" rare.

- **Launch at login** — `SMAppService.mainApp` toggle in Settings → Notifications (macOS only, **default off**). State is re-read from the system after every change, so denial / requires-approval display honestly, with a footer pointer to System Settings → General → Login Items; fixed footer structure, no reflow.
- **Menu-bar presence** — minimal `MenuBarExtra` (menu style, `envelope` symbol) behind a "Show in menu bar" toggle: unread count (existing badge poller), Open Cabalmail, New Message (existing compose scene), Quit. Recent-envelopes list deliberately deferred — it would need new app-wide plumbing that a v1 shouldn't grow.
- Neither toggle is gated on the push master toggle: residency is motivated by notifications but useful without them (menu-bar unread, background polling).
- iOS/visionOS compile none of the new code.

Verified: all three platform builds clean · swiftlint 0 · kit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)