### PR TITLE
Fix React test suite under Node 24+ (webstorage shadowing jsdom)

### DIFF
--- a/changelog.d/vitest-node-webstorage.fixed.md
+++ b/changelog.d/vitest-node-webstorage.fixed.md
@@ -1,0 +1,7 @@
+- **React test suite compatibility with Node 24+.** Node's experimental
+  file-backed `localStorage` global shadowed jsdom's in the Vitest
+  environment, failing every test that touches storage; the test runner now
+  disables it (`--no-experimental-webstorage`). Also restored the intended
+  single-fork serial test execution, which had been silently ignored since
+  the Vitest 4 upgrade (`poolOptions.forks.singleFork` is now
+  `fileParallelism: false`).

--- a/react/admin/vite.config.js
+++ b/react/admin/vite.config.js
@@ -62,8 +62,15 @@ export default defineConfig({
     // Run test files serially in a single forked process. jsdom is heavy
     // and the default parallel worker pool was driving RSS into multi-GB
     // territory on this suite. Trades wall-clock for memory ceiling.
+    // (Vitest 4 spelling; replaces the v3 poolOptions.forks.singleFork.)
     pool: 'forks',
-    forks: { singleFork: true },
+    fileParallelism: false,
+    // Node 24+ exposes its own experimental file-backed `localStorage` global
+    // by default; without --localstorage-file it is a getter that returns
+    // undefined, and it shadows jsdom's localStorage in the test environment
+    // (every window.localStorage access sees undefined). Disable it so
+    // jsdom's implementation wins regardless of Node version.
+    execArgv: ['--no-experimental-webstorage'],
     server: {
       deps: {
         inline: [/@tiptap\/.*/]


### PR DESCRIPTION
## Summary

Running the React test suite on Node 26 failed 65 of 311 tests, all with `window.localStorage` undefined. Root cause: Node 24+ exposes its own experimental file-backed `localStorage` global by default; without `--localstorage-file` it is a getter that returns `undefined`, and it shadows jsdom's `localStorage` in the Vitest environment. CI (Node 22) is unaffected because the global is still flag-gated there — but any developer on a current Node hits this locally.

- Pass `--no-experimental-webstorage` to Vitest test workers (`test.execArgv`) so jsdom's implementation wins on any Node version.
- Side finding, fixed in passing: `forks: { singleFork: true }` is Vitest 3 syntax that Vitest 4 silently ignores — the documented memory-ceiling serialization had quietly gone parallel again. Restored with the v4 spelling, `fileParallelism: false`.

## Testing

- `npm run test` on Node 26.4.0: **32 files / 313 tests, all pass** (was 6 files / 65 tests failing).
- Verified serial execution restored (single worker process; previously 7 concurrent forks).
- Verified no behavior change expected on Node 22: the flag simply disables a feature Node 22 doesn't enable by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)