### PR TITLE
Add app-layer unit tests: BulkSelectionTests (Phase 5)

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -174,6 +174,71 @@ jobs:
         run: .github/scripts/dump-xcodebuild-raw.sh
 
   # -----------------------------------------------------------------------
+  # App-layer unit tests (view models, app state) — the CabalmailMacTests
+  # bundle hosted by CabalmailMac. macOS-only by design: the mac target
+  # compiles the same shared Cabalmail/ViewModels sources as the iOS app,
+  # and a native macOS test run skips the simulator boot entirely.
+  # -----------------------------------------------------------------------
+  app-test:
+    name: Test app layer (macOS)
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install XcodeGen + xcbeautify
+        run: |
+          for pkg in xcodegen xcbeautify; do
+            brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+          done
+
+      - name: Generate Xcode project
+        working-directory: apple
+        run: xcodegen generate
+
+      - name: Sync vendored CabalmailKit resources (marked + turndown)
+        working-directory: apple
+        run: scripts/sync-vendored.sh
+
+      - name: Cache Swift packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-${{ runner.os }}-macOS-${{ hashFiles('apple/CabalmailKit/Package.swift', 'apple/CabalmailKit/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-macOS-
+            spm-${{ runner.os }}-
+
+      - name: Test CabalmailMac scheme (app-layer unit tests)
+        working-directory: apple
+        # Same tee-the-raw-log arrangement as kit-test: xcbeautify swallows
+        # the stderr of crashing subtools, so on failure a later step dumps
+        # the raw output.
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -workspace Cabalmail.xcworkspace \
+            -scheme CabalmailMac \
+            -destination 'platform=macOS' \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            2>&1 | tee "$RUNNER_TEMP/xcodebuild-raw-test.log" \
+            | xcbeautify --renderer github-actions
+
+      - name: Surface raw xcodebuild output on failure
+        if: failure()
+        run: .github/scripts/dump-xcodebuild-raw.sh
+
+  # -----------------------------------------------------------------------
   # Build the app targets for the three product platforms. Unsigned — this
   # job only verifies the code compiles and links; signing happens in the
   # upload jobs below. visionOS gets its own leg because the Cabalmail
@@ -265,7 +330,7 @@ jobs:
         run: .github/scripts/dump-xcodebuild-raw.sh
 
   approval:
-    needs: [kit-test, app-build]
+    needs: [kit-test, app-test, app-build]
     environment: gate-${{ github.ref_name == 'main' && 'prod' || ( github.ref_name == 'stage' && 'stage' || 'development' ) }}
     runs-on: ubuntu-latest
     steps:

--- a/apple/.swiftlint.yml
+++ b/apple/.swiftlint.yml
@@ -8,6 +8,7 @@ included:
   - CabalmailWatch
   - CabalmailKit/Sources
   - CabalmailKit/Tests
+  - CabalmailTests
 
 excluded:
   - build

--- a/apple/CabalmailTests/BulkSelectionTests.swift
+++ b/apple/CabalmailTests/BulkSelectionTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Phase 5 of docs/0.11.x/multi-select-bulk-operations.md: selection-set
+// mutations, optimistic bulk state on success, rollback on failure, and
+// partial-failure rollback granularity, all against MessageListViewModel
+// with a scripted ImapClient.
+@MainActor
+final class BulkSelectionTests: XCTestCase {
+
+    // MARK: - Selection mutations
+
+    func testToggleSelectionFlipsMembership() throws {
+        let model = try TestFixtures.makeModel(
+            imap: FakeImapClient(),
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+        model.toggleSelection(model.envelopes[0])
+        XCTAssertEqual(model.selectedUIDs, [1])
+        model.toggleSelection(model.envelopes[1])
+        XCTAssertEqual(model.selectedUIDs, [1, 2])
+        model.toggleSelection(model.envelopes[0])
+        XCTAssertEqual(model.selectedUIDs, [2])
+    }
+
+    func testSelectAllVisibleRespectsFilterTab() throws {
+        let model = try TestFixtures.makeModel(
+            imap: FakeImapClient(),
+            envelopes: [
+                TestFixtures.makeEnvelope(uid: 1),                  // unread
+                TestFixtures.makeEnvelope(uid: 2, flags: [.seen]),  // read
+                TestFixtures.makeEnvelope(uid: 3),                  // unread
+            ]
+        )
+        model.filterTab = .unread
+        model.selectAllVisible()
+        XCTAssertEqual(model.selectedUIDs, [1, 3], "select-all scopes to the visible (filtered) rows")
+
+        model.filterTab = .all
+        model.selectAllVisible()
+        XCTAssertEqual(model.selectedUIDs, [1, 2, 3])
+    }
+
+    func testExitBulkModeClearsSelection() throws {
+        let model = try TestFixtures.makeModel(
+            imap: FakeImapClient(),
+            envelopes: [TestFixtures.makeEnvelope(uid: 1)]
+        )
+        model.bulkMode = true
+        model.selectedUIDs = [1]
+        model.exitBulkMode()
+        XCTAssertFalse(model.bulkMode)
+        XCTAssertTrue(model.selectedUIDs.isEmpty)
+    }
+
+    // MARK: - Optimistic flag state
+
+    func testSetSeenAppliesAndStaysOnSuccess() async throws {
+        let imap = FakeImapClient()
+        let appState = AppState()
+        appState.setUnreadCounts(["INBOX": 5])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)],
+            appState: appState
+        )
+
+        await model.setSeen(true, uids: [1, 2])
+
+        XCTAssertTrue(model.envelopes.allSatisfy { $0.flags.contains(.seen) })
+        XCTAssertNil(model.errorMessage)
+        // Both rows transitioned unread -> read, so the badge dropped by 2.
+        XCTAssertEqual(appState.folderUnreadCounts["INBOX"], 3)
+        let calls = await imap.flagCalls
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.first?.uids, [1, 2])
+        XCTAssertEqual(calls.first?.flags, [.seen])
+    }
+
+    func testSetSeenSkipsUnreadDeltaForNonTransitions() async throws {
+        // Marking an already-read message read must not move the badge.
+        let imap = FakeImapClient()
+        let appState = AppState()
+        appState.setUnreadCounts(["INBOX": 5])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [
+                TestFixtures.makeEnvelope(uid: 1),                  // unread -> transitions
+                TestFixtures.makeEnvelope(uid: 2, flags: [.seen]),  // already read
+            ],
+            appState: appState
+        )
+
+        await model.setSeen(true, uids: [1, 2])
+
+        XCTAssertEqual(appState.folderUnreadCounts["INBOX"], 4, "only the real transition counts")
+    }
+
+    func testSetSeenRevertsAllOnTotalFailure() async throws {
+        let imap = FakeImapClient()
+        await imap.scriptFlagResults([
+            .failure(CabalmailError.server(code: "500", message: "unable")),
+        ])
+        let appState = AppState()
+        appState.setUnreadCounts(["INBOX": 5])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)],
+            appState: appState
+        )
+
+        await model.setSeen(true, uids: [1, 2])
+
+        XCTAssertTrue(
+            model.envelopes.allSatisfy { !$0.flags.contains(.seen) },
+            "a failed group reverts every row"
+        )
+        XCTAssertNotNil(model.errorMessage)
+        XCTAssertEqual(appState.folderUnreadCounts["INBOX"], 5, "no transition landed")
+    }
+
+    // MARK: - Partial-failure granularity
+
+    func testSetSeenPartialFailureRevertsOnlyFailedRows() async throws {
+        let imap = FakeImapClient()
+        await imap.scriptFlagResults([
+            .failure(CabalmailError.bulkPartialFailure(succeeded: [1], failed: [2])),
+        ])
+        let appState = AppState()
+        appState.setUnreadCounts(["INBOX": 5])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)],
+            appState: appState
+        )
+
+        await model.setSeen(true, uids: [1, 2])
+
+        let byUID = Dictionary(uniqueKeysWithValues: model.envelopes.map { ($0.uid, $0) })
+        XCTAssertTrue(byUID[1]!.flags.contains(.seen), "the succeeded row keeps the change")
+        XCTAssertFalse(byUID[2]!.flags.contains(.seen), "the failed row reverts")
+        XCTAssertEqual(model.errorMessage, "Updated 1 of 2 messages. 1 could not be updated.")
+        XCTAssertEqual(appState.folderUnreadCounts["INBOX"], 4, "only the landed transition counts")
+    }
+
+    func testPartialFailureRevertRestoresPreOpState() async throws {
+        // The failed row was ALREADY read before the op: the revert must
+        // restore that state, not blindly flip it to unread.
+        let imap = FakeImapClient()
+        await imap.scriptFlagResults([
+            .failure(CabalmailError.bulkPartialFailure(succeeded: [1], failed: [2])),
+        ])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [
+                TestFixtures.makeEnvelope(uid: 1),
+                TestFixtures.makeEnvelope(uid: 2, flags: [.seen]),
+            ]
+        )
+
+        await model.setSeen(true, uids: [1, 2])
+
+        let byUID = Dictionary(uniqueKeysWithValues: model.envelopes.map { ($0.uid, $0) })
+        XCTAssertTrue(
+            byUID[2]!.flags.contains(.seen),
+            "a failed row that already carried the target flag keeps it"
+        )
+    }
+
+    // MARK: - Moves
+
+    func testMoveRemovesRowsAndSelectionOnSuccess() async throws {
+        let imap = FakeImapClient()
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+        model.selectedUIDs = [1, 2]
+
+        await model.moveMessages(uids: [1, 2], to: "Archive")
+
+        XCTAssertTrue(model.envelopes.isEmpty)
+        XCTAssertTrue(model.selectedUIDs.isEmpty)
+        let calls = await imap.moveCalls
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.first?.uids, [1, 2])
+        XCTAssertEqual(calls.first?.destination, "Archive")
+    }
+
+    func testMovePartialFailureRestoresOnlyFailedRows() async throws {
+        let imap = FakeImapClient()
+        await imap.scriptMoveResults([
+            .failure(CabalmailError.bulkPartialFailure(succeeded: [1], failed: [2])),
+        ])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+
+        await model.moveMessages(uids: [1, 2], to: "Archive")
+
+        XCTAssertEqual(
+            model.envelopes.map(\.uid), [2],
+            "the failed row is restored; the moved row stays gone"
+        )
+        XCTAssertEqual(model.errorMessage, "Moved 1 of 2 messages. 1 could not be moved.")
+        XCTAssertTrue(
+            model.pendingRemovedUIDs.isEmpty,
+            "refresh shields drop once the batch settles"
+        )
+    }
+
+    func testMoveTotalFailureRestoresEverything() async throws {
+        let imap = FakeImapClient()
+        await imap.scriptMoveResults([
+            .failure(CabalmailError.server(code: "500", message: "unable")),
+        ])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+
+        await model.moveMessages(uids: [1, 2], to: "Archive")
+
+        XCTAssertEqual(Set(model.envelopes.map(\.uid)), [1, 2])
+        XCTAssertNotNil(model.errorMessage)
+    }
+
+    func testDisposeProceedsWhenSeenMarkingPartiallyFails() async throws {
+        // Dispose marks \Seen before the move (archived == read). A partial
+        // miss on that cosmetic step must not abort the move itself.
+        let imap = FakeImapClient()
+        await imap.scriptFlagResults([
+            .failure(CabalmailError.bulkPartialFailure(succeeded: [1], failed: [2])),
+        ])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+
+        await model.disposeMessages(uids: [1, 2], action: .archive)
+
+        XCTAssertTrue(model.envelopes.isEmpty, "the move ran despite the partial seen-marking")
+        let moves = await imap.moveCalls
+        XCTAssertEqual(moves.count, 1)
+        XCTAssertEqual(moves.first?.uids, [1, 2])
+    }
+}

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -1,0 +1,195 @@
+import Foundation
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Test doubles + fixture factory for the app-layer unit tests. The
+// CabalmailKit test target has its own stubs (TestHelpers.swift), but
+// those are internal to that target, so the handful we need here are
+// (re)defined against the Kit's public protocol surface.
+
+/// Scripted `ImapClient` double. Only the members the bulk paths use are
+/// functional — `setFlags` / `move` record their calls and pop a scripted
+/// result — and everything else traps loudly, so a test that wanders onto
+/// an unexpected wire path fails instead of silently no-oping.
+actor FakeImapClient: ImapClient {
+    struct FlagCall {
+        let folder: String
+        let uids: Set<UInt32>
+        let flags: Set<Flag>
+        let operation: FlagOperation
+    }
+
+    struct MoveCall {
+        let folder: String
+        let uids: Set<UInt32>
+        let destination: String
+    }
+
+    private(set) var flagCalls: [FlagCall] = []
+    private(set) var moveCalls: [MoveCall] = []
+    // FIFO scripts; an empty queue means "succeed". Seeded via the
+    // scriptFlagResults / scriptMoveResults helpers below.
+    private var flagResults: [Result<Void, Error>] = []
+    private var moveResults: [Result<Void, Error>] = []
+
+    func scriptFlagResults(_ results: [Result<Void, Error>]) {
+        flagResults = results
+    }
+
+    func scriptMoveResults(_ results: [Result<Void, Error>]) {
+        moveResults = results
+    }
+
+    func setFlags(
+        folder: String,
+        uids: [UInt32],
+        flags: Set<Flag>,
+        operation: FlagOperation
+    ) async throws {
+        flagCalls.append(FlagCall(
+            folder: folder, uids: Set(uids), flags: flags, operation: operation
+        ))
+        if !flagResults.isEmpty {
+            try flagResults.removeFirst().get()
+        }
+    }
+
+    func move(folder: String, uids: [UInt32], destination: String) async throws {
+        moveCalls.append(MoveCall(
+            folder: folder, uids: Set(uids), destination: destination
+        ))
+        if !moveResults.isEmpty {
+            try moveResults.removeFirst().get()
+        }
+    }
+
+    // Lifecycle no-ops — the view model may touch these harmlessly.
+    func connectAndAuthenticate() async throws {}
+    func disconnect() async {}
+    func invalidate() async {}
+
+    // Everything below is off the bulk paths: trap.
+    func listFolders() async throws -> [Folder] { try trap() }
+    func createFolder(name: String, parent: String?) async throws { try trapVoid() }
+    func deleteFolder(path: String) async throws { try trapVoid() }
+    func subscribe(path: String) async throws { try trapVoid() }
+    func unsubscribe(path: String) async throws { try trapVoid() }
+    func status(path: String, flagged: Bool) async throws -> FolderStatus { try trap() }
+    func envelopes(
+        folder: String, range: ClosedRange<UInt32>, sort: SortCriterion
+    ) async throws -> [Envelope] { try trap() }
+    func envelopes(
+        folder: String, offset: UInt32, limit: UInt32, sort: SortCriterion
+    ) async throws -> [Envelope] { try trap() }
+    func topEnvelopes(
+        folder: String, limit: UInt32, totalMessages: UInt32, sort: SortCriterion
+    ) async throws -> [Envelope] { try trap() }
+    func fetchBody(folder: String, uid: UInt32) async throws -> RawMessage { try trap() }
+    func fetchPart(folder: String, uid: UInt32, partId: String) async throws -> Data { try trap() }
+    func append(folder: String, message: Data, flags: Set<Flag>) async throws { try trapVoid() }
+
+    private func trap<T>() throws -> T {
+        throw CabalmailError.protocolError("FakeImapClient: unexpected call")
+    }
+
+    private func trapVoid() throws {
+        throw CabalmailError.protocolError("FakeImapClient: unexpected call")
+    }
+}
+
+/// Minimal `AuthService` conformance — the bulk paths never authenticate.
+actor NullAuthService: AuthService {
+    func signIn(username: String, password: String) async throws {}
+    func signUp(username: String, password: String, email: String?, phone: String?) async throws {}
+    func confirmSignUp(username: String, code: String) async throws {}
+    func resendConfirmationCode(username: String) async throws {}
+    func forgotPassword(username: String) async throws {}
+    func confirmForgotPassword(username: String, code: String, newPassword: String) async throws {}
+    func signOut() async throws {}
+    func currentIdToken() async throws -> String { "test-token" }
+    func currentImapCredentials() async throws -> ImapCredentials {
+        ImapCredentials(username: "tester", password: "secret")
+    }
+    func currentTokens() async -> AuthTokens? { nil }
+}
+
+struct NullSmtpClient: SmtpClient {
+    func send(_ message: OutgoingMessage) async throws {
+        throw CabalmailError.protocolError("NullSmtpClient: unexpected send")
+    }
+}
+
+/// HTTP transport that refuses every request — nothing in these tests may
+/// reach the network.
+struct NullHTTPTransport: HTTPTransport {
+    func perform(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        throw CabalmailError.transport("NullHTTPTransport: unexpected request")
+    }
+}
+
+enum TestFixtures {
+    static func makeConfiguration() -> Configuration {
+        Configuration(
+            controlDomain: "cabalmail.example",
+            domains: [MailDomain(domain: "cabalmail.example")],
+            invokeUrl: URL(string: "https://api.cabalmail.example/prod")!,
+            cognito: .init(region: "us-east-1", userPoolId: "u", clientId: "c")
+        )
+    }
+
+    /// Full client around the fake IMAP transport. Caches land in a
+    /// per-invocation temp directory (the bulk paths prune them; empty
+    /// caches make that a no-op).
+    static func makeClient(imap: FakeImapClient) throws -> CabalmailClient {
+        let config = makeConfiguration()
+        let auth = NullAuthService()
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cabalmail-tests-\(UUID().uuidString)")
+        return CabalmailClient(
+            configuration: config,
+            authService: auth,
+            apiClient: URLSessionApiClient(
+                configuration: config,
+                authService: auth,
+                transport: NullHTTPTransport()
+            ),
+            imapClient: imap,
+            smtpClient: NullSmtpClient(),
+            addressCache: AddressCache(),
+            envelopeCache: try EnvelopeCache(directory: tmp.appendingPathComponent("e")),
+            bodyCache: try MessageBodyCache(directory: tmp.appendingPathComponent("b")),
+            draftStore: try DraftStore(directory: tmp.appendingPathComponent("d")),
+            outbox: try Outbox(directory: tmp.appendingPathComponent("o"))
+        )
+    }
+
+    /// View model over `folder` with the given rows already loaded, ready
+    /// for selection / bulk-op calls. No lifecycle task runs — the model's
+    /// init is pure assignment and `loadInitial()` is never called.
+    @MainActor
+    static func makeModel(
+        imap: FakeImapClient,
+        envelopes: [Envelope],
+        folderPath: String = "INBOX",
+        appState: AppState = AppState()
+    ) throws -> MessageListViewModel {
+        let model = MessageListViewModel(
+            folder: Folder(path: folderPath, attributes: [], isSubscribed: true),
+            client: try makeClient(imap: imap),
+            preferences: Preferences(store: InMemoryPreferenceStore()),
+            appState: appState
+        )
+        model.envelopes = envelopes
+        return model
+    }
+
+    static func makeEnvelope(uid: UInt32, flags: Set<Flag> = []) -> Envelope {
+        Envelope(
+            uid: uid,
+            subject: "Subject \(uid)",
+            from: [EmailAddress(name: "Sender", mailbox: "sender\(uid)", host: "example.com")],
+            flags: flags
+        )
+    }
+}

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -484,6 +484,31 @@ targets:
           CODE_SIGN_IDENTITY: "Apple Distribution"
           PROVISIONING_PROFILE_SPECIFIER: "$(MAC_NSE_APP_STORE_PROFILE_UUID)"
 
