### PR TITLE
Accept collated CHANGELOG.md Apple entries in apple-changelog gate

### DIFF
--- a/.github/scripts/check-apple-changelog.sh
+++ b/.github/scripts/check-apple-changelog.sh
@@ -70,6 +70,18 @@ while IFS= read -r file; do
   fi
 done <<< "$changed"
 
+# Release PRs (stage -> main) carry no fragments: collate-changelog.sh has
+# already folded them into CHANGELOG.md and deleted the fragment files, so the
+# base...head diff shows the collated CHANGELOG.md gaining the entries and no
+# surviving changelog.d/*.md. Accept an `- Apple:` line added to CHANGELOG.md
+# as equivalent to a fragment - the note still reaches the TestFlight "What to
+# Test" build (set-testflight-notes.py reads the collated CHANGELOG.md).
+if git diff "${BASE_SHA}...${HEAD_SHA}" -- CHANGELOG.md \
+     | grep -qE '^\+- Apple:'; then
+  echo "[apple-changelog] Found Apple entry added to CHANGELOG.md (release PR)."
+  exit 0
+fi
+
 echo "::error::Apple client sources changed but no 'Apple:'-prefixed changelog fragment was added."
 cat >&2 <<'MSG'
 Add a fragment changelog.d/<slug>.<category>.md whose entry begins with

--- a/changelog.d/apple-changelog-release-pr.fixed.md
+++ b/changelog.d/apple-changelog-release-pr.fixed.md
@@ -1,0 +1,6 @@
+- **Apple changelog gate no longer blocks release PRs.** The
+  `apple-changelog` check now accepts an `Apple:`-prefixed entry added to
+  `CHANGELOG.md` as equivalent to a `changelog.d/` fragment, so a stage->main
+  release PR (whose fragments have already been collated into `CHANGELOG.md`
+  and deleted) passes without needing the `no-changelog` opt-out. Apple
+  changes with no note anywhere still fail.


### PR DESCRIPTION
## Problem

The `apple-changelog` gate fails on every **release PR** (stage -> main). It did so on #680 (Release 0.11.3).

The gate detects Apple client source changes, then requires an `Apple:`-prefixed `changelog.d/*.md` fragment in the PR range. But by release time, `collate-changelog.sh` has already folded every fragment into `CHANGELOG.md` and deleted the fragment files — so the `base...head` diff shows no surviving fragments, and the check fails even though the Apple notes shipped correctly in `CHANGELOG.md` (and reach the TestFlight "What to Test" build via `set-testflight-notes.py`, which reads the collated `CHANGELOG.md`).

Until now the only recourse was the `no-changelog` opt-out label on each release PR.

## Fix

After the fragment loop, fall back to checking whether the PR range added an `- Apple:` line to `CHANGELOG.md`; if so, treat it as equivalent to a fragment. This makes the gate release-aware without weakening it: an Apple source change with **no** Apple note anywhere in the range still fails.

## Verification

Ran `check-apple-changelog.sh` locally against real SHAs:

- Release PR #680 SHAs → **exit 0** (was exit 1) via the new CHANGELOG.md path.
- Apple source change, no note anywhere → **exit 1** (gate stays honest).
- Normal dev PR with an `Apple:` fragment → **exit 0** via the existing fragment loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)