### PR TITLE
React bulk ops: partial-failure reporting (Phase 4)

### DIFF
--- a/changelog.d/react-bulk-partial-failure.changed.md
+++ b/changelog.d/react-bulk-partial-failure.changed.md
@@ -1,0 +1,5 @@
+- **Web bulk actions now report partial failures.** When the server
+  completes a bulk move, archive, delete, or flag change for only some of
+  the selected messages, the web app restores the rows that failed,
+  keeps them selected for a one-click retry, and shows "Moved X of Y
+  messages" instead of silently dropping them from view.

--- a/react/admin/src/Email/Messages/Messages.test.jsx
+++ b/react/admin/src/Email/Messages/Messages.test.jsx
@@ -554,6 +554,77 @@ describe('Messages - optimistic bulk operations', () => {
     }
   });
 
+  it('restores and re-selects the failed rows on a partial bulk archive', async () => {
+    // The Lambda batches its IMAP commands: a 200 "partial" names the ids
+    // whose batch failed. Those rows must come back (they never left the
+    // folder), stay selected for a one-click retry, and the user must see
+    // the split — not a silent success.
+    mockMoveMessages.mockResolvedValue({
+      data: { status: 'partial', moved_ids: [1], failed_ids: [2] },
+    });
+    const setMessage = vi.fn();
+    const setSelected = vi.fn();
+    const { container, unmount } = render(
+      <Harness
+        folder="INBOX"
+        overrides={{ bulkMode: true, selected: new Set([1, 2]), setMessage, setSelected }}
+      />,
+    );
+    try {
+      await waitFor(() => {
+        expect(container.querySelectorAll('.envelope-row').length).toBe(3);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /archive/i }));
+      });
+      await flush();
+
+      // Row 1 moved and stays gone; row 2 failed and is restored beside the
+      // untouched row 3.
+      expect(container.querySelectorAll('.envelope-row').length).toBe(2);
+      expect(screen.getByText('Subject 2')).toBeInTheDocument();
+      expect(screen.queryByText('Subject 1')).not.toBeInTheDocument();
+      expect(setSelected).toHaveBeenCalledWith(new Set([2]));
+      expect(setMessage).toHaveBeenCalledWith(
+        'Archived 1 of 2 messages — 1 could not be archived.',
+        true,
+      );
+    } finally {
+      unmount();
+    }
+  });
+
+  it('rolls back the failed rows and reports the split on a partial mark-read', async () => {
+    mockSetFlag.mockResolvedValue({
+      data: { status: 'partial', flagged_ids: [1], failed_ids: [2] },
+    });
+    const setMessage = vi.fn();
+    const { container, unmount } = render(
+      <Harness
+        folder="INBOX"
+        overrides={{ bulkMode: true, selected: new Set([1, 2]), setMessage }}
+      />,
+    );
+    try {
+      await waitFor(() => {
+        expect(container.querySelectorAll('.envelope-row').length).toBe(3);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /mark read/i }));
+      });
+      await flush();
+
+      // Flag ops never remove rows; the user just learns which ids missed.
+      expect(container.querySelectorAll('.envelope-row').length).toBe(3);
+      expect(setMessage).toHaveBeenCalledWith(
+        'Updated 1 of 2 messages — 1 could not be updated.',
+        true,
+      );
+    } finally {
+      unmount();
+    }
+  });
+
   it('bulk mark-read chunks set_flag and reconciles without re-pulling the list', async () => {
     const { unmount } = render(
       <Harness folder="INBOX" overrides={{ bulkMode: true, selected: new Set([1, 2]) }} />,

--- a/react/admin/src/Email/Messages/index.jsx
+++ b/react/admin/src/Email/Messages/index.jsx
@@ -23,24 +23,45 @@ const SORT_OPTIONS = [DATE, ARRIVAL, FROM, SUBJECT];
 // calling `onProgress(doneCount)` after each slice lands. Sequential (not
 // parallel) so the server sees a steady stream rather than a burst, and so a
 // failure tells us exactly how many ids got through: on the first chunk that
-// throws, the rejection carries `.done` (the count that succeeded before it)
-// and `.cause` (the underlying error) so the caller can roll back the rest.
+// throws, the rejection carries `.done` (the count submitted before it),
+// `.failed` (ids earlier chunks reported as failed) and `.cause` (the
+// underlying error) so the caller can roll back the rest.
+//
+// A 200 carrying `status: "partial"` is not a throw: the bulk-op Lambdas run
+// their IMAP commands in bounded batches and report the ids whose batch
+// failed in `failed_ids` (see `batch_result_response` in
+// `lambda/api/_shared/helper.py`). Those accumulate across chunks into the
+// resolved value's `failed` list so the caller can restore exactly those
+// rows instead of silently losing them.
 async function runInChunks(ids, chunkSize, doChunk, onProgress) {
   let done = 0;
+  const failed = [];
   for (let start = 0; start < ids.length; start += chunkSize) {
     const chunk = ids.slice(start, start + chunkSize);
     try {
-      await doChunk(chunk);
+      const res = await doChunk(chunk);
+      const body = res && res.data;
+      if (body && body.status === 'partial' && Array.isArray(body.failed_ids)) {
+        failed.push(...body.failed_ids.map(Number));
+      }
     } catch (cause) {
       const err = new Error('bulk chunk failed');
       err.done = done;
+      err.failed = failed;
       err.cause = cause;
       throw err;
     }
     done += chunk.length;
     if (typeof onProgress === 'function') onProgress(done);
   }
-  return done;
+  return { done, failed };
+}
+
+// "Moved 387 of 412 messages — 25 could not be moved."
+function partialNotice(verb, okCount, total, failedCount) {
+  const capped = verb[0].toUpperCase() + verb.slice(1);
+  return `${capped} ${okCount.toLocaleString()} of ${total.toLocaleString()} messages — `
+    + `${failedCount.toLocaleString()} could not be ${verb}.`;
 }
 
 function Messages({
@@ -284,8 +305,11 @@ function Messages({
   // stream the operation to the server in chunks (showing progress), then
   // reconcile via STATUS. On a chunk failure, restore the rows past the point
   // that landed and surface the error -- the rows that did move stay gone.
+  // A chunk that lands with `status: "partial"` restores exactly the ids the
+  // Lambda reported failed, re-selects them (still in bulk mode) so a retry
+  // is one click away, and tells the user "Moved X of Y".
   const runOptimisticRemoval = useCallback(
-    (ids, { verb, failMessage, doChunk }) => {
+    (ids, { verb, doneVerb, failMessage, doChunk }) => {
       const numIds = ids.map(Number);
       if (!numIds.length) return;
       const removeSet = new Set(numIds);
@@ -297,21 +321,46 @@ function Messages({
       setMessageIds((prev) => prev.filter((id) => !removeSet.has(Number(id))));
       setTotal((t) => Math.max(0, t - numIds.length));
 
+      // Restore the rows in `failedIds`: they never left the server folder.
+      // Filtering the snapshot (rather than appending) keeps the sort order.
+      const restoreFailed = (failedIds) => {
+        const failedSet = new Set(failedIds);
+        setMessageIds(snapshotIds.filter(
+          (id) => !removeSet.has(Number(id)) || failedSet.has(Number(id)),
+        ));
+        setTotal(Math.max(0, snapshotTotal - (numIds.length - failedIds.length)));
+      };
+
       runInChunks(numIds, BULK_CHUNK_SIZE, doChunk, (done) =>
         setBulkProgress({ verb, done, total: numIds.length }),
       )
-        .then(() => settleBulk(true))
+        .then(({ failed }) => {
+          if (!failed.length) {
+            settleBulk(true);
+            return;
+          }
+          restoreFailed(failed);
+          setSelected(new Set(failed));
+          setMessage(
+            partialNotice(doneVerb, numIds.length - failed.length, numIds.length, failed.length),
+            true,
+          );
+          settleBulk(false);
+        })
         .catch((err) => {
-          const landed = err.done || 0;
-          const moved = new Set(numIds.slice(0, landed));
-          setMessageIds(snapshotIds.filter((id) => !moved.has(Number(id))));
-          setTotal(Math.max(0, snapshotTotal - landed));
+          // Rows in chunks that never fired roll back wholesale; rows the
+          // landed chunks reported failed roll back too.
+          const failedSet = new Set(err.failed || []);
+          const moved = numIds.slice(0, err.done || 0).filter((id) => !failedSet.has(id));
+          const movedSet = new Set(moved);
+          setMessageIds(snapshotIds.filter((id) => !movedSet.has(Number(id))));
+          setTotal(Math.max(0, snapshotTotal - moved.length));
           setMessage(failMessage, true);
           console.error(err.cause || err);
           settleBulk(true);
         });
     },
-    [settleBulk, setMessage],
+    [settleBulk, setMessage, setSelected],
   );
 
   const runFlagOp = useCallback(
@@ -330,10 +379,23 @@ function Messages({
         (chunk) => api.setFlag(folder, spec.imap, spec.op, chunk, sortDir.imap, sortKey.imap),
         (done) => setBulkProgress({ verb, done, total: numIds.length }),
       )
-        .then(() => settleBulk(false))
+        .then(({ failed }) => {
+          if (failed.length) {
+            // Roll the optimistic flip back on just the ids the Lambda
+            // reported failed; the selection stays whole (the rows are all
+            // still on screen) so the user can simply re-run the action.
+            pushFlagPatch(failed, spec.imap, spec.op === 'set' ? 'unset' : 'set');
+            setMessage(
+              partialNotice('updated', numIds.length - failed.length, numIds.length, failed.length),
+              true,
+            );
+          }
+          settleBulk(false);
+        })
         .catch((err) => {
-          // Roll the flag back on the ids whose chunk never landed.
-          const reverted = numIds.slice(err.done || 0);
+          // Roll the flag back on the ids whose chunk never landed, plus any
+          // ids the landed chunks reported as failed.
+          const reverted = [...(err.failed || []), ...numIds.slice(err.done || 0)];
           pushFlagPatch(reverted, spec.imap, spec.op === 'set' ? 'unset' : 'set');
           setMessage('Unable to set flag on selected messages.', true);
           console.error(err.cause || err);
@@ -348,6 +410,7 @@ function Messages({
     if (bulkLimitExceeded(selectedCount)) return;
     runOptimisticRemoval(selectedIdsArray, {
       verb: 'Archiving',
+      doneVerb: 'archived',
       failMessage: 'Unable to archive selected messages.',
       doChunk: (chunk) => api.moveMessages(folder, 'Archive', chunk, sortDir.imap, sortKey.imap),
     });
@@ -362,6 +425,7 @@ function Messages({
     }
     runOptimisticRemoval(selectedIdsArray, {
       verb: 'Deleting',
+      doneVerb: 'deleted',
       failMessage: 'Unable to delete selected messages.',
       doChunk: (chunk) => api.moveMessages(folder, 'Trash', chunk, sortDir.imap, sortKey.imap),
     });
@@ -373,6 +437,7 @@ function Messages({
     if (bulkLimitExceeded(selectedCount)) return;
     runOptimisticRemoval(selectedIdsArray, {
       verb: 'Deleting',
+      doneVerb: 'deleted',
       failMessage: 'Unable to permanently delete selected messages.',
       doChunk: (chunk) => api.purgeMessages(folder, chunk),
     });
@@ -387,6 +452,7 @@ function Messages({
       if (bulkLimitExceeded(selectedCount)) return;
       runOptimisticRemoval(selectedIdsArray, {
         verb: 'Moving',
+        doneVerb: 'moved',
         failMessage: 'Unable to move selected messages.',
         doChunk: (chunk) => api.moveMessages(folder, destination, chunk, sortDir.imap, sortKey.imap),
       });


### PR DESCRIPTION
## Summary

The **React half of Phase 4** of `docs/1.1.x/multi-select-bulk-operations.md`, companion to #669 (Apple half). The bulk-op Lambdas already return the batched split (`status: "partial"` + `moved_ids`/`flagged_ids` + `failed_ids`); until now the web app treated a 200 "partial" as full success — rows whose IMAP batch failed silently vanished (moves) or kept the wrong optimistic flag state.

- **`runInChunks`** accumulates `failed_ids` across chunks and resolves `{done, failed}`; a thrown chunk also carries the partials seen so far, so the hard-failure rollback covers both.
- **Bulk move/archive/delete** — restores exactly the failed rows (snapshot filter, sort order preserved), re-selects them in bulk mode for a one-click retry, and toasts "Archived X of Y messages — N could not be archived."
- **Bulk flag ops** — reverts the optimistic flip on just the failed ids and toasts "Updated X of Y"; rows are all still on screen so the selection stays whole.

## Plan deviations

- `refresh_list` gating: superseded — the Lambda dropped the post-store SORT entirely, so there's nothing to gate.
- `ApiClient.js` untouched: handlers read the response body directly (`res.data`), matching how every other call site consumes API responses.

## Verification

- `npx vitest run src/Email/Messages/Messages.test.jsx` — 22/22 green, including 2 new tests: partial bulk archive (failed row restored + re-selected + toast text) and partial mark-read (rows intact + toast text)
- Full `npm run test`: 248 passed / 65 failed — the 65 are identical on clean stage (pre-existing local-environment `window.localStorage` issue in unrelated suites); zero regressions
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)