### PR TITLE
Suppress stray main window on macOS mailto: clicks

### DIFF
--- a/apple/CabalmailMac/CabalmailMacApp.swift
+++ b/apple/CabalmailMac/CabalmailMacApp.swift
@@ -57,6 +57,14 @@ struct CabalmailMacApp: App {
                     }
                 }
         }
+        // A WindowGroup's default reaction to an external event (an
+        // incoming mailto: URL) is to *spawn a fresh window of the
+        // group* to receive it — so a mailto: click used to open a
+        // spurious second main window alongside the compose window the
+        // handler above requests. An empty matching set disables that
+        // new-window spawning; `.onOpenURL` is still delivered to the
+        // existing main window, which is what we want.
+        .handlesExternalEvents(matching: [])
         .commands {
             CabalmailCommands(appState: appState)
         }

--- a/changelog.d/mailto-no-stray-main-window.fixed.md
+++ b/changelog.d/mailto-no-stray-main-window.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **No stray main window when opening a mailto: link (macOS).**
+  Clicking a `mailto:` link with Cabalmail set as the default mail reader
+  opened the compose window as intended but also spawned an empty second
+  main window; the main window group no longer creates a new window in
+  response to external URL events, so only the compose window appears.


### PR DESCRIPTION
## What

On macOS, clicking a `mailto:` link (with Cabalmail set as the default mail reader) correctly opened a compose window but **also** opened an empty second main window. This suppresses the stray window.

## Root cause

`.onOpenURL` is attached to the main `WindowGroup` in `CabalmailMacApp.swift`. A `WindowGroup`'s default reaction to an external event (an incoming URL) is to **spawn a fresh window of that group** to receive it. So the flow was:

1. macOS routes the `mailto:` URL to the app.
2. SwiftUI spawns a new main window to deliver it → the stray window.
3. `.onOpenURL` fires → `requestCompose(seed:)` → the compose window opens.

## Fix

Add `.handlesExternalEvents(matching: [])` to the main `WindowGroup`. An empty matching set disables new-window spawning for external events; `.onOpenURL` is still delivered to the existing main window, so only the compose window appears.

## Verification

- Diagnosed against the scene/URL-routing code (`CabalmailMacApp.swift`, `ComposeWindowScene.swift`, `MessageListView.swift`).
- `xcodebuild ... -scheme CabalmailMac` **BUILD SUCCEEDED** locally (Xcode 26.6).
- Behavioral confirmation (click a `mailto:` link, observe a single compose window and no stray main window) still wants a real GUI session — the dev box is headless, so accessibility/window-count automation wasn't available. Worth a quick manual check on a Mac before promoting to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)