### PR TITLE
Attach TestFlight builds to internal groups explicitly from CI

### DIFF
--- a/.github/scripts/asc_api.py
+++ b/.github/scripts/asc_api.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Shared App Store Connect API helpers for CI scripts.
+
+Used by set-testflight-notes.py and assign-testflight-group.py, which run
+from an ephemeral venv in apple.yml's upload jobs (PyJWT + cryptography are
+installed at step time). Python resolves this module without any packaging
+because it sits next to the entry-point scripts: sys.path[0] is the
+directory of the script being run.
+
+Auth model: App Store Connect rejects JWTs whose exp is more than 20
+minutes out, and callers poll for longer than that, so every request mints
+a fresh token via a caller-supplied `token_factory` (usually a closure
+over `make_token`).
+"""
+
+import json
+import os
+import time
+import urllib.parse
+import urllib.request
+
+import jwt  # PyJWT, installed in the calling step's venv
+
+API_BASE = "https://api.appstoreconnect.apple.com"
+
+
+def warn(message):
+    """Emit a GitHub Actions warning annotation."""
+    print(f"::warning::{message}")
+
+
+def notice(message):
+    """Emit a GitHub Actions notice annotation."""
+    print(f"::notice::{message}")
+
+
+def error(message):
+    """Emit a GitHub Actions error annotation."""
+    print(f"::error::{message}")
+
+
+def require_env(name):
+    """Return env var `name` or raise with a clear message."""
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required environment variable {name}")
+    return value
+
+
+def make_token(key_id, issuer_id, private_key):
+    """Mint a short-lived ES256 JWT for the App Store Connect API."""
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": issuer_id,
+            "iat": now,
+            "exp": now + 1200,  # 20 minutes, ASC's maximum.
+            "aud": "appstoreconnect-v1",
+        },
+        private_key,
+        algorithm="ES256",
+        headers={"kid": key_id, "typ": "JWT"},
+    )
+
+
+def api_request(method, path, token_factory, body=None):
+    """Call the ASC API and return the parsed JSON (or None for 204).
+
+    `path` may be a full URL or a path relative to API_BASE. `token_factory`
+    is called per request so each call carries a fresh JWT.
+    """
+    url = path if path.startswith("http") else f"{API_BASE}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", f"Bearer {token_factory()}")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(request, timeout=60) as response:
+        raw = response.read()
+        return json.loads(raw) if raw else None
+
+
+def find_app_id(bundle_id, token_factory):
+    """Return the ASC app id for `bundle_id`, or None if not found."""
+    query = urllib.parse.urlencode({"filter[bundleId]": bundle_id, "limit": 1})
+    result = api_request("GET", f"/v1/apps?{query}", token_factory)
+    data = result.get("data") or []
+    return data[0]["id"] if data else None
+
+
+def find_build(app_id, build_number, token_factory):
+    """Return the build resource for `app_id` + CFBundleVersion, or None."""
+    query = urllib.parse.urlencode(
+        {
+            "filter[app]": app_id,
+            "filter[version]": build_number,
+            "limit": 1,
+        }
+    )
+    result = api_request("GET", f"/v1/builds?{query}", token_factory)
+    data = result.get("data") or []
+    return data[0] if data else None

--- a/.github/scripts/assign-testflight-group.py
+++ b/.github/scripts/assign-testflight-group.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+#
+# Attach a freshly-uploaded build to a TestFlight internal test group.
+#
+# apple.yml's upload jobs run this right after `altool --upload-app`.
+# Distribution used to rely on App Store Connect's "automatic distribution"
+# group setting, which fires exactly once per build (when processing
+# finishes) and never retries: a misfire leaves the build fully processed
+# but attached to no group — invisible to testers and to CI, which had
+# already gone green at upload time. A run of consecutive macOS builds
+# once vanished exactly that way. This script makes distribution
+# deterministic and branch-aware instead: each build is attached to the
+# internal group named by TF_GROUP (stage pushes -> "stage", main ->
+# "prod"), and a build that cannot be attached fails the step loudly
+# rather than silently never reaching testers. Automatic distribution
+# should be switched OFF on the groups once this is in place — leaving it
+# on re-adds every build to every group and the branch routing means
+# nothing (see docs/apple.md).
+#
+# Attachment is attempted as soon as the build resource surfaces in the
+# API, which is usually minutes before processing completes. If App Store
+# Connect refuses while the build is still processing, the script keeps
+# polling and retrying until the build turns VALID (at which point a
+# refusal is terminal) or the timeout lapses.
+#
+# Required env:
+#   ASC_KEY_ID        App Store Connect API key id (the AuthKey_<id>.p8 id)
+#   ASC_ISSUER_ID     App Store Connect API issuer id
+#   ASC_KEY_PATH      Path to the decoded .p8 private key
+#   BUNDLE_ID         App bundle id (e.g. com.cabalmail.Cabalmail)
+#   BUILD_NUMBER      CFBundleVersion of the uploaded build
+#   TF_GROUP          Name of the internal test group to attach to
+# Optional env:
+#   ASC_POLL_TIMEOUT  Seconds to wait overall (default 1200)
+#   ASC_POLL_INTERVAL Seconds between attempts (default 30)
+
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+
+from asc_api import (
+    api_request,
+    error,
+    find_app_id,
+    find_build,
+    make_token,
+    notice,
+    require_env,
+)
+
+
+def find_group_id(app_id, group_name, token_factory):
+    """Return the betaGroups id for `group_name` within `app_id`, or None."""
+    query = urllib.parse.urlencode(
+        {"filter[app]": app_id, "filter[name]": group_name, "limit": 5}
+    )
+    result = api_request("GET", f"/v1/betaGroups?{query}", token_factory)
+    for group in result.get("data") or []:
+        # filter[name] is documented as exact-match; verify anyway so a
+        # surprise substring match can't route builds to the wrong group.
+        if group.get("attributes", {}).get("name") == group_name:
+            return group["id"]
+    return None
+
+
+def attach(group_id, build_id, token_factory):
+    """Add `build_id` to `group_id`; raises urllib.error.HTTPError on refusal.
+
+    Adding a build that is already in the group is a no-op success, so
+    retrying after a lost response is safe.
+    """
+    api_request(
+        "POST",
+        f"/v1/betaGroups/{group_id}/relationships/builds",
+        token_factory,
+        body={"data": [{"type": "builds", "id": build_id}]},
+    )
+
+
+def main():
+    key_id = require_env("ASC_KEY_ID")
+    issuer_id = require_env("ASC_ISSUER_ID")
+    key_path = require_env("ASC_KEY_PATH")
+    bundle_id = require_env("BUNDLE_ID")
+    build_number = require_env("BUILD_NUMBER")
+    group_name = require_env("TF_GROUP")
+    timeout = int(os.environ.get("ASC_POLL_TIMEOUT", "1200"))
+    interval = int(os.environ.get("ASC_POLL_INTERVAL", "30"))
+
+    with open(key_path, encoding="utf-8") as handle:
+        private_key = handle.read()
+
+    def token_factory():
+        return make_token(key_id, issuer_id, private_key)
+
+    app_id = find_app_id(bundle_id, token_factory)
+    if app_id is None:
+        error(f"No App Store Connect app found for bundle id {bundle_id}.")
+        return 1
+    group_id = find_group_id(app_id, group_name, token_factory)
+    if group_id is None:
+        error(
+            f"No test group named {group_name!r} on app {bundle_id}. Create it "
+            "in App Store Connect -> TestFlight -> Internal Testing, or attach "
+            f"build {build_number} by hand."
+        )
+        return 1
+    print(f"Attaching build {build_number} of {bundle_id} to group {group_name!r}...")
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        build = find_build(app_id, build_number, token_factory)
+        if build is None:
+            # Upload accepted but the build resource hasn't surfaced yet.
+            time.sleep(interval)
+            continue
+        state = build.get("attributes", {}).get("processingState")
+        if state in ("FAILED", "INVALID"):
+            error(f"Build {build_number} processing state is {state}; cannot attach.")
+            return 1
+        try:
+            attach(group_id, build["id"], token_factory)
+        except urllib.error.HTTPError as err:
+            detail = ""
+            try:
+                detail = err.read().decode()
+            except Exception:  # pylint: disable=broad-except
+                pass
+            if state == "VALID":
+                # Fully processed and still refused: terminal.
+                error(
+                    f"Could not attach build {build_number} to {group_name!r}: "
+                    f"HTTP {err.code} {detail or err.reason}"
+                )
+                return 1
+            print(
+                f"Attach refused while processingState={state} "
+                f"(HTTP {err.code}); retrying in {interval}s."
+            )
+            time.sleep(interval)
+            continue
+        notice(
+            f"Attached build {build_number} to group {group_name!r} "
+            f"(processingState {state})."
+        )
+        return 0
+    error(
+        f"Build {build_number} was not attached to {group_name!r} within "
+        f"{timeout}s. Attach it manually: App Store Connect -> TestFlight -> "
+        f"{group_name} -> Builds -> +."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/set-testflight-notes.py
+++ b/.github/scripts/set-testflight-notes.py
@@ -32,7 +32,7 @@
 # a prod release red. The only thing lost on failure is the notes text, which
 # can be set by hand in App Store Connect.
 #
-# Flow:
+# Flow (ASC plumbing shared with assign-testflight-group.py via asc_api.py):
 #   1. Mint an ES256 JWT from the .p8 key already installed at $ASC_KEY_PATH.
 #      A fresh token is minted per request so polling can outlast the 20-minute
 #      token lifetime ASC enforces.
@@ -55,18 +55,23 @@
 #   ASC_POLL_TIMEOUT  Seconds to wait for processing (default 1200)
 #   ASC_POLL_INTERVAL Seconds between polls (default 30)
 
-import json
 import os
 import re
 import sys
 import time
 import urllib.error
 import urllib.parse
-import urllib.request
 
-import jwt  # PyJWT, installed in the calling step's venv
+from asc_api import (
+    api_request,
+    find_app_id,
+    find_build,
+    make_token,
+    notice,
+    require_env,
+    warn,
+)
 
-API_BASE = "https://api.appstoreconnect.apple.com"
 WHATS_NEW_MAX = 4000  # App Store Connect's hard cap on the field.
 
 # Changelog bullets meant for Apple-client testers are prefixed `Apple:`.
@@ -74,61 +79,6 @@ APPLE_PREFIX = re.compile(r"^Apple:\s*")
 # Shown when a release carries no Apple-scoped entries, so the field is never
 # blank for testers.
 FALLBACK_NOTES = "Bug fixes and behind-the-scenes improvements."
-
-
-def warn(message):
-    """Emit a GitHub Actions warning annotation."""
-    print(f"::warning::{message}")
-
-
-def notice(message):
-    """Emit a GitHub Actions notice annotation."""
-    print(f"::notice::{message}")
-
-
-def require_env(name):
-    """Return env var `name` or raise with a clear message."""
-    value = os.environ.get(name, "").strip()
-    if not value:
-        raise RuntimeError(f"missing required environment variable {name}")
-    return value
-
-
-def make_token(key_id, issuer_id, private_key):
-    """Mint a short-lived ES256 JWT for the App Store Connect API.
-
-    A new token per request keeps polling correct: ASC rejects tokens whose
-    exp is more than 20 minutes out, and processing can outlast that.
-    """
-    now = int(time.time())
-    return jwt.encode(
-        {
-            "iss": issuer_id,
-            "iat": now,
-            "exp": now + 1200,  # 20 minutes, ASC's maximum.
-            "aud": "appstoreconnect-v1",
-        },
-        private_key,
-        algorithm="ES256",
-        headers={"kid": key_id, "typ": "JWT"},
-    )
-
-
-def api_request(method, path, token_factory, body=None):
-    """Call the ASC API and return the parsed JSON (or None for 204).
-
-    `path` may be a full URL or a path relative to API_BASE. `token_factory`
-    is called per request so each call carries a fresh JWT.
-    """
-    url = path if path.startswith("http") else f"{API_BASE}{path}"
-    data = json.dumps(body).encode() if body is not None else None
-    request = urllib.request.Request(url, data=data, method=method)
-    request.add_header("Authorization", f"Bearer {token_factory()}")
-    if data is not None:
-        request.add_header("Content-Type", "application/json")
-    with urllib.request.urlopen(request, timeout=60) as response:
-        raw = response.read()
-        return json.loads(raw) if raw else None
 
 
 def flatten_changelog(changelog_path):
@@ -232,28 +182,6 @@ def flatten_changelog(changelog_path):
         text = clipped + marker
         warn(f"Notes exceeded {WHATS_NEW_MAX} chars; truncated for App Store Connect.")
     return text
-
-
-def find_app_id(bundle_id, token_factory):
-    """Return the ASC app id for `bundle_id`, or None if not found."""
-    query = urllib.parse.urlencode({"filter[bundleId]": bundle_id, "limit": 1})
-    result = api_request("GET", f"/v1/apps?{query}", token_factory)
-    data = result.get("data") or []
-    return data[0]["id"] if data else None
-
-
-def find_build(app_id, build_number, token_factory):
-    """Return the build resource for `app_id` + CFBundleVersion, or None."""
-    query = urllib.parse.urlencode(
-        {
-            "filter[app]": app_id,
-            "filter[version]": build_number,
-            "limit": 1,
-        }
-    )
-    result = api_request("GET", f"/v1/builds?{query}", token_factory)
-    data = result.get("data") or []
-    return data[0] if data else None
 
 
 def wait_for_build(app_id, build_number, token_factory, timeout, interval):

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -679,6 +679,32 @@ jobs:
             echo "- Track: App Store Connect → Cabalmail → TestFlight"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Assign build to TestFlight group
+        # Deterministic distribution: attach this build to the internal
+        # test group matching the branch instead of relying on App Store
+        # Connect's automatic distribution, which fires once per build and
+        # never retries — a misfire strands a fully-processed build outside
+        # every group with CI already green. Requires groups named exactly
+        # `stage` and `prod` on the app record, with automatic distribution
+        # switched off (see docs/apple.md). Fails the step if the build
+        # can't be attached, so a stranded build is visible for once.
+        if: steps.check.outputs.enabled == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          BUNDLE_ID: com.cabalmail.Cabalmail
+          TF_GROUP: ${{ github.ref_name == 'main' && 'prod' || 'stage' }}
+        run: |
+          set -euo pipefail
+          # Isolated venv: the runner's Homebrew python is externally
+          # managed (PEP 668), so a bare `pip install` is refused. The
+          # notes step below reuses the venv when it runs.
+          if [ ! -d "$RUNNER_TEMP/ascvenv" ]; then
+            python3 -m venv "$RUNNER_TEMP/ascvenv"
+            "$RUNNER_TEMP/ascvenv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          fi
+          "$RUNNER_TEMP/ascvenv/bin/python" "$GITHUB_WORKSPACE/.github/scripts/assign-testflight-group.py"
+
       - name: Set TestFlight "What to Test" notes (prod only)
         # Prod releases only - the stage track is the developer's own and
         # ships no notes. Best-effort: the binary is already uploaded, so the
@@ -694,10 +720,12 @@ jobs:
           CHANGELOG_PATH: ${{ github.workspace }}/CHANGELOG.md
         run: |
           set -euo pipefail
-          # Isolated venv: the runner's Homebrew python is externally managed
-          # (PEP 668), so a bare `pip install` is refused.
-          python3 -m venv "$RUNNER_TEMP/ascvenv"
-          "$RUNNER_TEMP/ascvenv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          # The venv usually exists already (group-assignment step above);
+          # create it only if that step was skipped.
+          if [ ! -d "$RUNNER_TEMP/ascvenv" ]; then
+            python3 -m venv "$RUNNER_TEMP/ascvenv"
+            "$RUNNER_TEMP/ascvenv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          fi
           "$RUNNER_TEMP/ascvenv/bin/python" "$GITHUB_WORKSPACE/.github/scripts/set-testflight-notes.py"
 
       - name: Clean up keychain and API key
@@ -1124,8 +1152,29 @@ jobs:
           path: ${{ env.NOTARIZED_ZIP }}
           retention-days: 30
 
-      # Best-effort, so it runs last - after the notarized artifact is produced
-      # - and never blocks it on the up-to-20-minute processing poll.
+      # The ASC-polling steps run last - after the notarized artifact is
+      # produced - so an up-to-20-minute processing poll never blocks it.
+      - name: Assign build to TestFlight group
+        # See the iOS job for rationale. Unlike the notes step this is NOT
+        # best-effort: a build that can't be attached never reaches testers,
+        # so the failure must be visible.
+        if: steps.check.outputs.enabled == 'true'
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          BUNDLE_ID: com.cabalmail.CabalmailMac
+          TF_GROUP: ${{ github.ref_name == 'main' && 'prod' || 'stage' }}
+        run: |
+          set -euo pipefail
+          # Isolated venv: the runner's Homebrew python is externally
+          # managed (PEP 668), so a bare `pip install` is refused. The
+          # notes step below reuses the venv when it runs.
+          if [ ! -d "$RUNNER_TEMP/ascvenv" ]; then
+            python3 -m venv "$RUNNER_TEMP/ascvenv"
+            "$RUNNER_TEMP/ascvenv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          fi
+          "$RUNNER_TEMP/ascvenv/bin/python" "$GITHUB_WORKSPACE/.github/scripts/assign-testflight-group.py"
+
       - name: Set TestFlight "What to Test" notes (prod only)
         # Prod releases only. Best-effort - see the iOS job for rationale.
         if: github.ref_name == 'main' && steps.check.outputs.enabled == 'true'
@@ -1136,8 +1185,12 @@ jobs:
           CHANGELOG_PATH: ${{ github.workspace }}/CHANGELOG.md
         run: |
           set -euo pipefail
-          python3 -m venv "$RUNNER_TEMP/ascvenv"
-          "$RUNNER_TEMP/ascvenv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          # The venv usually exists already (group-assignment step above);
+          # create it only if that step was skipped.
+          if [ ! -d "$RUNNER_TEMP/ascvenv" ]; then
+            python3 -m venv "$RUNNER_TEMP/ascvenv"
+            "$RUNNER_TEMP/ascvenv/bin/pip" install --quiet --disable-pip-version-check pyjwt cryptography
+          fi
           "$RUNNER_TEMP/ascvenv/bin/python" "$GITHUB_WORKSPACE/.github/scripts/set-testflight-notes.py"
 
       - name: Clean up keychain and API key

--- a/changelog.d/testflight-group-assignment.added.md
+++ b/changelog.d/testflight-group-assignment.added.md
@@ -1,0 +1,7 @@
+- **Deterministic TestFlight distribution.** The Apple upload jobs now
+  attach every uploaded build to the internal test group matching its
+  branch (`stage` pushes → the `stage` group, `main` → `prod`) via the
+  App Store Connect API, instead of relying on App Store Connect's
+  fire-once automatic distribution, and fail the job when a build cannot
+  be attached. Requires internal groups named `stage` and `prod` on each
+  app record, with automatic distribution switched off.

--- a/docs/apple.md
+++ b/docs/apple.md
@@ -247,15 +247,22 @@ are expanded in the sections further down.
      Testing** → **+**.
    - Add your Apple ID (with an App Store Connect role) as a tester to
      the groups you want builds offered on.
-   - Leave **automatic distribution off** on both groups. CI attaches
-     each uploaded build to the group matching its branch (`stage`
-     pushes → `stage`, `main` → `prod`) via the App Store Connect API
-     (`assign-testflight-group.py`), and fails the upload job if the
-     attach doesn't succeed. Automatic distribution would re-add every
-     build to every group, erasing the branch routing — and it fires
-     only once per build with no retry, so a missed build strands
-     silently. The explicit attach exists to replace it, not to
-     supplement it.
+   - Leave **"Enable automatic distribution" unchecked** in the
+     creation dialog. CI attaches each uploaded build to the group
+     matching its branch (`stage` pushes → `stage`, `main` → `prod`)
+     via the App Store Connect API (`assign-testflight-group.py`), and
+     fails the upload job if the attach doesn't succeed. Automatic
+     distribution would give every group every build, erasing the
+     branch routing — and the API refuses explicit attaches to such
+     groups, so the assign step would fail. The explicit attach exists
+     to replace it, not to supplement it.
+   - The distribution mode is **immutable after creation** — the
+     checkbox exists only in the create dialog, and the group Settings
+     tab merely displays the resulting "Build Distribution" state. To
+     convert an existing automatic group: rename it aside (Settings →
+     Edit Name), create a fresh group under the canonical name with the
+     checkbox unchecked, re-add the testers, attach the latest build by
+     hand so access continues, then delete the renamed group.
    - Install the **TestFlight** app on the target device, sign in, and
      accept the invite.
 

--- a/docs/apple.md
+++ b/docs/apple.md
@@ -239,16 +239,23 @@ are expanded in the sections further down.
    aren't attached to anything visible and you cannot distribute the
    build.
 8. **Populate the GitHub secrets** listed in the next section.
-9. **Populate TestFlight when you want to install a build.** CI uploads
-   succeed without any TestFlight setup — builds land in each app
-   record's Builds list after ~5–30 minutes of Apple-side processing.
-   Before anyone (including you) can install one, you need a testing
-   group to attach it to:
+9. **Create the TestFlight internal groups CI distributes to.** On
+   **each** app record (iOS and macOS), create two internal testing
+   groups named exactly **`stage`** and **`prod`** (lowercase — the
+   upload jobs look the group up by name):
    - App Store Connect → your app → **TestFlight** tab → **Internal
-     Testing** → **+** to create a group (e.g. `Stage`, `Prod`).
-   - Add your Apple ID (with an App Store Connect role) as a tester.
-   - Attach the build manually the first time, or enable automatic
-     distribution on the group for future uploads.
+     Testing** → **+**.
+   - Add your Apple ID (with an App Store Connect role) as a tester to
+     the groups you want builds offered on.
+   - Leave **automatic distribution off** on both groups. CI attaches
+     each uploaded build to the group matching its branch (`stage`
+     pushes → `stage`, `main` → `prod`) via the App Store Connect API
+     (`assign-testflight-group.py`), and fails the upload job if the
+     attach doesn't succeed. Automatic distribution would re-add every
+     build to every group, erasing the branch routing — and it fires
+     only once per build with no retry, so a missed build strands
+     silently. The explicit attach exists to replace it, not to
+     supplement it.
    - Install the **TestFlight** app on the target device, sign in, and
      accept the invite.
 
@@ -545,8 +552,8 @@ TestFlight upload and skips the notarization steps.
 |---|---|---|
 | `kit-test` | Any push touching `apple/**` or the workflow file | SwiftLint + `xcodebuild test` on CabalmailKit across macOS / iOS / visionOS destinations |
 | `app-build` | Same | Unsigned `xcodebuild build` for `Cabalmail` (iOS) and `CabalmailMac` (macOS) |
-| `upload-ios` | Pushes to `main` or `stage`, with the seven signing secrets configured | Manual-signed archive → TestFlight upload |
-| `upload-mac` | Same | Manual-signed App Store `.pkg` → TestFlight upload, plus (optional) a Developer ID export → `notarytool submit --wait` → `stapler staple` → uploaded as a workflow artifact |
+| `upload-ios` | Pushes to `main` or `stage`, with the seven signing secrets configured | Manual-signed archive → TestFlight upload → attach to the branch's internal test group |
+| `upload-mac` | Same | Manual-signed App Store `.pkg` → TestFlight upload, plus (optional) a Developer ID export → `notarytool submit --wait` → `stapler staple` → uploaded as a workflow artifact → attach to the branch's internal test group |
 
 `upload-ios` gracefully no-ops (with a workflow warning) when its
 required secrets are missing. `upload-mac` fails the workflow in the
@@ -568,19 +575,23 @@ and `CabalmailKit/Package.swift`.
 ## Installing a build from TestFlight
 
 After a successful CI upload and App Store Connect processing (5–30 min),
-the build appears in your app's **Builds** list. First-time attach:
+the build appears in your app's **Builds** list, and the upload job
+attaches it to the internal group matching the branch it was built from
+(`stage` pushes → the `stage` group, `main` → `prod`) — see the group
+setup in [Apple Developer account setup](#apple-developer-account-setup).
+To install one:
 
-1. App Store Connect → your app → **TestFlight** tab → pick the `Stage`
-   or `Prod` internal group → **Builds** section → **+** → attach the
-   just-processed build. Toggle **Automatically distribute builds** on
-   the group if you want future uploads attached without clicking.
-2. On your device, install the **TestFlight** app from the App Store.
-3. Sign in with the Apple ID that is a member of the group and accept
+1. On your device, install the **TestFlight** app from the App Store.
+2. Sign in with the Apple ID that is a member of the group and accept
    the invite from the TestFlight inbox. The build installs like any
    App Store app, with a small yellow dot marking it as a beta.
 
 macOS follows the same flow using the macOS TestFlight app (install
-from the Mac App Store).
+from the Mac App Store). If a build you expected never shows up, check
+the upload job's **Assign build to TestFlight group** step — it fails
+(with the build number in the error) when the build could not be
+attached, and the fallback is attaching that build by hand from the
+group's **Builds** tab.
 
 ## Setting Cabalmail as the default mail handler
 


### PR DESCRIPTION
## Why

App Store Connect's "automatic distribution" toggle fires exactly once per build (when processing finishes) and never retries. On 2026-07-17 it misfired for three consecutive macOS stage uploads (0.11.4 builds 1784297262, 1784297737, 1784307494): all three processed to Complete but were attached to no test group, invisible to testers, with CI green the whole time — the workflow's only ASC polling (the "What to Test" notes step) runs on `main` only.

## What

- **`.github/scripts/assign-testflight-group.py`** (new): attaches an uploaded build to the internal test group named by `TF_GROUP` via `POST /v1/betaGroups/{id}/relationships/builds`. Tries as soon as the build resource surfaces (usually mid-processing), retries while the build is still processing, and fails hard — with the build number and a manual-attach pointer — if the build never attaches within the poll timeout. Not best-effort by design: an unattached build never reaches testers.
- **`.github/workflows/apple.yml`**: new "Assign build to TestFlight group" step on all three upload legs (iOS, visionOS, macOS), routing `stage` pushes → the `stage` group and `main` → `prod`. On the mac job it runs after the notarized-artifact steps so the poll can't delay the artifact. The ASC venv is now created once and shared with the notes step.
- **`.github/scripts/asc_api.py`** (new): the JWT/api_request/app-and-build-lookup plumbing factored out of `set-testflight-notes.py`, now shared by both scripts.
- **`docs/apple.md`**: group setup instructions (groups named exactly `stage` and `prod`, created **without** automatic distribution) and updated install/troubleshooting flow.

## Operator steps BEFORE merge

The distribution mode of an internal group is immutable after creation (the "Enable automatic distribution" checkbox exists only in the create dialog; the API's `hasAccessToAllBuilds` is create-only), and the API refuses explicit build attaches to automatic groups — so the existing groups must be **recreated as manual** before this lands, or the new step fails its first run. Per app record (Cabalmail iOS and Cabalmail Mac):

1. Rename the existing group aside (`stage` → `stage-old`).
2. Create a new internal group named exactly `stage` with "Enable automatic distribution" **unchecked**.
3. Re-add the testers.
4. Manually attach the current latest build so access continues.
5. Delete `stage-old`.
6. Repeat for `prod`.

## Testing

- Python syntax + import-usage check on all three scripts.
- `actionlint` on `apple.yml`: no new findings (remaining warnings pre-date this change).
- Real ASC round-trip happens on the first push to stage after merge — the new step's annotations will show the attach result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)