### PR TITLE
Fit iPad create-address sheet to content height

### DIFF
--- a/apple/Cabalmail/Views/NewAddressSheet.swift
+++ b/apple/Cabalmail/Views/NewAddressSheet.swift
@@ -24,6 +24,9 @@ struct NewAddressSheet: View {
     let onCreate: @MainActor (String) async -> Void
     @Environment(\.dismiss) private var dismiss
     @Environment(AppState.self) private var appState
+    #if os(iOS) || os(visionOS)
+    @Environment(\.horizontalSizeClass) private var hSizeClass
+    #endif
 
     @State private var username: String = ""
     @State private var subdomain: String = ""
@@ -62,41 +65,48 @@ struct NewAddressSheet: View {
                     }
                 }
         }
-        // Size the sheet for its content instead of filling a full-height
-        // card. On iPad, `.form` yields a properly proportioned form-sized
-        // sheet; `.fitted` (used previously) collapsed to the `Form`'s tiny
-        // intrinsic width, rendering an absurdly small box. On compact-width
-        // iPhone `presentationSizing` is ignored and the sheet keeps its
-        // full-height card presentation. macOS keeps `.fitted` because its
-        // hand-built layout already pins its own `.frame(width:)`.
-        #if os(macOS)
+        // Size the sheet to the form's actual height instead of a fixed
+        // card. `.fitted` measures the content's ideal size, which works
+        // because the regular-width layout (macOS and iPad) is the
+        // hand-built VStack in `cardContent` — it reports a real intrinsic
+        // width and height. (A `Form` cannot be measured this way: it
+        // reports no compact ideal size, so `.fitted` over a Form collapses
+        // to a tiny box.) On compact-width iPhone `presentationSizing` is
+        // ignored, so the `Form` there keeps its full-height card.
         .presentationSizing(.fitted)
-        #else
-        .presentationSizing(.form)
-        #endif
     }
 
     // MARK: - Platform layouts
     //
-    // `Form` is kept for iOS/visionOS, where its grouped list style renders
-    // the field titles as in-field placeholders and section headers as tidy
-    // group captions. On macOS that same `Form` instead pins every title as
-    // an external left-hand label — which shatters the email-shaped row and
-    // drops the in-field placeholders — so macOS gets a hand-built layout
-    // that reproduces the iOS look: in-field placeholders, an `@`/`.`
-    // email-shaped row, headline section captions, and real content margins.
+    // Two layouts, chosen by how the sheet is sized:
+    //
+    // - `cardContent` — a hand-built VStack used on macOS and on
+    //   regular-width iOS/visionOS (iPad). It has a real intrinsic height,
+    //   so `.presentationSizing(.fitted)` can shrink the sheet to the form
+    //   instead of leaving ~40% empty space. It reproduces the grouped
+    //   look manually: in-field placeholders, an `@`/`.` email-shaped row,
+    //   and headline section captions.
+    // - `formContent` — SwiftUI's grouped `Form`, used only on
+    //   compact-width iPhone, where the sheet is a full-height card and
+    //   `presentationSizing` is ignored, so the Form's inability to
+    //   self-size to its content doesn't matter. (A `Form` also renders
+    //   cleaner grouped sections than the hand-built layout when it has the
+    //   full card to fill.)
 
     @ViewBuilder
     private var content: some View {
         #if os(macOS)
-        macContent
+        cardContent
         #else
-        formContent
+        if hSizeClass == .regular {
+            cardContent
+        } else {
+            formContent
+        }
         #endif
     }
 
-    #if os(macOS)
-    private var macContent: some View {
+    private var cardContent: some View {
         VStack(alignment: .leading, spacing: 20) {
             VStack(alignment: .leading, spacing: 8) {
                 Text("New address")
@@ -130,7 +140,8 @@ struct NewAddressSheet: View {
         .padding(24)
         .frame(width: 460, alignment: .leading)
     }
-    #else
+
+    #if os(iOS) || os(visionOS)
     private var formContent: some View {
         Form {
             Section("New address") {

--- a/changelog.d/ipad-new-address-sheet-size.fixed.md
+++ b/changelog.d/ipad-new-address-sheet-size.fixed.md
@@ -1,4 +1,4 @@
-- Apple: **Create-address sheet size on iPad.** The New Address form
-  no longer renders as a tiny box on iPadOS — it now uses a
-  form-appropriate sheet size instead of collapsing to the form's
-  intrinsic width.
+- Apple: **Create-address sheet size on iPad.** The New Address form no
+  longer renders as a tiny box on iPadOS. It now uses a hand-built layout
+  with a real intrinsic size so the sheet fits its content — neither
+  collapsed nor padded out with empty space below the fields.


### PR DESCRIPTION
Follow-up to the initial fix: `.presentationSizing(.form)` sized the sheet correctly in width but is a fixed system size, leaving ~40% empty space below a short form. Size the sheet to the content instead with `.presentationSizing(.fitted)`, which only measures correctly over a layout with a real intrinsic height.

A `Form` reports no compact ideal size, so `.fitted` over it collapses. Route regular-width iOS/visionOS (iPad) to the same hand-built VStack layout macOS already uses, which has a natural intrinsic size. Compact- width iPhone keeps the grouped `Form` full-height card (presentationSizing is ignored there), so iPhone is unchanged.