### PR TITLE
Seed the compose window from mailto: URLs routed to its scene

### DIFF
--- a/apple/Cabalmail/Views/ComposeWindowScene.swift
+++ b/apple/Cabalmail/Views/ComposeWindowScene.swift
@@ -49,8 +49,32 @@ struct ComposeWindowScene: Scene {
     var body: some Scene {
         WindowGroup("New Message", id: composeWindowID, for: Draft.self) { $draft in
             ComposeWindowContent(seed: draft ?? Draft())
+                // Re-identify by seed: `ComposeView` keeps its model in
+                // `@State`, so when the mailto: handler below replaces the
+                // window value the subtree must rebuild for the new seed
+                // to take effect. Safe because the seed only changes
+                // before the user has touched the fresh window.
+                .id(draft)
                 .environment(appState)
                 .environment(preferences)
+                .onOpenURL { url in
+                    // On macOS the main window group declines external
+                    // events (`handlesExternalEvents(matching: [])`, see
+                    // CabalmailMacApp) so a mailto: click routes here:
+                    // the system spawns a compose window with a default
+                    // empty Draft and delivers the URL to it. Seed the
+                    // window value from the URL; without this the window
+                    // opens with blank To/Subject fields.
+                    if let mailto = MailtoURL(url) {
+                        draft = mailto.draft()
+                    }
+                }
+                // A mailto: click can cold-launch the app straight into
+                // this scene, in which case the main window's `.task` —
+                // the usual `restoreIfPossible` call site — may not have
+                // run. Idempotent, so calling it again is a no-op when
+                // the main window already restored the session.
+                .task { await appState.restoreIfPossible() }
         }
         // Give the macOS compose window a sensible starting size so it
         // doesn't inherit the main mail window's geometry. iPadOS and

--- a/changelog.d/mailto-compose-seed.fixed.md
+++ b/changelog.d/mailto-compose-seed.fixed.md
@@ -1,0 +1,7 @@
+- Apple: **mailto: links populate the compose fields again (macOS).**
+  The stray-window fix rerouted incoming `mailto:` clicks to the compose
+  window scene, which spawned its window with a blank draft and dropped
+  the URL — To, Cc, Bcc, Subject, and body arrived empty. The compose
+  window now seeds itself from the delivered URL, and a `mailto:` click
+  that cold-launches the app restores the signed-in session instead of
+  showing a sign-in placeholder.


### PR DESCRIPTION
## What

Follow-up to #675. The stray second main window is gone, but `mailto:` clicks now open a compose window with **empty To/Subject fields**. This restores the field population.

## Root cause (a #675 side effect)

#675 made the main `WindowGroup` decline external events (`handlesExternalEvents(matching: [])`). macOS then routes the `mailto:` event to the next scene that accepts external events by default — the **compose `WindowGroup`**:

- It spawns its window with the default empty `Draft` (that's also why exactly one compose window appears — the same routing that fixed the stray window).
- The URL is delivered to *that* window's content, which had no `.onOpenURL` handler — so the parsed draft was dropped.
- The main window's handler (the old `requestCompose(seed:)` → tick path) no longer fires for `mailto:` at all.

## Fix

Handle the URL where it now arrives, in `ComposeWindowScene`:

- `.onOpenURL` in the compose window content seeds the window's `Draft` value via `MailtoURL`.
- `ComposeView` keeps its model in `@State`, so the content is re-identified by seed (`.id(draft)`) for the late-delivered value to take effect. Safe: the seed only changes right after the window spawns, before the user has touched it.
- `.task { await appState.restoreIfPossible() }` — a `mailto:` click can cold-launch the app straight into this scene, where the main window's `.task` (the usual restore site) may not have run; without this the compose window would show the "Sign in required" placeholder. The call is documented idempotent.

The iOS/iPadOS tick path is untouched (the iOS main `WindowGroup` still accepts external events first); the new handler is inert there.

## Verification

- `xcodebuild` **BUILD SUCCEEDED** for both `CabalmailMac` (macOS) and `Cabalmail` (iOS) — the changed file is shared.
- `swiftlint` clean.
- Behavioral check needs a real GUI session (headless box). Please verify on a Mac: click a `mailto:` link with address + subject (e.g. from Safari) with the app **running** and again **quit** — the compose window should come up populated, no stray main window, and (cold-launch, signed-in) no "Sign in required" placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)