### PR TITLE
Flag SMS registration as the long-lead, signup-gating setup step

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -111,6 +111,8 @@ The output contains the nameservers that AWS assigned to your mail domains. To w
 
 ## SMS verification (Required for phone verification)
 
+SMS delivery gates signup itself: Cognito verifies each new user's phone number by SMS at account creation, so no one can register until this section is complete. Both items below are independent of each other and of the remaining post-automation steps, and they carry the longest approval lead times in the whole setup -- start both as soon as the nameserver update has propagated and the front-door site resolves, and let them run while you work through the rest of this guide.
+
 Cognito sends verification SMS through AWS SNS. Delivery requires both of the following, in either order:
 
 - **A registered origination number.** US carriers only deliver from registered senders; follow the [10DLC SMS registration guide](./sms-10dlc.md) to register the brand and campaign and provision the number.

--- a/docs/sms-10dlc.md
+++ b/docs/sms-10dlc.md
@@ -7,6 +7,16 @@ and the message program must be registered and approved. Registration
 is per AWS account, so each environment that sends SMS repeats this
 process.
 
+**Start this early.** SMS delivery gates signup itself — Cognito
+verifies each new user's phone number by SMS at account creation, so
+no one can register on a new system until this process completes. The
+carrier reviews are the longest-lead items in a deployment, they can
+take multiple rounds, and nothing else in the setup depends on them —
+so begin as soon as the prerequisites below are satisfiable (in
+practice: right after the front-door site resolves), and run the SNS
+sandbox exit (see [setup.md](./setup.md)) in parallel rather than
+after.
+
 There are three layers:
 
 | Layer | What it establishes | How it's managed |


### PR DESCRIPTION
Docs-only. A new operator reading `setup.md` top to bottom had no signal that the SMS section is special: it gates signup entirely (Cognito verifies each new user's phone by SMS at account creation), its carrier reviews are the longest approval lead times in the whole setup, and nothing downstream depends on it — the ideal early-start, run-in-parallel step.

- `docs/setup.md`: the SMS section now opens with exactly that framing — start both tracks (carrier registration + SNS sandbox exit) as soon as nameservers propagate and the front door resolves, and let them run while working through the rest of the guide.
- `docs/sms-10dlc.md`: adds a "Start this early" paragraph up front with the same guidance from the runbook's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)