+  # Unit tests for the shared app layer (view models, app state). Hosted
+  # by CabalmailMac rather than the iOS app deliberately: the mac target
+  # already compiles the exact same shared sources (see its source list
+  # above), and a macOS test bundle runs natively on the CI mac runner —
+  # no simulator boot. The suite lives in CabalmailTests/ (no "Mac" in
+  # the directory name) because nothing in it is platform-specific; only
+  # the host choice is.
+  CabalmailMacTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: CabalmailTests
+    dependencies:
+      - target: CabalmailMac
+      - package: CabalmailKit
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.cabalmail.CabalmailMacTests
+        GENERATE_INFOPLIST_FILE: YES
+        # XcodeGen derives TEST_HOST from the host target's NAME, but
+        # CabalmailMac overrides PRODUCT_NAME to "Cabalmail" (the bundle
+        # ships as Cabalmail.app), so spell the path out.
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Cabalmail.app/Contents/MacOS/Cabalmail"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+
 schemes:
   Cabalmail:
     build:
@@ -497,8 +522,13 @@ schemes:
     build:
       targets:
         CabalmailMac: all
+        CabalmailMacTests: [test]
     run:
       config: Debug
+    test:
+      config: Debug
+      targets:
+        - CabalmailMacTests
     archive:
       config: Release
   CabalmailWatch:


