### PR TITLE
Apple bulk ops: large-dispose confirmation + a11y counts (Phase 3)

### DIFF
--- a/apple/Cabalmail/Views/MessageListView+Actions.swift
+++ b/apple/Cabalmail/Views/MessageListView+Actions.swift
@@ -19,6 +19,22 @@ struct PurgeCandidate: Identifiable {
     let id = UUID()
 }
 
+/// UID set staged for the large-selection dispose confirmation: an
+/// archive/trash dispose of `largeDisposeThreshold`-or-more messages
+/// pauses on an "are you sure" dialog before it runs (Phase 3 of
+/// docs/1.1.x/multi-select-bulk-operations.md). Smaller disposes commit
+/// immediately, and non-destructive bulk ops (move, flag, read) never
+/// confirm at any size.
+struct DisposeCandidate: Identifiable {
+    let uids: Set<UInt32>
+    let action: DisposeAction
+    /// Leave selection / edit mode once the dispose commits — set by the
+    /// bulk action bar, whose flow ends with the bar dismissing. The
+    /// context menu and Cmd+Delete leave the mode as the user had it.
+    let exitBulk: Bool
+    let id = UUID()
+}
+
 // Selection-scoped actions for `MessageListView`'s wide/keyboard
 // layouts (macOS, iPad regular, visionOS): the List-level context menu
 // that acts on the whole multi-selection, and the handlers behind the
@@ -66,7 +82,7 @@ extension MessageListView {
                 Label("Move to folder…", systemImage: "folder")
             }
             Button {
-                Task { await model.disposeMessages(uids: uids, action: .archive) }
+                requestDispose(uids: uids, action: .archive, exitBulk: false, model: model)
             } label: {
                 Label("Archive", systemImage: "archivebox")
             }
@@ -81,7 +97,7 @@ extension MessageListView {
                 }
             } else {
                 Button(role: .destructive) {
-                    Task { await model.disposeMessages(uids: uids, action: .trash) }
+                    requestDispose(uids: uids, action: .trash, exitBulk: false, model: model)
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
@@ -163,7 +179,40 @@ extension MessageListView {
             purgeCandidate = PurgeCandidate(uids: uids)
             return
         }
-        let action = model.disposeAction
-        Task { await model.disposeMessages(uids: uids, action: action) }
+        requestDispose(uids: uids, action: model.disposeAction, exitBulk: false, model: model)
+    }
+
+    /// Selection size at which a dispose asks first. Large enough that
+    /// routine triage never sees the dialog; small enough that a
+    /// mis-aimed select-all can't silently file hundreds of messages.
+    static var largeDisposeThreshold: Int { 25 }
+
+    /// Routes every non-Trash dispose surface (action bar, selection
+    /// context menu, Cmd+Delete): a large selection stages the
+    /// confirmation dialog, a small one commits immediately.
+    func requestDispose(
+        uids: Set<UInt32>,
+        action: DisposeAction,
+        exitBulk: Bool,
+        model: MessageListViewModel
+    ) {
+        guard !uids.isEmpty else { return }
+        let candidate = DisposeCandidate(uids: uids, action: action, exitBulk: exitBulk)
+        if uids.count >= Self.largeDisposeThreshold {
+            disposeCandidate = candidate
+        } else {
+            commitDispose(candidate, model: model)
+        }
+    }
+
+    /// Runs a staged (or immediately-committed) dispose. Selection /
+    /// edit mode drops right away when requested — the candidate holds
+    /// its own UID copy, so clearing the live selection is safe.
+    func commitDispose(_ candidate: DisposeCandidate, model: MessageListViewModel) {
+        Task { await model.disposeMessages(uids: candidate.uids, action: candidate.action) }
+        if candidate.exitBulk {
+            model.exitBulkMode()
+            endSelectionMode()
+        }
     }
 }

