### PR TITLE
Delayed-readiness warn-downgrade + CI warning-noise cleanup

### DIFF
--- a/.github/scripts/assign-testflight-group.py
+++ b/.github/scripts/assign-testflight-group.py
@@ -53,17 +53,23 @@ from asc_api import (
     warn,
 )
 
-# A known App Store Connect defect (observed 2026-07-17 on the Mac app
-# record, Apple support case pending): the build<->betaGroups relationship
-# service 404s the build id ("no resource of type 'builds'") even though
-# GET /v1/builds returns the same id as VALID, in both relationship
-# directions - and the ASC web UI's "Test a Build" dialog is equally
-# unable to select the build, so no attach path exists at all. When that
-# exact signature repeats this many times on a VALID build, the step
-# downgrades to a warning instead of burning the full poll window and
-# failing a release CI can do nothing about. Every other error keeps the
-# fail-loudly behavior, and once Apple fixes the service the attach
-# simply succeeds before the threshold is reached.
+# A known App Store Connect defect (observed since 2026-07-17, Apple
+# support case pending): builds can take 10+ hours - previously minutes -
+# to reach the hidden "Ready to Test" state that gates ALL distribution.
+# Until a build ripens, no attach path exists anywhere: the ASC web UI's
+# "Test a Build" dialog lists the build but cannot select it, and the API
+# either 404s the build id on both relationship directions ("no resource
+# of type 'builds'", even though GET /v1/builds reports it VALID - the
+# usual macOS shape) or doesn't surface the build in /v1/builds at all
+# (seen on iOS). The delay varies per build; macOS has been consistently
+# at the long end. When the 404-on-VALID signature repeats this many
+# times, the step downgrades to a warning instead of burning the full
+# poll window and failing a release CI can do nothing about - and a poll
+# that times out with the build never surfacing gets the same downgrade,
+# since altool has already verified the upload by then. Genuine failures
+# (FAILED/INVALID processing, missing group, any other persistent
+# refusal) still fail loudly, and for builds that ripen in time the
+# attach simply succeeds and none of this engages.
 KNOWN_DEFECT_ATTEMPTS = 10
 
 
@@ -171,9 +177,10 @@ def main():
                     warn(
                         f"Build {build_number} is VALID but App Store Connect "
                         f"404s it on every group-attach path ({defect_hits} "
-                        "attempts) - the known ASC-side attach defect. Not "
+                        "attempts) - the known delayed-readiness defect. Not "
                         f"failing the job; attach to {group_name!r} manually "
-                        "once Apple resolves it."
+                        'once the build reaches "Ready to Test" (hours, '
+                        "currently), or let the next push supersede it."
                     )
                     return 0
             else:
@@ -189,14 +196,24 @@ def main():
             f"(processingState {state})."
         )
         return 0
