### PR TITLE
Apple: cap toast/status banner width at ~70% of container

### DIFF
--- a/apple/Cabalmail/Views/ToastBanner.swift
+++ b/apple/Cabalmail/Views/ToastBanner.swift
@@ -59,6 +59,10 @@ struct BannerView: View {
             Capsule(style: .continuous)
                 .stroke(tint.opacity(0.3), lineWidth: 1)
         )
+        // Cap the banner at ~70% of the container width so it clears the
+        // toolbar/action buttons it would otherwise overlap. Text wraps within
+        // this width (no lineLimit) and the capsule grows vertically to fit.
+        .containerRelativeFrame(.horizontal) { width, _ in width * 0.7 }
     }
 }
 

--- a/changelog.d/toast-width.changed.md
+++ b/changelog.d/toast-width.changed.md
@@ -1,0 +1,4 @@
+- Apple: **Narrower toast banners.** Transient toasts and status banners
+  now cap at ~70% of the container width instead of spanning nearly the
+  full width, reducing overlap with toolbar and action buttons. Longer
+  messages wrap and the banner grows vertically to fit.


### PR DESCRIPTION
## What

Transient toast notifications and the root status banners in the Apple clients previously filled nearly the full container width (they spanned the container minus 24pt of padding because of the `Spacer(minLength: 0)`), overlapping toolbar and action buttons.

This caps the shared `BannerView` at ~70% of the container width via `.containerRelativeFrame(.horizontal)`. The banner is horizontally centered by the existing top-aligned overlay. Message text has no `lineLimit`, so it wraps within the narrower width and the capsule grows vertically to fit.

## Scope

`BannerView` is the single primitive shared by both the transient `toastOverlay` hosts and `SignedInRootView`'s status banners, across iOS/iPadOS/macOS/visionOS — so this one change covers every toast surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)