### PR TITLE
Apple: show attachments that also carry a Content-ID

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageDetailViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageDetailViewModel.swift
@@ -413,39 +413,25 @@ private extension MessageDetailViewModel {
         threadingMessageId = MessageIds.parse(root.headerValue("Message-ID")).first
         threadingInReplyTo = MessageIds.parse(root.headerValue("In-Reply-To")).first
         threadingReferences = MessageIds.parse(root.headerValue("References"))
-        var attachmentList: [Attachment] = []
-        var inlineMap: [String: URL] = [:]
-        for leaf in root.leafParts where isAttachmentLike(leaf) {
-            // Inline `cid:` images are embedded as `data:` URIs, not temp
-            // files: the body web view loads with an opaque origin and can't
-            // fetch `file://` subresources, so a file URL would silently fail
-            // to render. See `MimePart.inlineImageDataURL`.
-            if let contentID = leaf.contentID,
-               let dataURL = leaf.inlineImageDataURL {
-                inlineMap[contentID] = dataURL
-                continue
-            }
-            let filename = leaf.contentDisposition?.filename
-                ?? leaf.contentType.name
-                ?? "attachment-\(UUID().uuidString).bin"
-            let url = try writeToTmp(data: leaf.decodedBody, filename: filename)
-            attachmentList.append(Attachment(
-                id: leaf.contentID ?? url.lastPathComponent,
+        // Classification (which leaves are downloadable attachments vs inline
+        // `cid:` images) is a pure decision, lifted into `MimePart.attachmentPlan()`
+        // in CabalmailKit so it's unit-tested. Inline images are embedded as
+        // `data:` URIs, not temp files: the body web view loads with an opaque
+        // origin and can't fetch `file://` subresources, so a file URL would
+        // silently fail to render. See `MimePart.inlineImageDataURL`.
+        let plan = root.attachmentPlan()
+        inlineImages = plan.inlineImages
+        attachments = try plan.attachments.map { item in
+            let filename = item.filename ?? "attachment-\(UUID().uuidString).bin"
+            let url = try writeToTmp(data: item.data, filename: filename)
+            return Attachment(
+                id: item.contentID ?? url.lastPathComponent,
                 filename: filename,
-                mimeType: leaf.contentType.mimeType,
-                size: leaf.decodedBody.count,
+                mimeType: item.mimeType,
+                size: item.data.count,
                 fileURL: url
-            ))
+            )
         }
-        attachments = attachmentList
-        inlineImages = inlineMap
-    }
-
-    func isAttachmentLike(_ part: MimePart) -> Bool {
-        if part.contentDisposition?.isAttachment == true { return true }
-        if part.contentType.isText, part.contentType.subtype == "plain" { return false }
-        if part.contentType.isText, part.contentType.subtype == "html" { return false }
-        return !part.contentType.isMultipart
     }
 
     /// Writes a decoded part to the app's temp directory. Phase-7 polish can

--- a/apple/CabalmailKit/Sources/CabalmailKit/MIME/MimeAttachments.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/MIME/MimeAttachments.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// The result of classifying a parsed MIME tree into the two things the
+/// reader UI cares about: a list of downloadable attachment parts and a
+/// map of `cid:` → embedded `data:` URL for inline images.
+///
+/// These are drawn from two *independent* rules, matching the web/Lambda
+/// API exactly:
+///
+/// - **Attachment** — the part carries `Content-Disposition: attachment`,
+///   or is a non-text, non-multipart leaf (`list_attachments` keys on the
+///   disposition; the leaf fallback covers senders that omit it).
+/// - **Inline image** — the part is an `image/*` leaf with a `Content-ID`
+///   (`fetch_inline_image` keys purely on Content-ID).
+///
+/// A single part can satisfy both: Gmail stamps a `Content-ID` on genuine
+/// `attachment`-disposition images. Such a part is registered as an inline
+/// image *and* listed as a downloadable attachment — keying "inline" purely
+/// off the presence of a Content-ID would otherwise hide every such image
+/// from the attachment strip (the bug this split fixes).
+public struct MimeAttachmentPlan: Sendable, Equatable {
+    /// A downloadable attachment. `filename` is the sender-declared name
+    /// (`Content-Disposition` filename, falling back to the `Content-Type`
+    /// `name` parameter); nil when the sender declared neither, leaving the
+    /// caller to synthesize one.
+    public struct Attachment: Sendable, Equatable {
+        public let filename: String?
+        public let mimeType: String
+        public let contentID: String?
+        public let data: Data
+
+        public init(filename: String?, mimeType: String, contentID: String?, data: Data) {
+            self.filename = filename
+            self.mimeType = mimeType
+            self.contentID = contentID
+            self.data = data
+        }
+    }
+
+    public let attachments: [Attachment]
+    public let inlineImages: [String: URL]
+
+    public init(attachments: [Attachment], inlineImages: [String: URL]) {
+        self.attachments = attachments
+        self.inlineImages = inlineImages
+    }
+}
+
+public extension MimePart {
+    /// Whether this leaf part should be surfaced to the user as an
+    /// attachment-or-inline candidate: an explicit `attachment` disposition,
+    /// or any non-text, non-multipart leaf. The rendered `text/plain` and
+    /// `text/html` alternatives are excluded — they are the message body.
+    var isAttachmentCandidate: Bool {
+        if contentDisposition?.isAttachment == true { return true }
+        if contentType.isText, contentType.subtype == "plain" { return false }
+        if contentType.isText, contentType.subtype == "html" { return false }
+        return !contentType.isMultipart
+    }
+
+    /// Classify this part tree into downloadable attachments and inline
+    /// `cid:` images. See `MimeAttachmentPlan` for the rules.
+    func attachmentPlan() -> MimeAttachmentPlan {
+        var attachments: [MimeAttachmentPlan.Attachment] = []
+        var inlineImages: [String: URL] = [:]
+        for leaf in leafParts where leaf.isAttachmentCandidate {
+            // Register the inline `cid:` mapping so `cid:` refs in the body
+            // still resolve, but only *skip* the attachment listing when the
+            // part isn't explicitly flagged as an attachment. See the type doc.
+            if let contentID = leaf.contentID, let dataURL = leaf.inlineImageDataURL {
+                inlineImages[contentID] = dataURL
+                if leaf.contentDisposition?.isAttachment != true { continue }
+            }
+            attachments.append(MimeAttachmentPlan.Attachment(
+                filename: leaf.contentDisposition?.filename ?? leaf.contentType.name,
+                mimeType: leaf.contentType.mimeType,
+                contentID: leaf.contentID,
+                data: leaf.decodedBody
+            ))
+        }
+        return MimeAttachmentPlan(attachments: attachments, inlineImages: inlineImages)
+    }
+}

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/MimeAttachmentPlanTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/MimeAttachmentPlanTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import CabalmailKit
+
+final class MimeAttachmentPlanTests: XCTestCase {
+    // Regression: an image attachment that also carries a Content-ID (Gmail
+    // stamps one on every attached image) must still appear in the attachment
+    // list. Keying "inline" purely off Content-ID hid it from the strip on the
+    // Apple clients while the web client listed it fine.
+    func testAttachmentDispositionImageWithContentIDIsListed() {
+        let jpeg = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10])
+        let boundary = "BOUND"
+        let message = """
+        Content-Type: multipart/mixed; boundary="\(boundary)"\r
+        \r
+        --\(boundary)\r
+        Content-Type: text/plain; charset=us-ascii\r
+        \r
+        Body text.\r
+        --\(boundary)\r
+        Content-Type: image/jpeg; name="photo.jpg"\r
+        Content-Disposition: attachment; filename="photo.jpg"\r
+        Content-ID: <abc123>\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(jpeg.base64EncodedString())\r
+        --\(boundary)--\r
+        """
+        let plan = MimeParser.parse(Data(message.utf8)).attachmentPlan()
+
+        XCTAssertEqual(plan.attachments.count, 1)
+        let attachment = plan.attachments.first
+        XCTAssertEqual(attachment?.filename, "photo.jpg")
+        XCTAssertEqual(attachment?.mimeType, "image/jpeg")
+        XCTAssertEqual(attachment?.contentID, "abc123")
+        XCTAssertEqual(attachment?.data, jpeg)
+        // Also registered as inline so a `cid:` ref in the body still resolves.
+        XCTAssertNotNil(plan.inlineImages["abc123"])
+    }
+
+    // A genuine inline image (image/* with a Content-ID and no attachment
+    // disposition) resolves as inline and is NOT listed as an attachment.
+    func testInlineImageWithoutAttachmentDispositionIsNotListed() {
+        let png = Data([0x89, 0x50, 0x4E, 0x47])
+        let boundary = "BOUND"
+        let message = """
+        Content-Type: multipart/related; boundary="\(boundary)"\r
+        \r
+        --\(boundary)\r
+        Content-Type: text/html; charset=utf-8\r
+        \r
+        <img src="cid:logo">\r
+        --\(boundary)\r
+        Content-Type: image/png\r
+        Content-Disposition: inline\r
+        Content-ID: <logo>\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(png.base64EncodedString())\r
+        --\(boundary)--\r
+        """
+        let plan = MimeParser.parse(Data(message.utf8)).attachmentPlan()
+
+        XCTAssertTrue(plan.attachments.isEmpty)
+        XCTAssertNotNil(plan.inlineImages["logo"])
+    }
+
+    // A non-image attachment (no Content-ID) is listed, using the
+    // Content-Type name when Content-Disposition omits the filename.
+    func testNonImageAttachmentIsListed() {
+        let pdf = Data("%PDF-1.4".utf8)
+        let boundary = "BOUND"
+        let message = """
+        Content-Type: multipart/mixed; boundary="\(boundary)"\r
+        \r
+        --\(boundary)\r
+        Content-Type: text/plain\r
+        \r
+        See attached.\r
+        --\(boundary)\r
+        Content-Type: application/pdf; name="report.pdf"\r
+        Content-Disposition: attachment\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        \(pdf.base64EncodedString())\r
+        --\(boundary)--\r
+        """
+        let plan = MimeParser.parse(Data(message.utf8)).attachmentPlan()
+
+        XCTAssertEqual(plan.attachments.count, 1)
+        XCTAssertEqual(plan.attachments.first?.filename, "report.pdf")
+        XCTAssertEqual(plan.attachments.first?.mimeType, "application/pdf")
+        XCTAssertNil(plan.attachments.first?.contentID)
+        XCTAssertTrue(plan.inlineImages.isEmpty)
+    }
+
+    // The rendered text/plain and text/html body alternatives are never
+    // classified as attachments.
+    func testBodyAlternativesAreNotAttachments() {
+        let boundary = "BOUND"
+        let message = """
+        Content-Type: multipart/alternative; boundary="\(boundary)"\r
+        \r
+        --\(boundary)\r
+        Content-Type: text/plain; charset=utf-8\r
+        \r
+        Plain.\r
+        --\(boundary)\r
+        Content-Type: text/html; charset=utf-8\r
+        \r
+        <p>HTML.</p>\r
+        --\(boundary)--\r
+        """
+        let plan = MimeParser.parse(Data(message.utf8)).attachmentPlan()
+
+        XCTAssertTrue(plan.attachments.isEmpty)
+        XCTAssertTrue(plan.inlineImages.isEmpty)
+    }
+}