-    error(
-        f"Build {build_number} was not attached to {group_name!r} within "
-        f"{timeout}s. Last refusal: "
-        f"{last_refusal or 'the build never surfaced in the API'}. Attach it "
-        f"manually: App Store Connect -> TestFlight -> {group_name} -> "
-        "Builds -> +."
+    if last_refusal:
+        error(
+            f"Build {build_number} was not attached to {group_name!r} within "
+            f"{timeout}s. Last refusal: {last_refusal}. Attach it manually: "
+            f"App Store Connect -> TestFlight -> {group_name} -> Builds -> +."
+        )
+        return 1
+    # Never surfaced in /v1/builds at all. altool verified the upload
+    # before this step ran, so this is the delayed-readiness defect
+    # manifesting one API layer earlier (the iOS shape) - same downgrade.
+    warn(
+        f"Build {build_number} has not surfaced in the App Store Connect API "
+        f"after {timeout}s despite a verified upload - the known "
+        "delayed-readiness defect. Not failing the job; attach to "
+        f"{group_name!r} manually once it reaches \"Ready to Test\", or let "
+        "the next push supersede it."
     )
-    return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -70,7 +70,13 @@ jobs:
         # already installed...` line that GitHub surfaces as a workflow
         # annotation. Filter to packages that aren't installed yet so the
         # step stays silent when there's nothing to do.
+        #
+        # The image also preinstalls the third-party aws/tap, which we
+        # never use; newer Homebrew distrusts it and emits a "taps are not
+        # trusted" warning annotation on every brew invocation. Untap it
+        # first (silently - the untap itself would warn too).
         run: |
+          brew untap aws/tap >/dev/null 2>&1 || true
           for pkg in xcodegen swiftlint xcbeautify; do
             brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
           done
@@ -193,6 +199,7 @@ jobs:
 
       - name: Install XcodeGen + xcbeautify
         run: |
+          brew untap aws/tap >/dev/null 2>&1 || true
           for pkg in xcodegen xcbeautify; do
             brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
           done
@@ -288,6 +295,7 @@ jobs:
       - name: Install XcodeGen + xcbeautify
         # See the kit-test job for the rationale on the per-package check.
         run: |
+          brew untap aws/tap >/dev/null 2>&1 || true
           for pkg in xcodegen xcbeautify; do
             brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
           done
@@ -425,6 +433,7 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         # See the kit-test job for the rationale on the per-package check.
         run: |
+          brew untap aws/tap >/dev/null 2>&1 || true
           for pkg in xcodegen xcbeautify; do
             brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
           done
@@ -806,6 +815,7 @@ jobs:
         if: steps.check.outputs.enabled == 'true'
         # See the kit-test job for the rationale on the per-package check.
         run: |
+          brew untap aws/tap >/dev/null 2>&1 || true
           for pkg in xcodegen xcbeautify; do
             brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
           done

--- a/apple/Cabalmail/Views/HTMLBodyView.swift
+++ b/apple/Cabalmail/Views/HTMLBodyView.swift
@@ -312,7 +312,11 @@ final class HTMLBodyCoordinator: NSObject, WKNavigationDelegate {
         webView.evaluateJavaScript(script, completionHandler: nil)
         Task { [weak webView] in
             try? await Task.sleep(for: .milliseconds(400))
-            webView?.evaluateJavaScript(script, completionHandler: nil)
+            // Deliberately NOT the async evaluateJavaScript variant: the
+            // restore script's IIFE returns undefined and the async
+            // refinement traps on nil results. The sync closure keeps the
+            // nil-safe completion-handler API out of the async context.
+            await MainActor.run { webView?.evaluateJavaScript(script, completionHandler: nil) }
         }
     }
 

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/ContactsStoreTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/ContactsStoreTests.swift
@@ -7,7 +7,10 @@ final class ContactsStoreTests: XCTestCase {
     // MARK: - NoopContactsStore
 
     func testNoopReturnsDenied() async {
-        let store = NoopContactsStore()
+        // Typed as the protocol so the `get async` requirement is what's
+        // exercised (on the concrete type the property is synchronous and
+        // the await would be spurious).
+        let store: any ContactsStore = NoopContactsStore()
         let status = await store.authorizationStatus
         XCTAssertEqual(status, .denied)
         XCTAssertFalse(status.isAccessible)

--- a/apple/CabalmailNotificationService/NotificationService.swift
+++ b/apple/CabalmailNotificationService/NotificationService.swift
@@ -52,12 +52,14 @@ final class NotificationService: UNNotificationServiceExtension {
             return
         }
         let state = self.state
-        // The Swift 5.10 region-isolation checker emits a spurious
-        // "pattern ... does not understand" warning for this Task even
-        // though every capture is Sendable (endpoint/token/query are value
-        // types; DeliveryState is @unchecked Sendable with lock-guarded
-        // state). Extraction and Task.detached were both tried and do not
-        // silence it; revisit when the toolchain moves past 5.10.
+        // The region-isolation checker emits a spurious "pattern ... does
+        // not understand" warning for this Task even though every capture
+        // is Sendable (endpoint/token/query are value types; DeliveryState
+        // is @unchecked Sendable with lock-guarded state). Extraction,
+        // Task.detached, and nonisolated(unsafe) on the local (Xcode 26.6
+        // toolchain - it warns "unnecessary" and changes nothing) all fail
+        // to silence it; accepted as noise until a toolchain fixes the
+        // checker or the Swift 6 language-mode migration forces the issue.
         Task {
             let envelope = await Self.fetchEnvelope(endpoint: endpoint, token: token, query: query)
             state.deliver(envelope)


### PR DESCRIPTION
Two related CI-hygiene changes on one branch:

## 1. Warn on never-surfaced builds; reframe the ASC defect as delayed readiness

Corrects #692's diagnosis with new evidence: the ASC defect is **delayed readiness across platforms**, not a macOS-only attach breakage. Builds since 2026-07-17 take minutes-to-10+-hours (per-build variance) to reach the hidden "Ready to Test" state that gates all distribution paths. macOS builds have consistently been slow; iOS build `1784337932` showed the same delay one API layer earlier — never surfacing in `/v1/builds` during its poll window, reaching "Ready to Test" only the following morning.

A poll that times out with the build **never having surfaced** now warns-and-passes like the macOS 404 signature does — `altool` verified the upload before the step ran, so a red job adds nothing actionable. Timeouts after real refusals, and genuine failures (`FAILED`/`INVALID`, missing group), still fail loudly.

## 2. Quiet the recurring warning annotations (run #432 had ~33)

- **brew "taps are not trusted" (~13, every job):** the runner image preinstalls the third-party `aws/tap`; newer Homebrew distrusts it and warns on every brew invocation. All five brew steps now `brew untap aws/tap` silently first.
- **`HTMLBodyView.swift:315` "consider using asynchronous alternative function" (~7):** the delayed restore-script re-run called completion-handler `evaluateJavaScript` from an async context; now wrapped in a synchronous `MainActor.run` closure — deliberately not the async variant, which traps on the nil result the restore IIFE returns.
- **`ContactsStoreTests.swift:11` "no 'async' operations occur within 'await'" (3):** the store is now typed `any ContactsStore` so the protocol's `get async` requirement is what's exercised (the concrete Noop property is sync).
- **`NotificationService.swift` region-isolation warning: not fixable** — a third silencing attempt (`nonisolated(unsafe)`, unavailable when the original note was written) warns "unnecessary" and changes nothing; the comment records it. It remains the one persistent annotation besides the intentional delayed-readiness warnings.

Verified locally: kit `swift build --build-tests` warning-free, touched test suite passes 11/11, `swiftlint` clean (including a `type_body_length` regression the first draft would have introduced), full `CabalmailMac` build shows only the region-isolation warning.

Label `no-changelog`: CI/warning hygiene and test-only Apple changes, nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)