### PR TITLE
Merge the synced app preference map per key

### DIFF
--- a/apple/Cabalmail/PreferencesSyncCoordinator.swift
+++ b/apple/Cabalmail/PreferencesSyncCoordinator.swift
@@ -16,9 +16,10 @@ import CabalmailKit
 /// Lifecycle:
 /// - **Start** (`start`): fetch the server copy once and apply it — the server
 ///   wins on login — then observe local edits via `Preferences.onLocalChange`.
-/// - **Local edit**: debounce, then push the complete `app` map. The client
-///   always sends every key, so the server replaces the whole map (concurrent
-///   multi-device edits are last-write-wins).
+/// - **Local edit**: debounce, then push the complete `app` map (every key
+///   this build knows). The server merges per key, so concurrent multi-device
+///   edits are last-write-wins per key, and a key introduced by a newer
+///   client build survives a push from an older one.
 /// - **Foreground** (`reconcile`): re-fetch and re-apply so a change made on
 ///   another device mid-session lands, unless a local edit is still pending
 ///   (never clobber an edit we haven't managed to push yet).

--- a/apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift
@@ -364,8 +364,10 @@ public final class Preferences {
     }
 
     /// The complete set of synced preferences as the `app` map the server
-    /// stores. Always sends every key (the server replaces the whole map), with
-    /// `defaultFromAddress`'s "no default" (`nil`) encoded as an empty string.
+    /// stores. Always sends every key this build knows; the server merges
+    /// per key, so keys a newer client added (and this build doesn't know)
+    /// survive the push. `defaultFromAddress`'s "no default" (`nil`) is
+    /// encoded as an empty string — key removal is never needed.
     public func appPreferencesPayload() -> [String: String] {
         [
             AppWireKey.markAsRead: markAsRead.rawValue,

--- a/changelog.d/app-prefs-per-key-merge.fixed.md
+++ b/changelog.d/app-prefs-per-key-merge.fixed.md
@@ -1,0 +1,9 @@
+- **Per-key merge for the synced `app` preference map.** `set_preferences`
+  replaced the Apple clients' `app` map wholesale on every save, so once a
+  newer client version introduced an additional preference key, a settings
+  edit from a device still running an older version would silently delete
+  it for every device. The server now merges the map per key (`app.x`
+  nested updates, seeding the map on first save), making concurrent and
+  cross-version edits last-write-wins per key; keys unknown to the saving
+  client survive. An empty `app` map is now a no-op instead of wiping the
+  stored map.

--- a/lambda/api/set_preferences/function.py
+++ b/lambda/api/set_preferences/function.py
@@ -121,6 +121,41 @@ def _build_updates(body):
     return updates
 
 
+def _build_expression(flat, app):
+    '''Builds the UpdateExpression pieces for the flat keys and the nested
+    `app` keys. Every name is aliased - `name` is a DynamoDB reserved word,
+    and the `app` member names are aliased for uniformity.'''
+    sets = []
+    names = {}
+    values = {}
+    for i, key in enumerate(flat):
+        sets.append(f'#k{i} = :v{i}')
+        names[f'#k{i}'] = key
+        values[f':v{i}'] = flat[key]
+    if app:
+        names['#app'] = 'app'
+        for j, key in enumerate(app):
+            sets.append(f'#app.#a{j} = :a{j}')
+            names[f'#a{j}'] = key
+            values[f':a{j}'] = app[key]
+    return sets, names, values
+
+
+def _ensure_app_map(user):
+    '''Creates the row's `app` map if it does not exist yet, so the nested
+    per-key SETs in the main update cannot fail on a missing document path.
+    A separate write because DynamoDB rejects overlapping document paths
+    (`app` and `app.x`) in a single update expression. Idempotent and
+    non-destructive (`if_not_exists`), so a race between two first saves is
+    harmless.'''
+    table.update_item(
+        Key={'user': user},
+        UpdateExpression='SET #app = if_not_exists(#app, :empty)',
+        ExpressionAttributeNames={'#app': 'app'},
+        ExpressionAttributeValues={':empty': {}},
+    )
+
+
 def handler(event, _context):
     '''Validates and merges the caller's preferences into their row.'''
     user = event['requestContext']['authorizer']['claims']['cognito:username']
@@ -138,27 +173,36 @@ def handler(event, _context):
             'statusCode': 400,
             'body': json.dumps({'Error': str(err)})
         }
-    # Merge rather than replace: clients save only the keys they own (the
-    # React app sends theme/accent/density, the Apple clients send name and the
-    # `app` map), so a put_item here would clobber the other client's
-    # preferences. The `app` map itself is replaced wholesale - the Apple client
-    # always sends its complete set, so concurrent multi-device edits are
-    # last-write-wins. Every key is aliased - `name` is a DynamoDB reserved word.
-    expression = ', '.join(f'#k{i} = :v{i}' for i in range(len(updates)))
-    names = {f'#k{i}': key for i, key in enumerate(updates)}
-    values = {f':v{i}': updates[key] for i, key in enumerate(updates)}
+    # Merge rather than replace, at BOTH levels. Top level: clients save only
+    # the keys they own (the React app sends theme/accent/density, the Apple
+    # clients send name and the `app` map), so a put_item here would clobber
+    # the other client's preferences. Inside `app`: each member merges
+    # individually (`app.x = :v`), so a client that predates a newer client's
+    # preference key cannot delete it by saving its own, older set -
+    # concurrent multi-device edits are last-write-wins per key. A replace
+    # here would let one stale device silently wipe every newer setting.
+    app = updates.pop('app', None)
+    sets, names, values = _build_expression(updates, app)
     try:
-        table.update_item(
-            Key={'user': user},
-            UpdateExpression=f'SET {expression}',
-            ExpressionAttributeNames=names,
-            ExpressionAttributeValues=values,
-        )
+        if app:
+            _ensure_app_map(user)
+        # `{"app": {}}` validates to an empty merge - nothing to write. (The
+        # old wholesale replace would have wiped the map here; there is no
+        # legitimate caller for that.)
+        if sets:
+            table.update_item(
+                Key={'user': user},
+                UpdateExpression='SET ' + ', '.join(sets),
+                ExpressionAttributeNames=names,
+                ExpressionAttributeValues=values,
+            )
     except Exception as err:  # pylint: disable=broad-exception-caught
         return {
             'statusCode': 500,
             'body': json.dumps({'Error': str(err)})
         }
+    if app is not None:
+        updates['app'] = app
     return {
         'statusCode': 200,
         'body': json.dumps(updates)


### PR DESCRIPTION
## Problem

`set_preferences` replaced the Apple clients' `app` map wholesale (`SET app = :v`). Because every Apple client pushes its complete *known* key set, the first client version to add a tenth preference key sets up a data-loss window: any settings edit from a device still on the nine-key version pushes a nine-key map and silently deletes the newer preference for every device. The same replace semantics would have bitten any future client family (Android) sharing the map. Flagged while reviewing cross-client preference interactions on #684.

## Fix

- The `app` member keys now merge individually via nested document paths (`SET #app.#a0 = :a0, ...`).
- Before a nested merge, the parent map is seeded with an idempotent `SET #app = if_not_exists(#app, :empty)` in a separate write — DynamoDB rejects nested paths under a missing map, and forbids overlapping paths (`app` and `app.x`) in a single expression. The seed is non-destructive, so races between first saves are harmless.
- `{"app": {}}` is now a validated no-op (200, no writes) instead of wiping the stored map — no legitimate caller ever wanted the wipe.
- Semantics are now last-write-wins **per key** for concurrent and cross-version edits; keys unknown to the saving client survive. Client behavior needs no change: full known-key pushes and the empty-string encoding for "no default From" (never key removal) work as before. Only the two Swift doc comments describing the wholesale replace are updated — hence the `no-changelog` label for the Apple-source touches; the user-facing note rides the server-side changelog fragment.

## Testing

- Stubbed-DynamoDB simulation of the handler: React-style flat save (single update, `app` untouched), Apple-style `app` save (seed + nested per-key SETs), combined body, empty-map no-op, unknown-key 400, bad-enum 400, no-keys 400 — all pass.
- pylint 10.00/10 on the changed function; swiftlint clean and CabalmailKit builds (comment-only Swift changes).
- No IAM changes: the function already calls `UpdateItem` on the same table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)