### PR TITLE
Surface raw xcodebuild output when an apple.yml step fails

### DIFF
--- a/.github/scripts/dump-xcodebuild-raw.sh
+++ b/.github/scripts/dump-xcodebuild-raw.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Dump the raw xcodebuild logs tee'd by apple.yml's build/test/archive steps.
+#
+# The workflow pipes xcodebuild through xcbeautify for readable annotations,
+# but xcbeautify swallows the stderr of crashing subtools — an actool crash
+# (dyld override mismatch on the macOS 15 image) once surfaced as nothing but
+# "CompileAssetCatalogVariant failed" across two runs. Each xcodebuild step
+# therefore tees its raw output to $RUNNER_TEMP/xcodebuild-raw-<step>.log,
+# and this script runs on failure to surface the detail: a grep'd error
+# context first, then the tail, each in a collapsed log group.
+
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set (GitHub Actions runner env)}"
+
+shopt -s nullglob
+logs=("${RUNNER_TEMP}"/xcodebuild-raw-*.log)
+
+if [ "${#logs[@]}" -eq 0 ]; then
+  echo "[raw-log] no raw xcodebuild logs in RUNNER_TEMP (failure predates the first xcodebuild step)"
+  exit 0
+fi
+
+for f in "${logs[@]}"; do
+  name="${f##*/}"
+  echo "::group::[raw-log] ${name} — error context"
+  # Subtool crashes don't always say "error:": match exceptions, dyld
+  # complaints, and assertion text too. Cap the output so a pathological log
+  # doesn't flood the job annotation view.
+  grep -n -B2 -A20 -E "error:|[Ee]xception|dyld\[|Assertion|Terminating|fatal" "$f" | tail -n 300 \
+    || echo "[raw-log] no error-pattern matches in ${name}"
+  echo "::endgroup::"
+  echo "::group::[raw-log] ${name} — last 120 lines"
+  tail -n 120 "$f"
+  echo "::endgroup::"
+done

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -153,6 +153,10 @@ jobs:
 
       - name: Test CabalmailKit on ${{ matrix.platform }}
         working-directory: apple/CabalmailKit
+        # tee the raw xcodebuild output to a file: xcbeautify swallows the
+        # stderr of crashing subtools (an actool crash once surfaced as a bare
+        # "CompileAssetCatalogVariant failed" across two runs), so on failure
+        # a later step dumps the raw log.
         run: |
           set -o pipefail
           xcodebuild test \
@@ -162,7 +166,12 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-test.log" \
             | xcbeautify --renderer github-actions
+
+      - name: Surface raw xcodebuild output on failure
+        if: failure()
+        run: .github/scripts/dump-xcodebuild-raw.sh
 
   # -----------------------------------------------------------------------
   # Build the app targets for the three product platforms. Unsigned — this
@@ -237,6 +246,8 @@ jobs:
 
       - name: Build ${{ matrix.scheme }} (unsigned)
         working-directory: apple
+        # tee: see the kit-test job's equivalent comment — on failure the
+        # next step dumps the raw log xcbeautify may have swallowed.
         run: |
           set -o pipefail
           xcodebuild build \
@@ -246,7 +257,12 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGN_IDENTITY="" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-build.log" \
             | xcbeautify --renderer github-actions
+
+      - name: Surface raw xcodebuild output on failure
+        if: failure()
+        run: .github/scripts/dump-xcodebuild-raw.sh
 
   approval:
     needs: [kit-test, app-build]
@@ -497,6 +513,7 @@ jobs:
             IOS_NSE_APP_STORE_PROFILE_UUID="${IOS_NSE_APP_STORE_PROFILE_UUID:-}" \
             MARKETING_VERSION="$MARKETING_VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-archive.log" \
             | xcbeautify --renderer github-actions
 
       - name: Export IPA
@@ -553,6 +570,7 @@ jobs:
             -archivePath "$RUNNER_TEMP/Cabalmail.xcarchive" \
             -exportPath "$RUNNER_TEMP/export-${{ matrix.altool_type }}" \
             -exportOptionsPlist "$PLIST" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-export.log" \
             | xcbeautify --renderer github-actions
 
       - name: Upload to TestFlight
@@ -623,6 +641,10 @@ jobs:
           security delete-keychain "$KEYCHAIN_PATH" || true
           rm -f "$RUNNER_TEMP/keychain-password"
           rm -rf "$HOME/.appstoreconnect/private_keys"
+
+      - name: Surface raw xcodebuild output on failure
+        if: failure()
+        run: .github/scripts/dump-xcodebuild-raw.sh
 
   # -----------------------------------------------------------------------
   # Signed archive + TestFlight upload + developer-id notarization for
@@ -828,6 +850,7 @@ jobs:
             MAC_NSE_APP_STORE_PROFILE_UUID="${MAC_NSE_APP_STORE_PROFILE_UUID:-}" \
             MARKETING_VERSION="$MARKETING_VERSION" \
             CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-archive.log" \
             | xcbeautify --renderer github-actions
 
       - name: Export app-store .pkg
@@ -867,6 +890,7 @@ jobs:
             -archivePath "$RUNNER_TEMP/CabalmailMac.xcarchive" \
             -exportPath "$RUNNER_TEMP/export-mac-appstore" \
             -exportOptionsPlist "$PLIST" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-export-appstore.log" \
             | xcbeautify --renderer github-actions
 
       - name: Summarize macOS upload
@@ -1005,6 +1029,7 @@ jobs:
             -archivePath "$RUNNER_TEMP/CabalmailMac.xcarchive" \
             -exportPath "$RUNNER_TEMP/export-mac-devid" \
             -exportOptionsPlist "$PLIST" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-export-devid.log" \
             | xcbeautify --renderer github-actions
 
       - name: Notarize and staple
@@ -1056,3 +1081,7 @@ jobs:
           security delete-keychain "${KEYCHAIN_PATH:-}" || true
           rm -f "$RUNNER_TEMP/keychain-password"
           rm -rf "$HOME/.appstoreconnect/private_keys"
+
+      - name: Surface raw xcodebuild output on failure
+        if: failure()
+        run: .github/scripts/dump-xcodebuild-raw.sh


### PR DESCRIPTION
## Why

xcbeautify swallows the stderr of crashing subtools. Run #400's actool crash surfaced as a bare "CompileAssetCatalogVariant failed" across two runs, and getting the real error (dyld override mismatch on the macOS 15 host) took a throwaway diagnostic workflow. Next opaque failure should self-diagnose.

## What

- Every `xcodebuild … | xcbeautify` invocation (7 across kit-test / app-build / upload-ios / upload-mac) becomes `xcodebuild … 2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-<step>.log" | xcbeautify …`. `set -o pipefail` is already in place, so failure propagation is unchanged; `2>&1` additionally captures subtool stderr that previously reached nobody.
- Each of the four jobs ends with an `if: failure()` step running the new shared `.github/scripts/dump-xcodebuild-raw.sh`: for every raw log, a grep'd error-context section (matches `error:`, exceptions, `dyld[`, assertions — capped at 300 lines) and the last 120 lines, each in a collapsed `::group::`.
- Raw logs live in `$RUNNER_TEMP`, so nothing is uploaded or retained on success.

CI-only; no changelog fragment (nothing user-facing, no Apple client sources touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)