### PR TITLE
Apple bulk ops: chunking and partial-failure reporting (Phase 4)

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Bulk.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Bulk.swift
@@ -84,32 +84,34 @@ extension MessageListViewModel {
 
     /// \Seen / unset-\Seen for an explicit UID set. Walks the set per-
     /// source-folder. Optimistically updates the in-memory flags so the
-    /// row styling flips before the wire call lands. Leaves any active
-    /// selection intact.
+    /// row styling flips before the wire call lands; rows the server
+    /// rejects (whole-group or `bulkPartialFailure` split) revert to
+    /// their pre-op state. Leaves any active selection intact.
     func setSeen(_ shouldBeSeen: Bool, uids: Set<UInt32>) async {
         let grouping = groupedByFolder(uids)
-        // Unread badge tracking — count actual transitions per folder
-        // BEFORE the optimistic loop rewrites the flags: marking an
-        // already-read message read must not move the sidebar counter.
+        let prior = priorFlagState(uids: uids, flag: .seen)
+        // Unread badge tracking — capture the actual transition UIDs per
+        // folder BEFORE the optimistic loop rewrites the flags: marking an
+        // already-read message read must not move the sidebar counter, and
+        // a partial failure must only count transitions that landed.
         let transitionsByFolder = Dictionary(
             grouping: envelopes.filter {
                 uids.contains($0.uid) && $0.flags.contains(.seen) != shouldBeSeen
             },
             by: { sourceFolder(for: $0) }
-        ).mapValues(\.count)
+        ).mapValues { Set($0.map(\.uid)) }
         for uid in uids {
             applyOptimisticFlag(uid: uid, flag: .seen, add: shouldBeSeen)
         }
         pendingFlagUIDs.formUnion(uids)
         defer { pendingFlagUIDs.subtract(uids) }
         for (source, groupUIDs) in grouping {
-            try? await client.imapClient.setFlags(
-                folder: source,
-                uids: groupUIDs,
-                flags: [.seen],
-                operation: shouldBeSeen ? .add : .remove
+            let applied = await applyFlagGroup(
+                folder: source, uids: groupUIDs,
+                flag: .seen, add: shouldBeSeen, prior: prior
             )
-            if let transitions = transitionsByFolder[source], transitions > 0 {
+            let transitions = transitionsByFolder[source]?.intersection(applied).count ?? 0
+            if transitions > 0 {
                 appState.applyUnreadDelta(
                     folderPath: source,
                     delta: shouldBeSeen ? -transitions : transitions
@@ -123,18 +125,60 @@ extension MessageListViewModel {
     /// the sidebar).
     func setFlagged(_ shouldBeFlagged: Bool, uids: Set<UInt32>) async {
         let grouping = groupedByFolder(uids)
+        let prior = priorFlagState(uids: uids, flag: .flagged)
         for uid in uids {
             applyOptimisticFlag(uid: uid, flag: .flagged, add: shouldBeFlagged)
         }
         pendingFlagUIDs.formUnion(uids)
         defer { pendingFlagUIDs.subtract(uids) }
         for (source, groupUIDs) in grouping {
-            try? await client.imapClient.setFlags(
-                folder: source,
-                uids: groupUIDs,
-                flags: [.flagged],
-                operation: shouldBeFlagged ? .add : .remove
+            _ = await applyFlagGroup(
+                folder: source, uids: groupUIDs,
+                flag: .flagged, add: shouldBeFlagged, prior: prior
             )
+        }
+    }
+
+    /// Pre-op flag membership per UID, captured before the optimistic
+    /// rewrite so a rejected row can revert to exactly what it had — a
+    /// blind "apply the opposite" would corrupt rows that already carried
+    /// the target state (e.g. mark-read over an already-read message).
+    private func priorFlagState(uids: Set<UInt32>, flag: Flag) -> [UInt32: Bool] {
+        Dictionary(uniqueKeysWithValues: envelopes
+            .filter { uids.contains($0.uid) }
+            .map { ($0.uid, $0.flags.contains(flag)) })
+    }
+
+    /// One flag-group wire call plus reconciliation: returns the UIDs the
+    /// server actually applied. A `bulkPartialFailure` keeps the succeeded
+    /// rows, reverts the failed ones, and surfaces an "X of Y" message;
+    /// any other error reverts the whole group.
+    private func applyFlagGroup(
+        folder: String,
+        uids: [UInt32],
+        flag: Flag,
+        add: Bool,
+        prior: [UInt32: Bool]
+    ) async -> Set<UInt32> {
+        do {
+            try await client.imapClient.setFlags(
+                folder: folder, uids: uids, flags: [flag],
+                operation: add ? .add : .remove
+            )
+            return Set(uids)
+        } catch CabalmailError.bulkPartialFailure(let succeeded, let failed) {
+            for uid in failed {
+                applyOptimisticFlag(uid: uid, flag: flag, add: prior[uid] ?? !add)
+            }
+            errorMessage = "Updated \(succeeded.count) of \(uids.count) messages. "
+                + "\(failed.count) could not be updated."
+            return succeeded
+        } catch {
+            for uid in uids {
+                applyOptimisticFlag(uid: uid, flag: flag, add: prior[uid] ?? !add)
+            }
+            errorMessage = "\(error)"
+            return []
         }
     }
 

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Move.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Move.swift
@@ -102,26 +102,83 @@ extension MessageListViewModel {
         for (source, uids) in groups {
             do {
                 if markSeenFirst {
-                    try await client.imapClient.setFlags(
-                        folder: source, uids: uids,
-                        flags: [.seen], operation: .add
-                    )
+                    do {
+                        try await client.imapClient.setFlags(
+                            folder: source, uids: uids,
+                            flags: [.seen], operation: .add
+                        )
+                    } catch CabalmailError.bulkPartialFailure {
+                        // Seen-marking is best-effort cosmetics on a
+                        // dispose; a partial miss must not abort the move.
+                    }
                 }
                 try await client.imapClient.move(
                     folder: source, uids: uids, destination: destination
                 )
                 await pruneCachesAfter(move: source, uids: uids)
+            } catch CabalmailError.bulkPartialFailure(let succeeded, let failed) {
+                restoreAfterPartialMove(
+                    source: source, destination: destination, snapshot: snapshot,
+                    failed: failed, markSeenFirst: markSeenFirst
+                )
+                await pruneCachesAfter(move: source, uids: Array(succeeded))
+                errorMessage = "Moved \(succeeded.count) of \(uids.count) messages. "
+                    + "\(failed.count) could not be moved."
             } catch {
-                let restored = snapshot.filter { sourceFolder(for: $0) == source }
-                envelopes.append(contentsOf: restored)
-                envelopes.sort(by: envelopeOrder)
-                let unread = unreadBySource[source] ?? 0
-                appState.applyUnreadDelta(folderPath: source, delta: unread)
-                if !markSeenFirst {
-                    appState.applyUnreadDelta(folderPath: destination, delta: -unread)
-                }
+                restoreAfterFailedMove(
+                    source: source, destination: destination, snapshot: snapshot,
+                    unread: unreadBySource[source] ?? 0, markSeenFirst: markSeenFirst
+                )
                 errorMessage = "\(error)"
             }
+        }
+    }
+
+    /// Whole-group revert for a move that failed outright: every row from
+    /// `source` comes back and its unread count returns to the source (and
+    /// leaves the destination, when the optimistic pass had granted it).
+    private func restoreAfterFailedMove(
+        source: String,
+        destination: String,
+        snapshot: [Envelope],
+        unread: Int,
+        markSeenFirst: Bool
+    ) {
+        let restored = snapshot.filter { sourceFolder(for: $0) == source }
+        envelopes.append(contentsOf: restored)
+        envelopes.sort(by: envelopeOrder)
+        appState.applyUnreadDelta(folderPath: source, delta: unread)
+        if !markSeenFirst {
+            appState.applyUnreadDelta(folderPath: destination, delta: -unread)
+        }
+    }
+
+    /// Partial-failure counterpart of `performMove`'s whole-group revert:
+    /// only the failed rows come back. On a dispose (`markSeenFirst`) the
+    /// restored rows re-appear as read — the seen-marking already landed
+    /// server-side and the top-of-move unread subtraction assumed it — so
+    /// no unread deltas move; a plain move hands the failed rows' unread
+    /// counts back to the source and reclaims them from the destination.
+    private func restoreAfterPartialMove(
+        source: String,
+        destination: String,
+        snapshot: [Envelope],
+        failed: Set<UInt32>,
+        markSeenFirst: Bool
+    ) {
+        let restored = snapshot.filter {
+            sourceFolder(for: $0) == source && failed.contains($0.uid)
+        }
+        envelopes.append(contentsOf: restored)
+        envelopes.sort(by: envelopeOrder)
+        if markSeenFirst {
+            for envelope in restored {
+                applyOptimisticFlag(uid: envelope.uid, flag: .seen, add: true)
+            }
+        } else {
+            let unread = restored.filter { !$0.flags.contains(.seen) }.count
+            appState.applyUnreadDelta(folderPath: source, delta: unread)
+            appState.applyUnreadDelta(folderPath: destination, delta: -unread)
         }
     }
 }

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
@@ -90,9 +90,11 @@ public protocol ApiClient: Sendable {
     // MARK: Operations
     /// Sets or clears one or more flags on the supplied message UIDs.
     /// `request.operation` is `set` or `unset` to match the Lambda's
-    /// expected wire value (`lambda/api/set_flag/function.py`).
-    func setFlag(_ request: SetFlagRequest) async throws -> [UInt32]
-    func moveMessages(_ request: MoveMessagesRequest) async throws
+    /// expected wire value (`lambda/api/set_flag/function.py`). The result
+    /// carries the Lambda's succeeded/failed split; a fully-successful call
+    /// reports every requested UID as succeeded.
+    func setFlag(_ request: SetFlagRequest) async throws -> BulkOpResult
+    func moveMessages(_ request: MoveMessagesRequest) async throws -> BulkOpResult
 
     /// Permanently deletes (flags `\Deleted` + expunges) the given messages.
     /// The `/purge_messages` Lambda only accepts trash folders, so a client
@@ -259,6 +261,22 @@ public struct AttachmentUpload: Sendable, Hashable {
 }
 
 // MARK: - Request types
+
+/// Per-UID outcome of a bulk flag/move call. The Lambdas run their IMAP
+/// commands in bounded batches (`apply_in_batches` in
+/// `lambda/api/_shared/helper.py`) and return `status: "partial"` with a
+/// succeeded/failed split when some batches fail; on the plain
+/// `status: "submitted"` success body the API layer reports every
+/// requested UID as succeeded.
+public struct BulkOpResult: Sendable, Equatable {
+    public let succeeded: [UInt32]
+    public let failed: [UInt32]
+
+    public init(succeeded: [UInt32], failed: [UInt32]) {
+        self.succeeded = succeeded
+        self.failed = failed
+    }
+}
 
 /// Parameters for `/set_flag`. Bundled into a struct so the call site
 /// stays under SwiftLint's `function_parameter_count` limit while keeping

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Messages.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Messages.swift
@@ -21,12 +21,39 @@ private struct MessageIdsPayload: Decodable {
     }
 }
 
-private struct MessageIdsOptionalPayload: Decodable {
-    let messageIds: [UInt32]?
+/// Response body of the bulk-op Lambdas (`/set_flag`, `/move_messages`).
+/// Full success is `{"status": "submitted"}`; a batched partial failure is
+/// `{"status": "partial", "flagged_ids"/"moved_ids": [...], "failed_ids":
+/// [...]}` (the success key is endpoint-specific, so both are optional
+/// here). Older Lambdas returned `{"message_ids": [...]}` — decoding that
+/// yields no `status`, which the mapper treats as full success.
+private struct BulkOpPayload: Decodable {
+    let status: String?
+    let flaggedIds: [UInt32]?
+    let movedIds: [UInt32]?
+    let failedIds: [UInt32]?
 
     private enum CodingKeys: String, CodingKey {
-        case messageIds = "message_ids"
+        case status
+        case flaggedIds = "flagged_ids"
+        case movedIds = "moved_ids"
+        case failedIds = "failed_ids"
     }
+}
+
+/// Maps a bulk-op response body onto the requested UID list. Anything
+/// other than an explicit `status: "partial"` (including an undecodable
+/// body) is full success — a total failure arrives as a non-2xx status
+/// and throws inside `send` before reaching this.
+private func decodeBulkResult(_ data: Data, requested: [UInt32]) -> BulkOpResult {
+    guard let payload = try? JSONDecoder().decode(BulkOpPayload.self, from: data),
+          payload.status == "partial" else {
+        return BulkOpResult(succeeded: requested, failed: [])
+    }
+    return BulkOpResult(
+        succeeded: payload.flaggedIds ?? payload.movedIds ?? [],
+        failed: payload.failedIds ?? []
+    )
 }
 
 /// Day-granular date formatter matching `/search_envelopes`'s YYYY-MM-DD
@@ -225,7 +252,7 @@ extension URLSessionApiClient {
 
     // MARK: - Operations
 
-    public func setFlag(_ request: SetFlagRequest) async throws -> [UInt32] {
+    public func setFlag(_ request: SetFlagRequest) async throws -> BulkOpResult {
         let httpRequest = try await put("/set_flag", json: [
             "host": request.host,
             "folder": request.folder,
@@ -236,10 +263,10 @@ extension URLSessionApiClient {
             "sort_field": request.sortField,
         ])
         let data = try await send(httpRequest, expectedStatuses: 200..<300)
-        return (try? JSONDecoder().decode(MessageIdsOptionalPayload.self, from: data).messageIds) ?? []
+        return decodeBulkResult(data, requested: request.ids)
     }
 
-    public func moveMessages(_ request: MoveMessagesRequest) async throws {
+    public func moveMessages(_ request: MoveMessagesRequest) async throws -> BulkOpResult {
         let httpRequest = try await put("/move_messages", json: [
             "host": request.host,
             "source": request.source,
@@ -248,7 +275,8 @@ extension URLSessionApiClient {
             "sort_order": request.sortOrder,
             "sort_field": request.sortField,
         ])
-        _ = try await send(httpRequest, expectedStatuses: 200..<300)
+        let data = try await send(httpRequest, expectedStatuses: 200..<300)
+        return decodeBulkResult(data, requested: request.ids)
     }
 
     public func purgeMessages(host: String, folder: String, ids: [UInt32]) async throws {

--- a/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ApiBackedImapClient+Bulk.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ApiBackedImapClient+Bulk.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// Bulk-op chunking and partial-failure aggregation for the API-backed
+// client (Phase 4 of `docs/1.1.x/multi-select-bulk-operations.md`). In its
+// own file so `ApiBackedImapClient.swift` stays under SwiftLint's
+// file-length cap; everything here is a static helper, so the actor's
+// private stored state is never needed.
+
+/// Accumulated outcome of the chunked calls behind one logical bulk op.
+/// `firstError` keeps the original thrown error so a total failure can
+/// surface the real cause instead of a synthetic partial-failure.
+struct BulkChunkOutcome: Sendable {
+    var succeeded: Set<UInt32> = []
+    var failed: Set<UInt32> = []
+    var firstError: (any Error)?
+}
+
+extension ApiBackedImapClient {
+    /// Ceiling on UIDs per Lambda request. A timeout safety net: the Lambda
+    /// already batches its IMAP commands internally (500 UIDs per command)
+    /// but one request carrying tens of thousands of UIDs would still brush
+    /// the 29s API Gateway limit — and the Lambdas 413 anything over their
+    /// `MAX_IDS_PER_REQUEST` (5000) outright. Chunks run sequentially, not
+    /// concurrently, to avoid stampeding the IMAP tier and to keep
+    /// per-chunk error attribution simple.
+    static let bulkChunkSize = 1000
+
+    /// Runs `perform` over `bulkChunkSize`-sized slices of `uids`,
+    /// accumulating each chunk's succeeded/failed split. A chunk that
+    /// throws (network failure, Lambda `status: "unable"` 500) records all
+    /// of its UIDs as failed and the walk continues — mirroring the
+    /// Lambda's own `apply_in_batches` semantics — so the caller always
+    /// gets a complete per-UID picture.
+    static func runChunked(
+        uids: [UInt32],
+        perform: ([UInt32]) async throws -> BulkOpResult
+    ) async -> BulkChunkOutcome {
+        var outcome = BulkChunkOutcome()
+        for start in stride(from: 0, to: uids.count, by: bulkChunkSize) {
+            let chunk = Array(uids[start..<min(start + bulkChunkSize, uids.count)])
+            do {
+                let result = try await perform(chunk)
+                outcome.succeeded.formUnion(result.succeeded)
+                outcome.failed.formUnion(result.failed)
+            } catch {
+                outcome.failed.formUnion(chunk)
+                if outcome.firstError == nil { outcome.firstError = error }
+            }
+        }
+        return outcome
+    }
+
+    /// Merges the outcomes of one bulk op (several per-flag fan-out legs,
+    /// or a single move) and throws when any UID failed. A UID counts as
+    /// succeeded only if every leg applied it. Total failure rethrows the
+    /// original error; a genuine split throws `bulkPartialFailure` so the
+    /// view model can keep the succeeded UIDs applied and restore the rest.
+    static func throwIfIncomplete(_ outcomes: [BulkChunkOutcome]) throws {
+        let failed = outcomes.reduce(into: Set<UInt32>()) { $0.formUnion($1.failed) }
+        guard !failed.isEmpty else { return }
+        let succeeded = outcomes
+            .reduce(into: Set<UInt32>()) { $0.formUnion($1.succeeded) }
+            .subtracting(failed)
+        if succeeded.isEmpty, let error = outcomes.compactMap(\.firstError).first {
+            throw error
+        }
+        throw CabalmailError.bulkPartialFailure(succeeded: succeeded, failed: failed)
+    }
+}

--- a/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ApiBackedImapClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/IMAP/ApiBackedImapClient.swift
@@ -153,37 +153,53 @@ public actor ApiBackedImapClient: ImapClient {
         }
         // Snapshot actor state before fanning out; the child tasks run
         // outside this actor's isolation, so they must not touch `self`.
+        // Each per-flag leg walks the UID list in `bulkChunkSize` chunks
+        // (see `ApiBackedImapClient+Bulk.swift`) and reports its
+        // succeeded/failed split; the merge below throws
+        // `bulkPartialFailure` when any UID missed any flag.
         let api = self.api
         let host = self.host
         let sortOrder = defaultSortOrder
         let sortField = defaultSortField
-        try await withThrowingTaskGroup(of: Void.self) { group in
+        let outcomes = await withTaskGroup(of: BulkChunkOutcome.self) { group in
             for flag in flags {
                 group.addTask {
-                    _ = try await api.setFlag(SetFlagRequest(
-                        host: host,
-                        folder: folder,
-                        ids: uids,
-                        flag: flag.wireValue,
-                        operation: wireOp,
-                        sortOrder: sortOrder,
-                        sortField: sortField
-                    ))
+                    await Self.runChunked(uids: uids) { chunk in
+                        try await api.setFlag(SetFlagRequest(
+                            host: host,
+                            folder: folder,
+                            ids: chunk,
+                            flag: flag.wireValue,
+                            operation: wireOp,
+                            sortOrder: sortOrder,
+                            sortField: sortField
+                        ))
+                    }
                 }
             }
-            try await group.waitForAll()
+            var collected: [BulkChunkOutcome] = []
+            for await outcome in group { collected.append(outcome) }
+            return collected
         }
+        try Self.throwIfIncomplete(outcomes)
     }
 
     public func move(folder: String, uids: [UInt32], destination: String) async throws {
-        try await api.moveMessages(MoveMessagesRequest(
-            host: host,
-            source: folder,
-            destination: destination,
-            ids: uids,
-            sortOrder: defaultSortOrder,
-            sortField: defaultSortField
-        ))
+        let api = self.api
+        let host = self.host
+        let sortOrder = defaultSortOrder
+        let sortField = defaultSortField
+        let outcome = await Self.runChunked(uids: uids) { chunk in
+            try await api.moveMessages(MoveMessagesRequest(
+                host: host,
+                source: folder,
+                destination: destination,
+                ids: chunk,
+                sortOrder: sortOrder,
+                sortField: sortField
+            ))
+        }
+        try Self.throwIfIncomplete([outcome])
     }
 
     // MARK: - Search

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/Errors.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/Errors.swift
@@ -32,4 +32,12 @@ public enum CabalmailError: Error, Sendable, Equatable {
     /// 503 with `{"status":"maintenance"}`. `message` is the client-facing copy
     /// so the UI can show "temporarily unavailable" instead of a raw error.
     case maintenance(message: String)
+
+    /// A bulk flag/move landed for some UIDs but not others. The bulk-op
+    /// Lambdas issue their IMAP commands in bounded batches and report a
+    /// succeeded/failed split (`status: "partial"`); the API-backed client
+    /// also aggregates across its own request chunks into one of these.
+    /// Callers keep the succeeded UIDs applied and restore (or offer to
+    /// retry) the failed ones.
+    case bulkPartialFailure(succeeded: Set<UInt32>, failed: Set<UInt32>)
 }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ApiBackedImapClientBulkTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ApiBackedImapClientBulkTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import CabalmailKit
+
+// Coverage for Phase 4 of `docs/1.1.x/multi-select-bulk-operations.md`:
+// client-side chunking of large bulk ops and partial-failure aggregation
+// (`CabalmailError.bulkPartialFailure`). In its own file so the primary
+// `ApiBackedImapClientTests` stays under SwiftLint's file/type caps.
+final class ApiBackedImapClientBulkTests: XCTestCase {
+
+    private let submitted = #"{"status":"submitted"}"#
+
+    // MARK: - Chunking
+
+    func testMoveChunksLargeSelections() async throws {
+        // 2.5 chunks' worth of UIDs must fan into exactly three sequential
+        // PUTs of 1000 / 1000 / 500 ids, all against /move_messages.
+        let http = RecordingHTTPTransport(responses: [
+            (Data(submitted.utf8), 200),
+            (Data(submitted.utf8), 200),
+            (Data(submitted.utf8), 200),
+        ])
+        let client = makeClient(http)
+        let uids = Array(UInt32(1)...2500)
+        try await client.move(folder: "INBOX", uids: uids, destination: "Archive")
+
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 3)
+        let idCounts = requests.map { requestIds($0).count }
+        XCTAssertEqual(idCounts, [1000, 1000, 500])
+        XCTAssertEqual(requestIds(requests[0]).first, 1)
+        XCTAssertEqual(requestIds(requests[1]).first, 1001)
+        XCTAssertEqual(requestIds(requests[2]).first, 2001)
+        for request in requests {
+            XCTAssertTrue(request.url!.absoluteString.contains("/move_messages"))
+        }
+    }
+
+    func testSetFlagsChunksPerFlagLeg() async throws {
+        // One flag over 1500 UIDs: two chunked calls, no partial → no throw.
+        let http = RecordingHTTPTransport(responses: [
+            (Data(submitted.utf8), 200),
+            (Data(submitted.utf8), 200),
+        ])
+        let client = makeClient(http)
+        let uids = Array(UInt32(1)...1500)
+        try await client.setFlags(folder: "INBOX", uids: uids, flags: [.seen], operation: .add)
+
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests.map { requestIds($0).count }, [1000, 500])
+    }
+
+    // MARK: - Partial failure
+
+    func testMovePartialFailureThrowsWithSplit() async throws {
+        let body = #"{"status":"partial","moved_ids":[1,2],"failed_ids":[3]}"#
+        let http = RecordingHTTPTransport(responses: [(Data(body.utf8), 200)])
+        let client = makeClient(http)
+        do {
+            try await client.move(folder: "INBOX", uids: [1, 2, 3], destination: "Archive")
+            XCTFail("expected bulkPartialFailure")
+        } catch CabalmailError.bulkPartialFailure(let succeeded, let failed) {
+            XCTAssertEqual(succeeded, [1, 2])
+            XCTAssertEqual(failed, [3])
+        }
+    }
+
+    func testSetFlagsPartialFailureThrowsWithSplit() async throws {
+        let body = #"{"status":"partial","flagged_ids":[1],"failed_ids":[2]}"#
+        let http = RecordingHTTPTransport(responses: [(Data(body.utf8), 200)])
+        let client = makeClient(http)
+        do {
+            try await client.setFlags(folder: "INBOX", uids: [1, 2], flags: [.seen], operation: .add)
+            XCTFail("expected bulkPartialFailure")
+        } catch CabalmailError.bulkPartialFailure(let succeeded, let failed) {
+            XCTAssertEqual(succeeded, [1])
+            XCTAssertEqual(failed, [2])
+        }
+    }
+
+    func testSetFlagsMultiFlagPartialFailureMerges() async throws {
+        // Both flag legs report the same split (identical bodies keep the
+        // concurrent request→response pairing deterministic); the merge
+        // must union the failures and never count a failed UID as
+        // succeeded.
+        let body = #"{"status":"partial","flagged_ids":[1],"failed_ids":[2]}"#
+        let http = RecordingHTTPTransport(responses: [
+            (Data(body.utf8), 200),
+            (Data(body.utf8), 200),
+        ])
+        let client = makeClient(http)
+        do {
+            try await client.setFlags(
+                folder: "INBOX", uids: [1, 2], flags: [.seen, .flagged], operation: .add
+            )
+            XCTFail("expected bulkPartialFailure")
+        } catch CabalmailError.bulkPartialFailure(let succeeded, let failed) {
+            XCTAssertEqual(succeeded, [1])
+            XCTAssertEqual(failed, [2])
+        }
+    }
+
+    func testMidChunkHardFailureAggregatesIntoPartial() async throws {
+        // First chunk lands, second 500s ({"status":"unable"}): the walk
+        // continues past the throw and reports the dead chunk's UIDs as
+        // failed rather than surfacing a bare server error.
+        let http = RecordingHTTPTransport(responses: [
+            (Data(submitted.utf8), 200),
+            (Data(#"{"status":"unable"}"#.utf8), 500),
+        ])
+        let client = makeClient(http)
+        let uids = Array(UInt32(1)...1500)
+        do {
+            try await client.move(folder: "INBOX", uids: uids, destination: "Archive")
+            XCTFail("expected bulkPartialFailure")
+        } catch CabalmailError.bulkPartialFailure(let succeeded, let failed) {
+            XCTAssertEqual(succeeded, Set(UInt32(1)...1000))
+            XCTAssertEqual(failed, Set(UInt32(1001)...1500))
+        }
+    }
+
+    func testTotalFailureRethrowsOriginalError() async throws {
+        // Nothing succeeded → the caller gets the real server error, not a
+        // partial-failure with an empty succeeded set.
+        let http = RecordingHTTPTransport(responses: [
+            (Data(#"{"status":"unable"}"#.utf8), 500),
+        ])
+        let client = makeClient(http)
+        do {
+            try await client.move(folder: "INBOX", uids: [1, 2], destination: "Archive")
+            XCTFail("expected server error")
+        } catch CabalmailError.bulkPartialFailure {
+            XCTFail("total failure must not masquerade as partial")
+        } catch let error as CabalmailError {
+            guard case .server = error else {
+                return XCTFail("expected .server, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeClient(_ http: RecordingHTTPTransport) -> ApiBackedImapClient {
+        let api = URLSessionApiClient(
+            configuration: Configuration(
+                controlDomain: "cabalmail.example",
+                domains: [MailDomain(domain: "cabalmail.example")],
+                invokeUrl: URL(string: "https://api.cabalmail.example/prod")!,
+                cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
+            ),
+            authService: StubAuthService(),
+            transport: http
+        )
+        return ApiBackedImapClient(api: api, host: "imap.example.com")
+    }
+
+    private func requestIds(_ request: URLRequest) -> [Int] {
+        let json = try? JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+        return (json as? [String: Any])?["ids"] as? [Int] ?? []
+    }
+}

--- a/changelog.d/apple-bulk-partial-failure.changed.md
+++ b/changelog.d/apple-bulk-partial-failure.changed.md
@@ -1,4 +1,4 @@
-- **Apple bulk actions now chunk large selections and report partial
+- Apple: **Apple bulk actions now chunk large selections and report partial
   failures.** Flag and move operations go to the server in 1,000-message
   chunks as a timeout safety net, and when only some messages succeed the
   client keeps the ones that landed, restores the ones that failed, and

--- a/changelog.d/apple-bulk-partial-failure.changed.md
+++ b/changelog.d/apple-bulk-partial-failure.changed.md
@@ -1,0 +1,5 @@
+- **Apple bulk actions now chunk large selections and report partial
+  failures.** Flag and move operations go to the server in 1,000-message
+  chunks as a timeout safety net, and when only some messages succeed the
+  client keeps the ones that landed, restores the ones that failed, and
+  shows "Moved X of Y" instead of silently losing rows.


### PR DESCRIPTION
## Summary

Implements the **Apple half of Phase 4** of `docs/1.1.x/multi-select-bulk-operations.md`. The Lambda side (uniform `submitted`/`partial`/`unable` response via `batch_result_response`, per-batch failure partitioning) already shipped; this makes the Apple client consume it.

- **`CabalmailError.bulkPartialFailure(succeeded:failed:)`** — new error case carrying the per-UID split. (The plan sketched an `underlying: Error` payload; dropped to keep the enum `Equatable`, and the Lambda's batch split carries no per-UID reason anyway.)
- **Response decoding** — `/set_flag` and `/move_messages` now return `BulkOpResult`; `status: "partial"` maps `flagged_ids`/`moved_ids` + `failed_ids` into the split, anything else (including the legacy `message_ids` body) is full success. Total failure still arrives as a non-2xx and throws `.server` as before.
- **Client-side chunking** — `ApiBackedImapClient` splits bulk ops over `bulkChunkSize` (1000) UIDs into sequential chunks (Lambda-timeout safety net; the Lambdas 413 anything over `MAX_IDS_PER_REQUEST` = 5000). Per-chunk outcomes aggregate: a chunk that throws records its UIDs as failed and the walk continues, mirroring the Lambda's own `apply_in_batches`. Total failure rethrows the original error rather than a partial with an empty succeeded set.
- **View-model reconciliation** — partial flag ops revert only the failed rows, restoring each to its *captured pre-op state* (a blind opposite-flip would corrupt rows that already carried the target flag) and count unread-badge transitions only for UIDs that landed; partial moves restore only the failed rows, hand their unread counts back, and prune caches for the succeeded UIDs. User sees "Moved X of Y messages. N could not be moved." Seen-marking before a dispose is now best-effort — a partial miss no longer aborts the move.

## Not in this PR (remaining Phase 4/5 items)

- React side: parse the split, partial-failure toast
- `refresh_list` gating was superseded — the Lambda dropped the post-store SORT entirely
- `BulkSelectionTests.swift` view-model coverage; VoiceOver pass

## Verification

- `cd apple/CabalmailKit && swift test` — 331 tests, all green (after `sync-vendored.sh`)
- New `ApiBackedImapClientBulkTests`: chunk fan-out (2500 → 1000/1000/500), partial decode for both endpoints, multi-flag merge, mid-chunk hard failure aggregation, total-failure rethrow
- `swiftlint` from `apple/` — 0 warnings
- `xcodegen generate && xcodebuild … generic/platform=iOS` — BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)