--- a/changelog.d/attachment-with-content-id.fixed.md
+++ b/changelog.d/attachment-with-content-id.fixed.md
@@ -1,0 +1,8 @@
+- Apple: **Attachments carrying a Content-ID now appear in the reader.**
+  An attached image whose part also carried a `Content-ID` (Gmail stamps one
+  on every attached image) was mis-classified as an inline image and hidden
+  from the attachment strip, so it could be neither viewed nor downloaded on
+  iOS and macOS. Attachment listing and inline-image resolution are now two
+  independent decisions, matching the web client: a part flagged
+  `Content-Disposition: attachment` always gets an attachment chip, even when
+  it also resolves a `cid:` reference in the body.


### PR DESCRIPTION
## Problem

A production email (Gmail, `image/jpeg` attachment) shows a downloadable photo in the React client but **no view/download affordance on macOS or iOS**.

## Root cause

The attached image's MIME part is `Content-Disposition: attachment` **and** carries a `Content-ID` (Gmail stamps one on every attached image). In `MessageDetailViewModel.hydrate`, the Apple client treated *any* `image/*` leaf with a `Content-ID` as an inline image:

```swift
if let contentID = leaf.contentID, let dataURL = leaf.inlineImageDataURL {
    inlineMap[contentID] = dataURL
    continue   // ← never added to the attachment strip
}
```

