### PR TITLE
Move Apple CI to macos-26 runners (fixes the macOS icon compile crash)

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -26,8 +26,20 @@ env:
   # resolve as "ineligible" ("iOS 18.1 is not installed").
   #
   # If reproducibility becomes important, pin to a specific version here AND
-  # ensure it matches a Xcode actually preinstalled on the macos-15 runner
+  # ensure it matches a Xcode actually preinstalled on the macos-26 runner
   # image.
+  #
+  # The runner image's HOST macOS version is load-bearing, not just a
+  # freshness preference: compiling the Liquid Glass AppIcon.icon for
+  # --platform macosx renders through the host's asset runtime
+  # (AssetCatalogAgent-AssetRuntime). On a macOS 15 host that agent crashes
+  # against Xcode 26's framework overrides (dyld "symbol missing from root
+  # that overrides CoreMedia", IBPlatformToolFailureException) and the
+  # CabalmailMac asset-catalog compile fails with no useful error through
+  # xcbeautify. iphoneos compiles of the same .icon are host-independent
+  # (they render via the SDK runtime inside Xcode), which is why only the
+  # macOS leg broke. Keep the runner's macOS >= the SDK major the .icon
+  # targets.
   XCODE_VERSION: 'latest-stable'
   WORKSPACE: apple/Cabalmail.xcworkspace
 
@@ -38,7 +50,7 @@ jobs:
   # -----------------------------------------------------------------------
   kit-test:
     name: Test CabalmailKit (${{ matrix.platform }})
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +65,7 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Install XcodeGen + SwiftLint + xcbeautify
-        # The macos-15 runner image preinstalls some of these (xcbeautify in
+        # The macOS runner image preinstalls some of these (xcbeautify in
         # particular), and `brew install` then emits a `Warning: foo is
         # already installed...` line that GitHub surfaces as a workflow
         # annotation. Filter to packages that aren't installed yet so the
@@ -162,7 +174,7 @@ jobs:
   # -----------------------------------------------------------------------
   app-build:
     name: Build ${{ matrix.scheme }} (${{ matrix.platform }})
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:
@@ -261,7 +273,7 @@ jobs:
     name: Upload ${{ matrix.platform }} to TestFlight
     needs: approval
     if: ${{ github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'stage') }}
-    runs-on: macos-15
+    runs-on: macos-26
     environment: ${{ github.ref_name == 'main' && 'prod' || 'stage' }}
     strategy:
       # Never cancel a leg mid-upload because the other leg failed.
@@ -623,7 +635,7 @@ jobs:
       actions: write
     needs: approval
     if: ${{ github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'stage') }}
-    runs-on: macos-15
+    runs-on: macos-26
     environment: ${{ github.ref_name == 'main' && 'prod' || 'stage' }}
     steps:
       - name: Checkout

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -101,7 +101,7 @@ jobs:
           fi
 
           if [ "$NEED_MAC" = "true" ]; then
-            echo "runner=macos-15"     >> "$GITHUB_OUTPUT"
+            echo "runner=macos-26"     >> "$GITHUB_OUTPUT"
             echo "mode=apple"          >> "$GITHUB_OUTPUT"
           else
             echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

`apple.yml` run #400 (and its re-run) failed deterministically in **Build CabalmailMac (macOS)** at `CompileAssetCatalogVariant` on `AppIcon.icon`, with no error detail — the build pipes through xcbeautify, which swallows actool's stderr.

## Root cause (from a raw-actool diagnostic run)

actool **crashes** when compiling the Liquid Glass `.icon` for `--platform macosx` on the `macos-15` image (macOS 15.7 host + Xcode 26.3):

```
dyld: symbol '…' missing from root that overrides CoreMedia …
*** IBPlatformToolFailureException: The tool closed the connection (AssetCatalogAgent-AssetRuntime)
exit 255
```

Compiling a `.icon` for macosx renders the appearances through the **host's** asset runtime, and a macOS 15 host can't load Xcode 26's framework overrides. The iphoneos compile of the *same* bundle passed in the same run because iOS asset rendering uses the SDK runtime inside Xcode — host-independent. Local validation passed because it ran on a macOS 26 host.

## Fix

- All four `apple.yml` jobs: `runs-on: macos-15` → `macos-26`. The macos-26 image hosts macOS 26 and resolves `latest-stable` to **Xcode 26.6 (17F113)** — the exact toolchain the `.icon` was validated against locally.
- `claude.yml`'s Apple-build runner routing gets the same bump (it exists to build `apple/**`, so it had the same landmine).
- A comment on `XCODE_VERSION` records that the runner's **host macOS version is load-bearing** for macosx `.icon` compiles, not just a freshness preference.
- `lint.yml`'s macos-15 SwiftLint job is untouched — no asset compile there.

Diagnostic evidence: run 29362697178 on the throwaway branch `claude/icon-actool-diagnostic` (raw actool: macosx crashes with/without the xcassets input; iphoneos succeeds). I'll delete that branch after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)