### PR DESCRIPTION
## Summary

Closes the last automatable item of **Phase 5** of `docs/0.11.x/multi-select-bulk-operations.md` (following #669/#670/#673). The plan asked for `BulkSelectionTests`, but the bulk-selection logic lives in the app target's view models, which no test bundle could reach — CabalmailKit's `swift test` is Kit-only. So this PR adds the app-layer test infrastructure and the suite.

### Test infrastructure

- **`CabalmailMacTests`** unit-test bundle (project.yml), hosted by **CabalmailMac** deliberately: the mac target compiles the exact same shared `Cabalmail/ViewModels` sources as the iOS app, and a macOS bundle runs natively on the CI mac runner — no simulator boot. Gotcha encoded in a comment: `TEST_HOST` must be spelled out because XcodeGen derives it from the target *name* while CabalmailMac overrides `PRODUCT_NAME` to "Cabalmail".
- **CI**: new `app-test` job in `apple.yml` (same xcodegen/sync-vendored/tee-raw-log recipe as `kit-test`); the TestFlight approval gate now `needs` it.
- The suite directory is `apple/CabalmailTests/` (no "Mac") — nothing in it is platform-specific, only the host choice is. SwiftLint now covers it.

### The suite (12 tests, all green)

- Selection mutations: toggle membership, filtered select-all scope, exit-clears
- Optimistic flag state kept on success + one wire call with the full UID set
- Unread-badge accounting counts only real transitions, and only landed ones
- Whole-group revert on total failure
- **Partial-failure granularity**: succeeded rows keep the change, failed rows revert — including restoring a failed row's *pre-op* flag state rather than blind-flipping it
- Move: success clears rows+selection; partial restores only failed rows (with the exact "Moved 1 of 2" message and shield cleanup); total failure restores everything
- Dispose proceeds past a partial seen-marking (best-effort semantics from #669)

`TestSupport.swift` holds a scripted `FakeImapClient` (unexpected wire calls trap loudly) and a full-`CabalmailClient` fixture factory against the Kit's public surface.

## Remaining from the plan

Only the **manual VoiceOver pass** — needs a human with a device.

## Verification

- `xcodebuild test -scheme CabalmailMac -destination platform=macOS` — 12/12 passed
- `xcodebuild build` Cabalmail (iOS) — still succeeds after the project.yml change
- `swiftlint` — 0 findings (including the new directory)
- Both workflow/project YAMLs parse

Labeled `no-changelog`: test-only, nothing user-facing for TestFlight notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)