### PR TITLE
Scale the .icon glyph up from 0.72 to 0.85

### DIFF
--- a/apple/Cabalmail/AppIcon.icon/icon.json
+++ b/apple/Cabalmail/AppIcon.icon/icon.json
@@ -9,10 +9,10 @@
         { "image-name" : "Mark.svg", "name" : "Glyph Light", "glass" : true,
           "fill" : { "solid" : "srgb:0.18039,0.32157,0.20784,1.00000" },
           "hidden-specializations" : [ { "appearance" : "dark", "value" : true } ],
-          "position" : { "scale" : 0.72, "translation-in-points" : [ 0, 0 ] } },
+          "position" : { "scale" : 0.85, "translation-in-points" : [ 0, 0 ] } },
         { "image-name" : "Mark.svg", "name" : "Glyph Dark", "glass" : true,
           "fill" : { "solid" : "srgb:0.90980,0.87451,0.78431,1.00000" },
-          "position" : { "scale" : 0.72, "translation-in-points" : [ 0, 0 ] } }
+          "position" : { "scale" : 0.85, "translation-in-points" : [ 0, 0 ] } }
       ],
       "specular" : true,
       "shadow" : { "kind" : "neutral", "opacity" : 0.5 }

--- a/apple/CabalmailMac/AppIcon.icon/icon.json
+++ b/apple/CabalmailMac/AppIcon.icon/icon.json
@@ -9,10 +9,10 @@
         { "image-name" : "Mark.svg", "name" : "Glyph Light", "glass" : true,
           "fill" : { "solid" : "srgb:0.18039,0.32157,0.20784,1.00000" },
           "hidden-specializations" : [ { "appearance" : "dark", "value" : true } ],
-          "position" : { "scale" : 0.72, "translation-in-points" : [ 0, 0 ] } },
+          "position" : { "scale" : 0.85, "translation-in-points" : [ 0, 0 ] } },
         { "image-name" : "Mark.svg", "name" : "Glyph Dark", "glass" : true,
           "fill" : { "solid" : "srgb:0.90980,0.87451,0.78431,1.00000" },
-          "position" : { "scale" : 0.72, "translation-in-points" : [ 0, 0 ] } }
+          "position" : { "scale" : 0.85, "translation-in-points" : [ 0, 0 ] } }
       ],
       "specular" : true,
       "shadow" : { "kind" : "neutral", "opacity" : 0.5 }

--- a/scripts/generate-logo-assets
+++ b/scripts/generate-logo-assets
@@ -53,6 +53,12 @@ readonly LIGHT_TOP="#FAF4E4"    LIGHT_BOTTOM="#EFE2C0"
 readonly DARK_TOP="#17261B"     DARK_BOTTOM="#0A130D"
 readonly PLATE_0="#FAF4E4"      PLATE_1="#EFE2C0"      PLATE_2="#D9C890"
 
+# Glyph size on the Liquid Glass .icon canvas. 1.0 runs the wide mark nearly
+# edge-to-edge; 0.72 read undersized next to system icons on a real Home
+# Screen / Dock. 0.85 matches neighboring icons' visual weight while keeping
+# the M's right edge clear of the squircle mask (0.90 crowds it).
+readonly ICON_GLYPH_SCALE="0.85"
+
 # The docs masthead logo is a solid silhouette (composited over a dark
 # animated plate by docs/_sass) — black preserves its established look.
 readonly MASK_INK="#000000"
@@ -410,10 +416,10 @@ write_icon() {
         { "image-name" : "Mark.svg", "name" : "Glyph Light", "glass" : true,
           "fill" : { "solid" : "$(hex_srgb "${FOREST}")" },
           "hidden-specializations" : [ { "appearance" : "dark", "value" : true } ],
-          "position" : { "scale" : 0.72, "translation-in-points" : [ 0, 0 ] } },
+          "position" : { "scale" : ${ICON_GLYPH_SCALE}, "translation-in-points" : [ 0, 0 ] } },
         { "image-name" : "Mark.svg", "name" : "Glyph Dark", "glass" : true,
           "fill" : { "solid" : "$(hex_srgb "${PARCHMENT}")" },
-          "position" : { "scale" : 0.72, "translation-in-points" : [ 0, 0 ] } }
+          "position" : { "scale" : ${ICON_GLYPH_SCALE}, "translation-in-points" : [ 0, 0 ] } }
       ],
       "specular" : true,
       "shadow" : { "kind" : "neutral", "opacity" : 0.5 }


### PR DESCRIPTION
On-device feedback: at `scale: 0.72` the mark reads undersized next to neighboring icons (Books, Affinity, etc.), which pad far less.

- Rendered 0.80 / 0.85 / 0.90 side by side with ictool: 0.85 matches neighbors' visual weight; 0.90 runs the wide M's right edge too close to the squircle mask.
- `ICON_GLYPH_SCALE=0.85` named constant in `generate-logo-assets` with the rationale; both `AppIcon.icon` bundles regenerated from it (only the two `icon.json`s change — all rasters byte-identical).
- ictool-verified Default + Dark renders at the new scale.

`no-changelog`: sizing tweak within the same unreleased cycle as the Liquid Glass icon itself; the existing pending fragment covers the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)