### PR TITLE
Fix app-layer move test broken by collapsed archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ Versioned subdirectories of `docs/` (e.g. `docs/0.4.0/`, `docs/0.7.0/`, `docs/0.
 
 ### Apple Clients (`apple/`)
 - Generate Xcode project: `cd apple && xcodegen generate` (regenerates `Cabalmail.xcodeproj` from `project.yml`; not committed)
-- Kit tests: `cd apple/CabalmailKit && swift test` (only automated coverage for the Apple side)
+- Kit tests: `cd apple/CabalmailKit && swift test` (the bulk of the Apple-side coverage — networking, parsing, caching, auth)
+- App-layer tests: `cd apple && xcodebuild test -workspace Cabalmail.xcworkspace -scheme CabalmailMac -destination 'platform=macOS' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` — XCTest suite for the app target's view models (`apple/CabalmailTests/`, e.g. bulk-selection/move flows against a `FakeImapClient`). `swift test` does **not** compile or run these, and `apple.yml` runs them only on push to a named branch, not on PRs — so run them locally before merging a change to a shared protocol (e.g. `ImapClient`) or a view model.
 - iOS build sanity check: `cd apple && xcodebuild -workspace Cabalmail.xcworkspace -scheme Cabalmail -destination 'generic/platform=iOS' build CODE_SIGNING_ALLOWED=NO`
 - CI: `apple.yml` builds and tests on a macOS runner; does not deploy anything to AWS
 
@@ -187,7 +188,7 @@ Native SwiftUI clients for iOS (iPhone/iPad), macOS, and visionOS. The Xcode pro
 
 - **`Cabalmail/`** — iOS/visionOS app target (views, view models, app shell)
 - **`CabalmailMac/`** — native macOS app target (not Catalyst)
-- **`CabalmailKit/`** — Swift package shared by both targets; holds all networking, parsing, caching, auth, and IMAP/SMTP code. The test suite (`swift test` from `apple/CabalmailKit/`) is the only automated coverage for the Apple clients.
+- **`CabalmailKit/`** — Swift package shared by both targets; holds all networking, parsing, caching, auth, and IMAP/SMTP code. Its `swift test` suite (from `apple/CabalmailKit/`) carries the bulk of the Apple-side coverage. The app targets add a smaller XCTest suite in `apple/CabalmailTests/` (run via the `CabalmailMac` scheme — see Build/Lint/Test Commands) for view-model logic; that one is **not** part of `swift test` and CI runs it only on push to a named branch.
 
 **Mail traffic goes through the Lambda API, not direct IMAP.** `CabalmailKit/CabalmailClient.live(...)` wires the production `imapClient` to `ApiBackedImapClient`, which adapts the React-shaped Lambda endpoints (`/list_folders`, `/list_envelopes`, `/fetch_message`, `/set_flag`, `/move_messages`, `/send`, etc.) onto the `ImapClient` protocol. Issue #371 captures the switch: the hand-rolled IMAP stack (`LiveImapClient`, `ImapConnection`, `NetworkByteStream`) proved unreliable across network transitions, sleep/wake, and provider quirks, while the React client had been running off the same Lambda surface since 0.2.0 with no such trouble. **Before debugging anything that looks like an IMAP-level issue in the Apple clients, confirm which `ImapClient` is wired up — `LiveImapClient` still compiles and has its own tests, but production paths don't use it.** Errors that say "cancelled" in the UI typically come from `URLError.cancelled` (URLSession data task), not the `CabalmailError.cancelled` enum case.
 

--- a/apple/CabalmailTests/BulkSelectionTests.swift
+++ b/apple/CabalmailTests/BulkSelectionTests.swift
@@ -186,6 +186,7 @@ final class BulkSelectionTests: XCTestCase {
         XCTAssertEqual(calls.count, 1)
         XCTAssertEqual(calls.first?.uids, [1, 2])
         XCTAssertEqual(calls.first?.destination, "Archive")
+        XCTAssertEqual(calls.first?.markSeen, false, "a plain move leaves read state alone")
     }
 
     func testMovePartialFailureRestoresOnlyFailedRows() async throws {
@@ -227,13 +228,11 @@ final class BulkSelectionTests: XCTestCase {
         XCTAssertNotNil(model.errorMessage)
     }
 
-    func testDisposeProceedsWhenSeenMarkingPartiallyFails() async throws {
-        // Dispose marks \Seen before the move (archived == read). A partial
-        // miss on that cosmetic step must not abort the move itself.
+    func testDisposeArchivesInOneMoveMarkingSeenServerSide() async throws {
+        // Archive == read, folded into the move: dispose issues a single
+        // `move` carrying `markSeen: true` (the server adds \Seen before
+        // relocating) rather than a separate STORE followed by a MOVE.
         let imap = FakeImapClient()
-        await imap.scriptFlagResults([
-            .failure(CabalmailError.bulkPartialFailure(succeeded: [1], failed: [2])),
-        ])
         let model = try TestFixtures.makeModel(
             imap: imap,
             envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
@@ -241,9 +240,12 @@ final class BulkSelectionTests: XCTestCase {
 
         await model.disposeMessages(uids: [1, 2], action: .archive)
 
-        XCTAssertTrue(model.envelopes.isEmpty, "the move ran despite the partial seen-marking")
+        XCTAssertTrue(model.envelopes.isEmpty)
+        let flags = await imap.flagCalls
+        XCTAssertTrue(flags.isEmpty, "no separate seen-marking round trip")
         let moves = await imap.moveCalls
         XCTAssertEqual(moves.count, 1)
         XCTAssertEqual(moves.first?.uids, [1, 2])
+        XCTAssertEqual(moves.first?.markSeen, true)
     }
 }

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -24,6 +24,7 @@ actor FakeImapClient: ImapClient {
         let folder: String
         let uids: Set<UInt32>
         let destination: String
+        let markSeen: Bool
     }
 
     private(set) var flagCalls: [FlagCall] = []
@@ -55,9 +56,9 @@ actor FakeImapClient: ImapClient {
         }
     }
 
-    func move(folder: String, uids: [UInt32], destination: String) async throws {
+    func move(folder: String, uids: [UInt32], destination: String, markSeen: Bool) async throws {
         moveCalls.append(MoveCall(
-            folder: folder, uids: Set(uids), destination: destination
+            folder: folder, uids: Set(uids), destination: destination, markSeen: markSeen
         ))
         if !moveResults.isEmpty {
             try moveResults.removeFirst().get()


### PR DESCRIPTION
## Problem

Build 425 (post-merge Apple build on `stage` from #686) failed at:

> Test CabalmailMac scheme (app-layer unit tests) → `type 'FakeImapClient' does not conform to protocol 'ImapClient'`

#686 changed the `ImapClient.move` requirement to `move(folder:uids:destination:markSeen:)`. The app-layer test double `FakeImapClient` (in `apple/CabalmailTests/`) still implemented the old 3-arg `move`, so it stopped conforming and the target failed to compile.

Why it slipped through: `apple.yml` runs the full build/test suite only on **push to a named branch**, not on PRs — the PR checks are just Lint + Apple-changelog. So the app-layer target was never compiled until after the merge landed on `stage`. (The Kit test target, which I did run locally, was fine — its own fake lives elsewhere and I'd missed the second conformer under `CabalmailTests/`.)

## Fix

- `FakeImapClient.move` adopts the 4-arg signature; `MoveCall` records `markSeen` so tests can assert it.
- Replaced `testDisposeProceedsWhenSeenMarkingPartiallyFails` — its premise (a separately-failable seen-marking STORE that the move proceeds past) no longer exists now that mark-seen is folded server-side — with `testDisposeArchivesInOneMoveMarkingSeenServerSide`, which locks in the collapse: archive issues **one** `move` with `markSeen: true` and **no** separate `setFlags`.
- Added a `markSeen: false` assertion to the plain-move success test.

## Testing

Ran the exact CI invocation locally:

```
xcodebuild test -workspace Cabalmail.xcworkspace -scheme CabalmailMac -destination 'platform=macOS' …
** TEST SUCCEEDED **   # BulkSelectionTests 12/12
```

Plus `scripts/build-apple.sh lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)