### PR TITLE
Downgrade the known ASC mac-attach defect to a warning

### DIFF
--- a/.github/scripts/assign-testflight-group.py
+++ b/.github/scripts/assign-testflight-group.py
@@ -50,7 +50,21 @@ from asc_api import (
     make_token,
     notice,
     require_env,
+    warn,
 )
+
+# A known App Store Connect defect (observed 2026-07-17 on the Mac app
+# record, Apple support case pending): the build<->betaGroups relationship
+# service 404s the build id ("no resource of type 'builds'") even though
+# GET /v1/builds returns the same id as VALID, in both relationship
+# directions - and the ASC web UI's "Test a Build" dialog is equally
+# unable to select the build, so no attach path exists at all. When that
+# exact signature repeats this many times on a VALID build, the step
+# downgrades to a warning instead of burning the full poll window and
+# failing a release CI can do nothing about. Every other error keeps the
+# fail-loudly behavior, and once Apple fixes the service the attach
+# simply succeeds before the threshold is reached.
+KNOWN_DEFECT_ATTEMPTS = 10
 
 
 def find_group_id(app_id, group_name, token_factory):
@@ -126,6 +140,7 @@ def main():
 
     deadline = time.time() + timeout
     last_refusal = ""
+    defect_hits = 0
     while time.time() < deadline:
         build = find_build(app_id, build_number, token_factory)
         if build is None:
@@ -145,10 +160,24 @@ def main():
             except Exception:  # pylint: disable=broad-except
                 pass
             # ASC refuses attachment while the build is still processing,
-            # and is eventually consistent even afterwards (the TestFlight
-            # side once 404'd a build id /v1/builds was already reporting
-            # as VALID). No refusal is terminal; retry until the deadline.
+            # and is eventually consistent even afterwards. No refusal is
+            # terminal on its own; retry until the deadline - except the
+            # known-defect signature, which caps out early (see
+            # KNOWN_DEFECT_ATTEMPTS above).
             last_refusal = f"HTTP {err.code} {detail or err.reason}"
+            if err.code == 404 and state == "VALID" and "type 'builds'" in detail:
+                defect_hits += 1
+                if defect_hits >= KNOWN_DEFECT_ATTEMPTS:
+                    warn(
+                        f"Build {build_number} is VALID but App Store Connect "
+                        f"404s it on every group-attach path ({defect_hits} "
+                        "attempts) - the known ASC-side attach defect. Not "
+                        f"failing the job; attach to {group_name!r} manually "
+                        "once Apple resolves it."
+                    )
+                    return 0
+            else:
+                defect_hits = 0
             print(
                 f"Attach refused (processingState={state}): {last_refusal}; "
                 f"retrying in {interval}s."

--- a/changelog.d/testflight-group-assignment.added.md
+++ b/changelog.d/testflight-group-assignment.added.md
@@ -3,5 +3,7 @@
   branch (`stage` pushes → the `stage` group, `main` → `prod`) via the
   App Store Connect API, instead of relying on App Store Connect's
   fire-once automatic distribution, and fail the job when a build cannot
-  be attached. Requires internal groups named `stage` and `prod` on each
-  app record, with automatic distribution switched off.
+  be attached (downgraded to a warning for one known App Store Connect
+  server-side defect that leaves no attach path at all). Requires
+  internal groups named `stage` and `prod` on each app record, with
+  automatic distribution switched off.


### PR DESCRIPTION
Follow-up to #691. Diagnosis is complete: the Mac app record cannot attach builds to TestFlight internal groups by **any** path — automatic distribution (stopped silently 2026-07-17, the original incident), the public API (404 `no resource of type 'builds'` in both relationship directions for a build `GET /v1/builds` simultaneously returns as VALID), and the ASC web UI ("Test a Build" lists the builds but rows are unselectable; reproduced in private windows and with a brand-new throwaway group; no JS errors). The iOS app record works throughout — iOS and visionOS attach cleanly since #691.

This is Apple's defect to fix. Until then, the assign step recognizes the exact signature — 404 blaming the build id while the build polls VALID — and after 10 consecutive hits (~5 min) emits a `::warning` and exits 0, instead of holding the mac leg for the full 40-minute window and failing a job CI can do nothing about. Every other error still fails loudly. When Apple repairs the service, attaches succeed on the first try and the threshold never engages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)