--- a/apple/Cabalmail/Views/MessageListView+Bulk.swift
+++ b/apple/Cabalmail/Views/MessageListView+Bulk.swift
@@ -66,8 +66,10 @@ extension MessageListView {
     /// action bar dismisses on iPad / visionOS. No-op on macOS, which has no
     /// EditMode. The read/unread and flag buttons deliberately skip it:
     /// their rows stay on screen, and keeping the selection lets the user
-    /// chain another action onto the same messages.
-    private func endSelectionMode() {
+    /// chain another action onto the same messages. Internal (not private)
+    /// so `commitDispose` in `+Actions.swift` can drop the mode after a
+    /// confirmed large dispose.
+    func endSelectionMode() {
         #if !os(macOS)
         editMode = .inactive
         #endif
@@ -79,8 +81,6 @@ extension MessageListView {
     @ViewBuilder
     func bulkActionBar(model: MessageListViewModel) -> some View {
         let count = model.selectedUIDs.count
-        let hasUnread = bulkSelectionContainsUnread(model)
-        let hasUnflagged = bulkSelectionContainsUnflagged(model)
         VStack(spacing: 0) {
             Divider()
             HStack(spacing: 14) {
@@ -88,47 +88,7 @@ extension MessageListView {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                 Spacer()
-                bulkActionButton(systemImage: "archivebox", label: "Archive") {
-                    Task {
-                        // Inside Trash the dispose preference may point back
-                        // at Trash itself (a same-folder no-op); Archive on
-                        // this bar is the rescue path, so send the selection
-                        // to the real Archive folder there.
-                        if model.isTrashFolder {
-                            await model.bulkMove(to: DisposeAction.archive.destinationFolder)
-                        } else {
-                            await model.bulkDispose()
-                        }
-                    }
-                    endSelectionMode()
-                }
-                bulkActionButton(systemImage: "folder", label: "Move…") {
-                    bulkMoveSheetPresented = true
-                }
-                bulkActionButton(
-                    systemImage: hasUnread ? "envelope.open" : "envelope.badge",
-                    label: hasUnread ? "Read" : "Unread"
-                ) {
-                    Task { await model.bulkSetSeen(hasUnread) }
-                }
-                bulkActionButton(
-                    systemImage: hasUnflagged ? "flag" : "flag.slash",
-                    label: hasUnflagged ? "Flag" : "Unflag"
-                ) {
-                    Task { await model.bulkSetFlagged(hasUnflagged) }
-                }
-                // Trash only: permanent delete for the whole selection,
-                // behind the same "Delete Forever?" confirmation as the
-                // row swipe.
-                if model.isTrashFolder {
-                    bulkActionButton(
-                        systemImage: "trash.slash",
-                        label: "Delete",
-                        role: .destructive
-                    ) {
-                        purgeCandidate = PurgeCandidate(uids: model.selectedUIDs)
-                    }
-                }
+                bulkActionButtons(model: model, count: count)
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
@@ -137,11 +97,83 @@ extension MessageListView {
         .disabled(count == 0)
     }
 
+    /// The action buttons themselves — split from `bulkActionBar` to keep
+    /// each function under SwiftLint's body-length cap.
+    @ViewBuilder
+    private func bulkActionButtons(model: MessageListViewModel, count: Int) -> some View {
+        let hasUnread = bulkSelectionContainsUnread(model)
+        let hasUnflagged = bulkSelectionContainsUnflagged(model)
+        bulkActionButton(
+            systemImage: "archivebox",
+            label: "Archive",
+            accessibilityLabel: "Archive \(messageCount(count))"
+        ) {
+            // Inside Trash the dispose preference may point back at Trash
+            // itself (a same-folder no-op); Archive on this bar is the
+            // rescue path, so send the selection to the real Archive
+            // folder there. Rescue is a plain move (non-destructive), so
+            // it skips the large-selection confirmation that
+            // requestDispose applies.
+            if model.isTrashFolder {
+                Task { await model.bulkMove(to: DisposeAction.archive.destinationFolder) }
+                endSelectionMode()
+            } else {
+                requestDispose(
+                    uids: model.selectedUIDs,
+                    action: model.disposeAction,
+                    exitBulk: true,
+                    model: model
+                )
+            }
+        }
+        bulkActionButton(
+            systemImage: "folder",
+            label: "Move…",
+            accessibilityLabel: "Move \(messageCount(count))"
+        ) {
+            bulkMoveSheetPresented = true
+        }
+        bulkActionButton(
+            systemImage: hasUnread ? "envelope.open" : "envelope.badge",
+            label: hasUnread ? "Read" : "Unread",
+            accessibilityLabel: "Mark \(messageCount(count)) \(hasUnread ? "read" : "unread")"
+        ) {
+            Task { await model.bulkSetSeen(hasUnread) }
+        }
+        bulkActionButton(
+            systemImage: hasUnflagged ? "flag" : "flag.slash",
+            label: hasUnflagged ? "Flag" : "Unflag",
+            accessibilityLabel: "\(hasUnflagged ? "Flag" : "Unflag") \(messageCount(count))"
+        ) {
+            Task { await model.bulkSetFlagged(hasUnflagged) }
+        }
+        // Trash only: permanent delete for the whole selection, behind
+        // the same "Delete Forever?" confirmation as the row swipe.
+        if model.isTrashFolder {
+            bulkActionButton(
+                systemImage: "trash.slash",
+                label: "Delete",
+                role: .destructive,
+                accessibilityLabel: "Delete \(messageCount(count)) forever"
+            ) {
+                purgeCandidate = PurgeCandidate(uids: model.selectedUIDs)
+            }
+        }
+    }
+
+    /// "12 messages" / "1 message" — the count phrase VoiceOver reads on
+    /// every bulk action button, so "Archive" is announced as "Archive 12
+    /// messages" rather than a bare verb with no scope.
+    private func messageCount(_ count: Int) -> String {
+        count == 1 ? "1 message" : "\(count) messages"
+    }
+
     @ViewBuilder
     private func bulkActionButton(
         systemImage: String,
         label: String,
         role: ButtonRole? = nil,
+        accessibilityLabel: String? = nil,
         action: @escaping () -> Void
     ) -> some View {
         Button(role: role, action: action) {
@@ -155,7 +187,7 @@ extension MessageListView {
         // `.plain` drops the automatic destructive tinting, so red is
         // applied explicitly for destructive roles.
         .foregroundStyle(role == .destructive ? AnyShapeStyle(.red) : AnyShapeStyle(.tint))
-        .accessibilityLabel(label)
+        .accessibilityLabel(accessibilityLabel ?? label)
     }
 
     @ViewBuilder

--- a/apple/Cabalmail/Views/MessageListView.swift
+++ b/apple/Cabalmail/Views/MessageListView.swift
@@ -110,6 +110,11 @@ struct MessageListView: View {
     /// Forever?" confirmation for the captured UID set. Non-private so
     /// the `+Rows` / `+Bulk` / `+Actions` extensions can stage it.
     @State var purgeCandidate: PurgeCandidate?
+    /// Set by `requestDispose` when a dispose crosses the large-selection
+    /// threshold; presents the "Archive/Delete N Messages?" confirmation
+    /// (see `MessageListView+Actions.swift`). Non-private for the same
+    /// reason as `purgeCandidate`.
+    @State var disposeCandidate: DisposeCandidate?
     /// `true` while the bulk-move destination picker is presented.
     @State var bulkMoveSheetPresented = false
     /// Set by the wide-layout selection context menu's "Move to folder…"
@@ -156,6 +161,25 @@ struct MessageListView: View {
                 if !isPresented { purgeCandidate = nil }
             }
         )
+    }
+
+    /// Boolean projection of `disposeCandidate`, same shape as above.
+    private var disposeDialogBinding: Binding<Bool> {
+        Binding(
+            get: { disposeCandidate != nil },
+            set: { isPresented in
+                if !isPresented { disposeCandidate = nil }
+            }
+        )
+    }
+
+    /// Title for the large-selection dispose confirmation. Computed off
+    /// the staged candidate because `confirmationDialog`'s title is a
+    /// plain value, not a `presenting:` closure.
+    private var disposeDialogTitle: String {
+        guard let candidate = disposeCandidate else { return "" }
+        let verb = candidate.action == .trash ? "Delete" : "Archive"
+        return "\(verb) \(candidate.uids.count) Messages?"
     }
 
     @ViewBuilder
@@ -385,6 +409,34 @@ extension MessageListView {
                 candidate.uids.count == 1
                 ? "This message will be permanently deleted. This can't be undone."
                 : "These \(candidate.uids.count) messages will be permanently deleted. This can't be undone."
+            )
+        }
+        // Large-selection dispose guard (threshold in `+Actions.swift`):
+        // recoverable, unlike the purge above, but big enough that a
+        // mis-aimed select-all shouldn't file everything silently.
+        .confirmationDialog(
+            disposeDialogTitle,
+            isPresented: disposeDialogBinding,
+            titleVisibility: .visible,
+            presenting: disposeCandidate
+        ) { candidate in
+            Button(
+                candidate.action == .trash ? "Delete" : "Archive",
+                role: candidate.action == .trash ? .destructive : nil
+            ) {
+                disposeCandidate = nil
+                if let model {
+                    commitDispose(candidate, model: model)
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                disposeCandidate = nil
+            }
+        } message: { candidate in
+            Text(
+                candidate.action == .trash
+                ? "\(candidate.uids.count) messages will be moved to Trash."
+                : "\(candidate.uids.count) messages will be archived."
             )
         }
     }

--- a/changelog.d/apple-bulk-polish.changed.md
+++ b/changelog.d/apple-bulk-polish.changed.md
@@ -1,4 +1,4 @@
-- **Large bulk disposes on Apple clients now confirm first.** Archiving or
+- Apple: **Large bulk disposes on Apple clients now confirm first.** Archiving or
   deleting 25 or more messages at once asks "Archive/Delete N Messages?"
   before running, on every dispose surface (action bar, selection context
   menu, Cmd+Delete). Smaller disposes and non-destructive bulk actions

--- a/changelog.d/apple-bulk-polish.changed.md
+++ b/changelog.d/apple-bulk-polish.changed.md
@@ -1,0 +1,6 @@
+- **Large bulk disposes on Apple clients now confirm first.** Archiving or
+  deleting 25 or more messages at once asks "Archive/Delete N Messages?"
+  before running, on every dispose surface (action bar, selection context
+  menu, Cmd+Delete). Smaller disposes and non-destructive bulk actions
+  (move, flag, mark read) are unchanged. VoiceOver now announces the
+  selection size on every bulk action button ("Archive 12 messages").


### PR DESCRIPTION
## Summary

Closes out the implementable remainder of **Phase 3** of `docs/1.1.x/multi-select-bulk-operations.md`, following #669 (Apple Phase 4) and #670 (React Phase 4).

- **Large-selection dispose confirmation** — disposing (archive or delete) **25+** messages stages an "Archive/Delete N Messages?" dialog before running. All three non-Trash dispose surfaces route through a new `requestDispose`/`commitDispose` pair: the bulk action bar, the selection context menu, and Cmd+Delete. Smaller disposes commit immediately; non-destructive bulk ops (move, flag, read) never confirm; Trash's Archive-rescue is a plain move and skips it; Trash purges keep their existing any-count "Delete Forever?" confirmation.
- **Count-inclusive VoiceOver labels** on every bulk action button: "Archive 12 messages", "Mark 5 messages read", "Flag 3 messages", "Delete 2 messages forever".

## Already shipped since the plan was written (verified, no changes)

- Cmd+Delete dispose chord — window-scoped invisible key equivalent (`MessageListView+Selection.swift`), deliberately not a menu item (would steal the text system's chord mid-compose)
- Row checked/unchecked VoiceOver announcements (`MessageListView+Rows.swift`)
- Selection count — the action bar's "N selected" serves the plan's header-badge intent; a second badge would be redundant

## Remaining plan items and why they're not here

- **`BulkSelectionTests` (Phase 5)**: the view models live in the app target, and no app-target test bundle exists — only CabalmailKit's `swift test`. Adding one is a project.yml + CI (`apple.yml`) infrastructure change; happy to do it as its own PR if wanted. The Kit-side bulk logic (chunking, partial-failure aggregation) is already covered by `ApiBackedImapClientBulkTests` from #669.
- **Manual VoiceOver pass (Phase 5)**: needs a human with a device; the plan says record findings in the implementing PR — this PR is the natural place if you can run one on iPhone/macOS.

## Verification

- `swiftlint` from `apple/` — 0 findings
- `xcodegen generate` + `xcodebuild` — **BUILD SUCCEEDED** for both `Cabalmail` (iOS) and `CabalmailMac`
- `cd apple/CabalmailKit && swift test` — all green (no Kit changes; regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)