### PR TITLE
Sync Apple client settings across devices via the Cabalmail account

### DIFF
--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -254,6 +254,17 @@ final class AppState {
     /// Wired alongside `client` on sign-in / restore, cleared on sign-out.
     private(set) var navCoordinator: NavStateCoordinator?
 
+    /// Syncs app `Preferences` to the server so settings changed on one Apple
+    /// client follow the Cabalmail account to another. Wired alongside `client`
+    /// on sign-in / restore, cleared on sign-out.
+    private(set) var prefsCoordinator: PreferencesSyncCoordinator?
+
+    /// The app-root `Preferences` instance, handed in at launch by the app
+    /// entry (`usePreferences(_:)`) so `wireSession` can start a
+    /// `PreferencesSyncCoordinator` for it. Weak-by-convention: the app scene
+    /// owns it for the whole process lifetime.
+    private var preferences: Preferences?
+
     /// Local-only contacts lookup, used by message list / detail / avatar
     /// to enrich incoming mail with the user's own name and photo for the
     /// sender. One instance per app launch — the actor caches results for
@@ -315,7 +326,16 @@ final class AppState {
         WatchSessionBridge.shared.pushSignedOut()
         self.client = nil
         self.navCoordinator = nil
+        self.prefsCoordinator?.stop()
+        self.prefsCoordinator = nil
         self.status = .signedOut
+    }
+
+    /// Hands the app-root `Preferences` to `AppState` at launch, before any
+    /// sign-in or restore, so `wireSession` can start a
+    /// `PreferencesSyncCoordinator` for the signed-in user. Idempotent.
+    func usePreferences(_ preferences: Preferences) {
+        self.preferences = preferences
     }
 
     /// Launch-time auto-restore. Looks at the UserDefaults-persisted
@@ -508,6 +528,14 @@ extension AppState {
     private func wireSession(client newClient: CabalmailClient, username: String) async {
         self.client = newClient
         self.navCoordinator = NavStateCoordinator(client: newClient)
+        if let preferences {
+            let coordinator = PreferencesSyncCoordinator(client: newClient, preferences: preferences)
+            self.prefsCoordinator = coordinator
+            // Non-blocking: the initial server pull (server wins on login)
+            // shouldn't hold up the UI flipping to signed-in; the applied
+            // values land a moment later.
+            Task { await coordinator.start() }
+        }
         self.status = .signedIn
         startInboxBadgePolling()
         requestContactsAccessIfNeeded()

--- a/apple/Cabalmail/CabalmailApp.swift
+++ b/apple/Cabalmail/CabalmailApp.swift
@@ -28,6 +28,10 @@ struct CabalmailApp: App {
                 .environment(preferences)
                 .preferredColorScheme(colorScheme(for: preferences.theme))
                 .task {
+                    // Hand the app-root Preferences to AppState before any
+                    // restore so the session's PreferencesSyncCoordinator can
+                    // pull the server copy (server wins on login).
+                    appState.usePreferences(preferences)
                     // Launch-time auto-restore. `restoreIfPossible()` is a
                     // no-op once the user is signed in, so SwiftUI re-
                     // running this `.task` across scene re-attaches (e.g.
@@ -55,6 +59,10 @@ struct CabalmailApp: App {
                     // app installed while this app was already running.
                     guard phase == .active else { return }
                     Task { await appState.refreshWatchSession() }
+                    // Pick up settings changed on another device while this
+                    // one was backgrounded (server wins, unless a local edit
+                    // is still pending its push).
+                    Task { await appState.prefsCoordinator?.reconcile() }
                 }
                 .onOpenURL { url in
                     // Cold-launch mailto: arrives here before any view

--- a/apple/Cabalmail/PreferencesSyncCoordinator.swift
+++ b/apple/Cabalmail/PreferencesSyncCoordinator.swift
@@ -1,0 +1,106 @@
+import Foundation
+import CabalmailKit
+
+/// Syncs the user's app `Preferences` to the server so a setting changed on one
+/// Apple client shows up the next time they sign in on another. The settings
+/// are stored per Cognito user (the `app` map on the `cabal-user-preferences`
+/// row, behind `/get_preferences` / `/set_preferences`), which anchors them to
+/// the Cabalmail login rather than the Apple ID that iCloud key-value sync
+/// keys on.
+///
+/// Created by `AppState` when a client is wired (sign-in or restore) and torn
+/// down on sign-out. `@MainActor` because it drives the main-actor-isolated
+/// `Preferences` and is invoked from SwiftUI lifecycle hooks.
+///
+/// Lifecycle:
+/// - **Start** (`start`): fetch the server copy once and apply it — the server
+///   wins on login — then observe local edits via `Preferences.onLocalChange`.
+/// - **Local edit**: debounce, then push the complete `app` map. The client
+///   always sends every key, so the server replaces the whole map (concurrent
+///   multi-device edits are last-write-wins).
+/// - **Foreground** (`reconcile`): re-fetch and re-apply so a change made on
+///   another device mid-session lands, unless a local edit is still pending
+///   (never clobber an edit we haven't managed to push yet).
+@MainActor
+final class PreferencesSyncCoordinator {
+    private let client: CabalmailClient
+    private let preferences: Preferences
+
+    private var saveTask: Task<Void, Never>?
+    /// The map last confirmed in sync with the server (fetched or pushed), so a
+    /// no-op edit or a redundant reconcile doesn't trigger a write.
+    private var lastSynced: [String: String]?
+    /// True from a local edit until its push succeeds — reconcile skips the
+    /// server pull while set so an in-flight local change isn't overwritten.
+    private var pendingLocalChange = false
+    /// Debounce window for pushes: a quick flurry of toggles collapses to one
+    /// write. Matches `NavStateCoordinator`'s cursor-save cadence.
+    private let saveDebounce: Duration = .seconds(1)
+
+    init(client: CabalmailClient, preferences: Preferences) {
+        self.client = client
+        self.preferences = preferences
+    }
+
+    /// Applies the server copy (server wins on login) and starts observing
+    /// local edits. Safe to call once per wired session.
+    func start() async {
+        await pullFromServer()
+        preferences.onLocalChange = { [weak self] in
+            self?.scheduleSave()
+        }
+    }
+
+    /// Detaches the local-edit observer and cancels any pending push. Called on
+    /// sign-out before the coordinator is released.
+    func stop() {
+        saveTask?.cancel()
+        saveTask = nil
+        preferences.onLocalChange = nil
+    }
+
+    /// Re-pulls the server copy on foreground so a change made elsewhere lands
+    /// mid-session. Skips while a local edit is still pending its push, so the
+    /// user's own unsaved change always wins over a stale server value.
+    func reconcile() async {
+        guard !pendingLocalChange else { return }
+        await pullFromServer()
+    }
+
+    /// Fetches the server's `app` map and applies it. A missing/empty map (the
+    /// user has never synced) leaves the local defaults in place.
+    private func pullFromServer() async {
+        guard let remote = try? await client.fetchAppPreferences(), !remote.isEmpty else { return }
+        preferences.applyRemote(remote)
+        // Record the applied set so the value we just wrote in doesn't read as
+        // a local edit and echo straight back out.
+        lastSynced = preferences.appPreferencesPayload()
+    }
+
+    private func scheduleSave() {
+        let payload = preferences.appPreferencesPayload()
+        // Applying a server pull can fire the observer via the store write;
+        // skip when nothing actually changed relative to the last sync.
+        if payload == lastSynced { return }
+        pendingLocalChange = true
+        saveTask?.cancel()
+        let debounce = saveDebounce
+        saveTask = Task { [weak self] in
+            try? await Task.sleep(for: debounce)
+            guard !Task.isCancelled else { return }
+            await self?.push(payload)
+        }
+    }
+
+    private func push(_ payload: [String: String]) async {
+        do {
+            try await client.saveAppPreferences(payload)
+            lastSynced = payload
+            pendingLocalChange = false
+        } catch {
+            // Best-effort: a failed push is never worth surfacing. The next
+            // edit reschedules, and the next sign-in / foreground reconciles
+            // from whatever did persist.
+        }
+    }
+}

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/ApiClient.swift
@@ -118,6 +118,19 @@ public protocol ApiClient: Sendable {
     /// server-side when composing the From header.
     func updateDisplayName(_ name: String) async throws
 
+    /// Fetches the Apple client's synced preferences from `/get_preferences`.
+    /// These live under the row's `app` map (namespaced away from the web
+    /// client's flat theme/accent/density), so this returns just that
+    /// sub-object as wire-key -> value. An empty dictionary means the user has
+    /// no server-side app preferences yet (fall back to local/enum defaults).
+    func fetchAppPreferences() async throws -> [String: String]
+
+    /// Persists the Apple client's preferences via `/set_preferences`, wrapped
+    /// in an `{"app": {...}}` envelope so the Lambda merges only that map and
+    /// never disturbs the display name or the web client's fields. The client
+    /// always sends its complete set; the server replaces the whole `app` map.
+    func saveAppPreferences(_ prefs: [String: String]) async throws
+
     // MARK: Navigation cursor
     /// Loads the cross-client navigation cursor from `/get_nav_state`, or nil
     /// when none has been saved yet (the Lambda returns `{}`). See `NavState`.

--- a/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Preferences.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/API/URLSessionApiClient+Preferences.swift
@@ -17,4 +17,22 @@ extension URLSessionApiClient {
         let request = try await put("/set_preferences", json: ["name": name])
         _ = try await send(request, expectedStatuses: 200..<300)
     }
+
+    public func fetchAppPreferences() async throws -> [String: String] {
+        let request = try await get("/get_preferences")
+        let data = try await send(request, expectedStatuses: 200..<300)
+        struct Payload: Decodable { let app: [String: String]? }
+        let decoded = try? JSONDecoder().decode(Payload.self, from: data)
+        // A missing `app` key (older Lambda deployment, or a user who has
+        // only ever used the web client) reads as "no synced preferences".
+        return decoded?.app ?? [:]
+    }
+
+    public func saveAppPreferences(_ prefs: [String: String]) async throws {
+        // Wrap in the `app` envelope: set_preferences merges per top-level
+        // key, so this replaces only the `app` map and leaves `name` and the
+        // web client's theme/accent/density untouched.
+        let request = try await put("/set_preferences", json: ["app": prefs])
+        _ = try await send(request, expectedStatuses: 200..<300)
+    }
 }

--- a/apple/CabalmailKit/Sources/CabalmailKit/CabalmailClient+Addresses.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/CabalmailClient+Addresses.swift
@@ -64,4 +64,17 @@ extension CabalmailClient {
     public func setDisplayName(_ name: String) async throws {
         try await apiClient.updateDisplayName(name)
     }
+
+    /// Fetches the Apple client's synced preferences (the row's `app` map) so
+    /// a fresh sign-in on another device picks up settings changed elsewhere.
+    /// Empty means "none saved yet"; the caller keeps its local defaults.
+    public func fetchAppPreferences() async throws -> [String: String] {
+        try await apiClient.fetchAppPreferences()
+    }
+
+    /// Persists the Apple client's preferences server-side, anchored to the
+    /// signed-in Cognito user so they follow the account across devices.
+    public func saveAppPreferences(_ prefs: [String: String]) async throws {
+        try await apiClient.saveAppPreferences(prefs)
+    }
 }

--- a/apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift
@@ -198,6 +198,15 @@ public final class Preferences {
 
     private let store: PreferenceStore
     private var isReloading = false
+    private var isApplyingRemote = false
+
+    /// Fired after a user-driven preference write, once the new value has been
+    /// persisted locally. The session's `PreferencesSyncCoordinator` sets this
+    /// to debounce a push of the full `app` map to the server so settings
+    /// follow the Cabalmail account across devices. Deliberately *not* fired
+    /// for the `reload()` (inbound iCloud) or `applyRemote(_:)` (inbound
+    /// server) paths — echoing an inbound update back out would loop.
+    public var onLocalChange: (() -> Void)?
 
     public init(store: PreferenceStore) {
         self.store = store
@@ -254,6 +263,12 @@ public final class Preferences {
     private func persist(_ key: Key, _ value: String?) {
         guard !isReloading else { return }
         store.setString(value, forKey: key.rawValue)
+        // A server-applied value is already persisted locally by the write
+        // above; it must not be pushed straight back to the server, or a
+        // fetched change would echo out as a fresh save. Only genuine user
+        // edits fall through to notify the sync coordinator.
+        guard !isApplyingRemote else { return }
+        onLocalChange?()
     }
 
     private static func readEnum<Value: RawRepresentable>(
@@ -261,6 +276,78 @@ public final class Preferences {
     ) -> Value where Value.RawValue == String {
         guard let raw = store.stringValue(forKey: key.rawValue) else { return fallback }
         return Value(rawValue: raw) ?? fallback
+    }
+
+    // MARK: - Server sync marshalling
+
+    /// Wire keys for the server-synced `app` map (the `set_preferences` Lambda
+    /// validates against these exact names). Distinct from `Key`, whose dotted
+    /// raw values are the local UserDefaults/iCloud keys; these short
+    /// snake_case names are the cross-client JSON contract.
+    private enum AppWireKey {
+        static let markAsRead = "mark_as_read"
+        static let loadRemoteContent = "load_remote_content"
+        static let defaultFromAddress = "default_from_address"
+        static let signature = "signature"
+        static let disposeAction = "dispose_action"
+        static let theme = "theme"
+        static let crashReportingEnabled = "crash_reporting_enabled"
+        static let defaultBodyRenderMode = "default_body_render_mode"
+        static let folderCountDisplay = "folder_count_display"
+    }
+
+    /// The complete set of synced preferences as the `app` map the server
+    /// stores. Always sends every key (the server replaces the whole map), with
+    /// `defaultFromAddress`'s "no default" (`nil`) encoded as an empty string.
+    public func appPreferencesPayload() -> [String: String] {
+        [
+            AppWireKey.markAsRead: markAsRead.rawValue,
+            AppWireKey.loadRemoteContent: loadRemoteContent.rawValue,
+            AppWireKey.defaultFromAddress: defaultFromAddress ?? "",
+            AppWireKey.signature: signature,
+            AppWireKey.disposeAction: disposeAction.rawValue,
+            AppWireKey.theme: theme.rawValue,
+            AppWireKey.crashReportingEnabled: crashReportingEnabled ? "1" : "0",
+            AppWireKey.defaultBodyRenderMode: defaultBodyRenderMode.rawValue,
+            AppWireKey.folderCountDisplay: folderCountDisplay.rawValue,
+        ]
+    }
+
+    /// Applies a server-fetched `app` map (server wins on login). Each value is
+    /// written through to the local store as a cache, but `isApplyingRemote`
+    /// suppresses the `onLocalChange` push so the fetch doesn't bounce back out.
+    /// Missing or unrecognized values leave the current value untouched.
+    public func applyRemote(_ remote: [String: String]) {
+        isApplyingRemote = true
+        defer { isApplyingRemote = false }
+        if let raw = remote[AppWireKey.markAsRead], let value = MarkAsReadBehavior(rawValue: raw) {
+            markAsRead = value
+        }
+        if let raw = remote[AppWireKey.loadRemoteContent], let value = LoadRemoteContentPolicy(rawValue: raw) {
+            loadRemoteContent = value
+        }
+        if let raw = remote[AppWireKey.defaultFromAddress] {
+            // Empty string is the wire encoding for "no default".
+            defaultFromAddress = raw.isEmpty ? nil : raw
+        }
+        if let raw = remote[AppWireKey.signature] {
+            signature = raw
+        }
+        if let raw = remote[AppWireKey.disposeAction], let value = DisposeAction(rawValue: raw) {
+            disposeAction = value
+        }
+        if let raw = remote[AppWireKey.theme], let value = AppTheme(rawValue: raw) {
+            theme = value
+        }
+        if let raw = remote[AppWireKey.crashReportingEnabled] {
+            crashReportingEnabled = raw == "1"
+        }
+        if let raw = remote[AppWireKey.defaultBodyRenderMode], let value = BodyRenderMode(rawValue: raw) {
+            defaultBodyRenderMode = value
+        }
+        if let raw = remote[AppWireKey.folderCountDisplay], let value = FolderCountDisplay(rawValue: raw) {
+            folderCountDisplay = value
+        }
     }
 }
 

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientPreferencesTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ApiClientPreferencesTests.swift
@@ -66,4 +66,65 @@ final class ApiClientPreferencesTests: XCTestCase {
         XCTAssertEqual(payload?.count, 1)
         XCTAssertEqual(payload?["name"] as? String, "Chris Carr")
     }
+
+    // MARK: - App preferences (cross-device settings sync)
+
+    func testFetchAppPreferencesDecodesAppMap() async throws {
+        // get_preferences returns the whole row; the Apple client reads only
+        // the namespaced `app` sub-object.
+        let body = #"""
+        {"theme":"light","accent":"forest","density":"compact","name":"Chris",\#
+        "app":{"theme":"dark","dispose_action":"trash","signature":"Cheers"}}
+        """#
+        let http = RecordingHTTPTransport(responses: [(Data(body.utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        let prefs = try await client.fetchAppPreferences()
+        XCTAssertEqual(prefs["theme"], "dark")
+        XCTAssertEqual(prefs["dispose_action"], "trash")
+        XCTAssertEqual(prefs["signature"], "Cheers")
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].httpMethod, "GET")
+        XCTAssertTrue(requests[0].url!.absoluteString.contains("/get_preferences"))
+    }
+
+    func testFetchAppPreferencesEmptyWhenAbsent() async throws {
+        // A user who has only ever used the web client (or an older Lambda)
+        // has no `app` key; that must read as "none saved", not an error.
+        let body = #"{"theme":"light","accent":"forest","density":"compact"}"#
+        let http = RecordingHTTPTransport(responses: [(Data(body.utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        let prefs = try await client.fetchAppPreferences()
+        XCTAssertTrue(prefs.isEmpty)
+    }
+
+    func testSaveAppPreferencesWrapsInAppEnvelope() async throws {
+        let http = RecordingHTTPTransport(responses: [(Data(#"{"app":{"theme":"dark"}}"#.utf8), 200)])
+        let client = URLSessionApiClient(
+            configuration: makeConfiguration(),
+            authService: StubAuthService(),
+            transport: http
+        )
+        try await client.saveAppPreferences(["theme": "dark", "dispose_action": "trash"])
+        let requests = await http.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].httpMethod, "PUT")
+        XCTAssertTrue(requests[0].url!.absoluteString.contains("/set_preferences"))
+        let payload = try JSONSerialization.jsonObject(with: requests[0].httpBody ?? Data()) as? [String: Any]
+        // The body must carry only the `app` envelope - set_preferences merges
+        // per top-level key, so this must not disturb `name` or the web
+        // client's theme/accent/density.
+        XCTAssertEqual(payload?.count, 1)
+        let app = payload?["app"] as? [String: Any]
+        XCTAssertEqual(app?["theme"] as? String, "dark")
+        XCTAssertEqual(app?["dispose_action"] as? String, "trash")
+    }
 }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/PreferencesTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/PreferencesTests.swift
@@ -146,4 +146,82 @@ final class PreferencesTests: XCTestCase {
         XCTAssertEqual(preferences.markAsRead, .manual)
         XCTAssertEqual(preferences.theme, .system)
     }
+
+    // MARK: - Server sync marshalling
+
+    /// The full payload sent to the server round-trips back through
+    /// `applyRemote(_:)` so a setting saved on one device reproduces exactly on
+    /// another. Every synced key is exercised with a non-default value.
+    func testAppPreferencesPayloadRoundTripsThroughApplyRemote() {
+        let source = Preferences(store: InMemoryPreferenceStore())
+        source.markAsRead = .afterDelay
+        source.loadRemoteContent = .always
+        source.defaultFromAddress = "me@example.com"
+        source.signature = "Cheers,\nChris"
+        source.disposeAction = .trash
+        source.theme = .dark
+        source.crashReportingEnabled = true
+        source.defaultBodyRenderMode = .reader
+        source.folderCountDisplay = .both
+
+        let target = Preferences(store: InMemoryPreferenceStore())
+        target.applyRemote(source.appPreferencesPayload())
+
+        XCTAssertEqual(target.markAsRead, .afterDelay)
+        XCTAssertEqual(target.loadRemoteContent, .always)
+        XCTAssertEqual(target.defaultFromAddress, "me@example.com")
+        XCTAssertEqual(target.signature, "Cheers,\nChris")
+        XCTAssertEqual(target.disposeAction, .trash)
+        XCTAssertEqual(target.theme, .dark)
+        XCTAssertTrue(target.crashReportingEnabled)
+        XCTAssertEqual(target.defaultBodyRenderMode, .reader)
+        XCTAssertEqual(target.folderCountDisplay, .both)
+    }
+
+    /// An empty From address is encoded as "" on the wire and must decode back
+    /// to `nil` ("no default"), not an empty string.
+    func testApplyRemoteEmptyFromAddressBecomesNil() {
+        let preferences = Preferences(store: InMemoryPreferenceStore())
+        preferences.defaultFromAddress = "was@example.com"
+        preferences.applyRemote(["default_from_address": ""])
+        XCTAssertNil(preferences.defaultFromAddress)
+    }
+
+    /// A server apply must write through to the local store (so the fast-path
+    /// cache matches the server) but must NOT fire `onLocalChange` — echoing an
+    /// inbound update back out as a save would loop between devices.
+    func testApplyRemoteWritesStoreButDoesNotFireOnLocalChange() {
+        let store = InMemoryPreferenceStore()
+        let preferences = Preferences(store: store)
+        var localChangeCount = 0
+        preferences.onLocalChange = { localChangeCount += 1 }
+
+        preferences.applyRemote(["theme": "dark", "dispose_action": "trash"])
+
+        XCTAssertEqual(localChangeCount, 0)
+        // Written through to the local store as a cache of the server value.
+        XCTAssertEqual(store.stringValue(forKey: Preferences.Key.theme.rawValue), "dark")
+        XCTAssertEqual(store.stringValue(forKey: Preferences.Key.disposeAction.rawValue), "trash")
+    }
+
+    /// A genuine user edit fires `onLocalChange` so the sync coordinator can
+    /// debounce a push. Unknown/garbage remote values leave the value untouched.
+    func testLocalEditFiresOnLocalChange() {
+        let preferences = Preferences(store: InMemoryPreferenceStore())
+        var localChangeCount = 0
+        preferences.onLocalChange = { localChangeCount += 1 }
+
+        preferences.theme = .light
+        preferences.disposeAction = .trash
+
+        XCTAssertEqual(localChangeCount, 2)
+    }
+
+    func testApplyRemoteIgnoresUnknownAndMissingValues() {
+        let preferences = Preferences(store: InMemoryPreferenceStore())
+        preferences.theme = .dark
+        // A garbage theme and a key we don't recognize both leave state intact.
+        preferences.applyRemote(["theme": "lunar-eclipse", "unknown_key": "x"])
+        XCTAssertEqual(preferences.theme, .dark)
+    }
 }

--- a/apple/CabalmailMac/CabalmailMacApp.swift
+++ b/apple/CabalmailMac/CabalmailMacApp.swift
@@ -24,6 +24,7 @@ struct CabalmailMacApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var appState = AppState()
     @State private var preferences = Preferences(store: UbiquitousPreferenceStore())
+    @Environment(\.scenePhase) private var scenePhase
     // Mac residency: whether the status-item menu is installed. Backed by
     // UserDefaults so the "Show in menu bar" toggle in Settings >
     // Notifications inserts/removes the item live via `isInserted`.
@@ -36,6 +37,10 @@ struct CabalmailMacApp: App {
                 .environment(preferences)
                 .preferredColorScheme(colorScheme(for: preferences.theme))
                 .task {
+                    // Hand the app-root Preferences to AppState before any
+                    // restore so the session's PreferencesSyncCoordinator can
+                    // pull the server copy (server wins on login).
+                    appState.usePreferences(preferences)
                     await appState.restoreIfPossible()
                     if preferences.crashReportingEnabled {
                         appState.client?.setCrashReportingEnabled(true)
@@ -46,6 +51,13 @@ struct CabalmailMacApp: App {
                     if preferences.crashReportingEnabled {
                         appState.client?.setCrashReportingEnabled(true)
                     }
+                }
+                .onChange(of: scenePhase) { _, phase in
+                    // Pick up settings changed on another device while this
+                    // window was in the background (server wins, unless a
+                    // local edit is still pending its push).
+                    guard phase == .active else { return }
+                    Task { await appState.prefsCoordinator?.reconcile() }
                 }
                 .onOpenURL { url in
                     // mailto: clicks from Safari / Mail.app / other

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -210,6 +210,7 @@ targets:
       - path: Cabalmail/AppState.swift
       - path: Cabalmail/AppStateSignals.swift
       - path: Cabalmail/NavStateCoordinator.swift
+      - path: Cabalmail/PreferencesSyncCoordinator.swift
       - path: Cabalmail/Pasteboard.swift
       # Shared with AppState.swift: the no-op stub branch compiles here
       # (WatchConnectivity is iOS-only). See WatchSessionBridge.swift.

--- a/changelog.d/apple-settings-sync.added.md
+++ b/changelog.d/apple-settings-sync.added.md
@@ -1,0 +1,4 @@
+- Apple: **Settings sync across devices.** Reading, composing, action,
+  appearance, and diagnostics preferences now follow your Cabalmail account —
+  change a setting on one device and it applies the next time you sign in on
+  another, regardless of which Apple ID each device uses.

--- a/lambda/api/get_preferences/function.py
+++ b/lambda/api/get_preferences/function.py
@@ -1,4 +1,4 @@
-'''Fetches the current user's preferences (theme/accent/density/name).'''
+'''Fetches the current user's preferences (theme/accent/density/name/app).'''
 import json
 import os
 import boto3  # pylint: disable=import-error
@@ -22,6 +22,12 @@ def handler(event, _context):
         response = table.get_item(Key={'user': user})
         item = response.get('Item', {})
         prefs = {k: item.get(k, default) for k, default in DEFAULTS.items()}
+        # The Apple clients namespace their own preferences under `app` (a
+        # DynamoDB Map) so they never collide with the flat theme/accent/
+        # density fields the React app owns. Absent for users who have only
+        # ever used the web client - an empty object, which the Apple client
+        # reads as "fall back to local defaults".
+        prefs['app'] = item.get('app', {})
     except Exception as err:  # pylint: disable=broad-exception-caught
         return {
             'statusCode': 500,

--- a/lambda/api/set_preferences/function.py
+++ b/lambda/api/set_preferences/function.py
@@ -1,4 +1,4 @@
-'''Persists the current user's preferences (theme/accent/density/name).'''
+'''Persists the current user's preferences (theme/accent/density/name/app).'''
 import json
 import os
 import boto3  # pylint: disable=import-error
@@ -20,6 +20,26 @@ ALLOWED = {
 # means "no display name".
 MAX_NAME_LENGTH = 100
 
+# Apple-client preferences, namespaced under `app` so they never collide with
+# the flat theme/accent/density fields the React app owns. The enum-valued keys
+# mirror the Swift `Preferences` enums exactly (see
+# apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift); the two
+# free-text keys reuse the display-name/signature validators below.
+APP_ALLOWED = {
+    'mark_as_read':             {'manual', 'on_open', 'after_delay'},
+    'load_remote_content':      {'off', 'ask', 'always'},
+    'dispose_action':           {'archive', 'trash'},
+    'theme':                    {'system', 'light', 'dark'},
+    'default_body_render_mode': {'original', 'reader'},
+    'folder_count_display':     {'unread', 'total', 'both'},
+    'crash_reporting_enabled':  {'0', '1'},
+}
+
+# The signature lands in the outgoing message body (not a header), so newlines
+# and tabs are legitimate; only other control characters are rejected. Capped
+# so a runaway value can't bloat every row.
+MAX_SIGNATURE_LENGTH = 2000
+
 
 def _validate_name(value):
     '''Returns the trimmed display name, or None if the value is invalid.'''
@@ -33,6 +53,74 @@ def _validate_name(value):
     return cleaned
 
 
+def _validate_signature(value):
+    '''Returns the signature unchanged, or None if the value is invalid.'''
+    if not isinstance(value, str):
+        return None
+    if len(value) > MAX_SIGNATURE_LENGTH:
+        return None
+    if any((ord(ch) < 32 and ch not in '\n\t') or ord(ch) == 127 for ch in value):
+        return None
+    return value
+
+
+def _validate_app(value):
+    '''Returns the validated `app` preference map, or None if it is invalid.
+
+    Unknown keys are rejected rather than silently dropped so a client typo
+    surfaces as a 400 instead of a preference that never persists.
+    '''
+    if not isinstance(value, dict):
+        return None
+    cleaned = {}
+    for key, val in value.items():
+        if key in APP_ALLOWED:
+            if val not in APP_ALLOWED[key]:
+                return None
+            cleaned[key] = val
+        elif key == 'default_from_address':
+            address = _validate_name(val)
+            if address is None:
+                return None
+            cleaned[key] = address
+        elif key == 'signature':
+            signature = _validate_signature(val)
+            if signature is None:
+                return None
+            cleaned[key] = signature
+        else:
+            return None
+    return cleaned
+
+
+def _build_updates(body):
+    '''Validates the request body into the DynamoDB update map.
+
+    Raises ValueError with a client-facing message on any invalid field, so the
+    handler keeps a single 400 exit. Keeps validation for all four surfaces
+    (theme/accent/density, name, and the Apple `app` map) in one place.
+    '''
+    updates = {}
+    for key, allowed in ALLOWED.items():
+        if key in body:
+            if body[key] not in allowed:
+                raise ValueError(f'Invalid value for {key}.')
+            updates[key] = body[key]
+    if 'name' in body:
+        name = _validate_name(body['name'])
+        if name is None:
+            raise ValueError('Invalid value for name.')
+        updates['name'] = name
+    if 'app' in body:
+        app = _validate_app(body['app'])
+        if app is None:
+            raise ValueError('Invalid value for app.')
+        updates['app'] = app
+    if not updates:
+        raise ValueError('No known preference keys supplied.')
+    return updates
+
+
 def handler(event, _context):
     '''Validates and merges the caller's preferences into their row.'''
     user = event['requestContext']['authorizer']['claims']['cognito:username']
@@ -43,33 +131,19 @@ def handler(event, _context):
             'statusCode': 400,
             'body': json.dumps({'Error': 'Invalid JSON body.'})
         }
-    updates = {}
-    for key, allowed in ALLOWED.items():
-        if key in body:
-            value = body[key]
-            if value not in allowed:
-                return {
-                    'statusCode': 400,
-                    'body': json.dumps({'Error': f'Invalid value for {key}.'})
-                }
-            updates[key] = value
-    if 'name' in body:
-        name = _validate_name(body['name'])
-        if name is None:
-            return {
-                'statusCode': 400,
-                'body': json.dumps({'Error': 'Invalid value for name.'})
-            }
-        updates['name'] = name
-    if not updates:
+    try:
+        updates = _build_updates(body)
+    except ValueError as err:
         return {
             'statusCode': 400,
-            'body': json.dumps({'Error': 'No known preference keys supplied.'})
+            'body': json.dumps({'Error': str(err)})
         }
     # Merge rather than replace: clients save only the keys they own (the
-    # React app sends accent/density, the Apple clients send name), so a
-    # put_item here would clobber the other client's preferences. Every key
-    # is aliased - `name` is a DynamoDB reserved word.
+    # React app sends theme/accent/density, the Apple clients send name and the
+    # `app` map), so a put_item here would clobber the other client's
+    # preferences. The `app` map itself is replaced wholesale - the Apple client
+    # always sends its complete set, so concurrent multi-device edits are
+    # last-write-wins. Every key is aliased - `name` is a DynamoDB reserved word.
     expression = ', '.join(f'#k{i} = :v{i}' for i in range(len(updates)))
     names = {f'#k{i}': key for i, key in enumerate(updates)}
     values = {f':v{i}': updates[key] for i, key in enumerate(updates)}


### PR DESCRIPTION
## What

Make the nine Apple **content** preferences (Reading, Composing, Actions, Appearance, Diagnostics) follow the **Cabalmail account** across devices — change a setting on one Apple client and it applies the next time you sign in on another.

## Why

Those preferences previously synced only through iCloud's key-value store, which is keyed to the **Apple ID**, not the Cabalmail login. That fails across different iCloud accounts and can't distinguish two Cabalmail users on one device. The user asked for settings to be "reflected the next time I log in on another Apple client" — i.e. anchored to the login.

## How

Store the settings per Cognito user in the existing `cabal-user-preferences` row, namespaced under an `app` map so they never collide with the flat `theme`/`accent`/`density` the React app owns or the display-name path. **Server wins on login** (and on foreground reconcile); a debounced push saves local edits. Reuses the existing `/get_preferences` + `/set_preferences` endpoints — **no new Lambdas, table, API Gateway, IAM, or Terraform**. iCloud/UserDefaults remains a local fast-path.

- **Lambdas** — `get_preferences` returns the `app` map; `set_preferences` validates + merges it (enum allow-lists mirroring the Swift enums; free-text `default_from_address`/`signature` reuse the display-name / a new signature validator). The `app` map is replaced wholesale (client always sends the full set → last-write-wins).
- **CabalmailKit** — `fetchAppPreferences`/`saveAppPreferences` on the API client; `Preferences` gains `appPreferencesPayload()` / `applyRemote(_:)` and an `onLocalChange` hook, guarded by `isApplyingRemote` so inbound (server/iCloud) updates never echo back out.
- **App** — new `PreferencesSyncCoordinator` wired in `AppState.wireSession` (one point, serves both iOS and macOS targets); foreground reconcile on scene-active, skipped while a local edit is pending so it never clobbers unsaved changes.

## Scope

Only the nine content prefs. Push-notification prefs and layout/UI state stay deliberately per-device.

## Verification

- `pylint` 10/10; `swiftlint --strict` clean.
- `swift test`: 8 new tests pass (API wire shape for fetch/save; `Preferences` payload↔applyRemote round-trip; `applyRemote` writes-through-but-doesn't-echo; local-edit fires the hook). The only failing test is the pre-existing `AcknowledgementsTests` vendored-license check, which needs `sync-vendored.sh` (runs in CI).
- iOS and macOS app targets both build (`scripts/build-apple.sh ios` / `macos`).
- Recommend a manual two-device round-trip on stage before promotion: change a setting on one signed-in client, sign in fresh on another, confirm it lands; sanity-check the React webmail theme/accent/density are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)