So the image was routed into the `cid: → inline` map instead of the attachment list. Because the HTML body (a plain signature) never references that `cid:`, it rendered nowhere **and** never appeared as an attachment.

The web client is unaffected because the Lambda API draws two **independent** lines:
- `list_attachments` → any part with `Content-Disposition: attachment`
- `fetch_inline_image` → any part with a `Content-ID`

A part can satisfy both; the Apple client was collapsing them into one either/or decision.

## Fix

Split the two decisions apart to mirror the API: always register the `cid:` mapping (so body refs still resolve), but only skip the attachment listing when the part isn't explicitly `Content-Disposition: attachment`.

The pure classification (which leaves are downloadable attachments vs inline images) was lifted out of the app-target view model into `MimePart.attachmentPlan()` in **CabalmailKit**, where it's covered by unit tests — the app target has no test target, so this logic was previously untested.

## Verification

- Reproduced against the actual `.eml`: the parser correctly yields an `image/jpeg` leaf with `disp=attachment`, `filename`, and a `Content-ID`; before the fix the classifier hid it, after the fix it lists it.
- New `MimeAttachmentPlanTests` (4 cases): attachment-with-Content-ID is listed *and* inline-registered; genuine inline image is not listed; non-image attachment listed; body alternatives excluded.
- Full CabalmailKit suite passes (pre-existing `AcknowledgementsTests` vendored-license failures are unrelated to this change and depend on `sync-vendored.sh`).
- `swiftlint --strict` clean; iOS and macOS app targets both build.

Not yet tested on a device/simulator with this specific message — the change is a pure classification fix verified by unit tests + real-email parse, but a quick manual confirm on macOS/iOS is worth doing before promotion to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)