### PR TITLE
Remove the toll-free number and its feature flag

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -656,7 +656,6 @@ jobs:
         echo "healthchecks_registration_open = ${{ vars.TF_VAR_HEALTHCHECKS_REGISTRATION_OPEN || 'false' }}" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
         echo "quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}" >> terraform.tfvars
-        echo "use_eum_sms = ${{ vars.TF_VAR_USE_EUM_SMS || 'false' }}" >> terraform.tfvars
         echo "ten_dlc_campaign_registration_id = \"${{ vars.TF_VAR_TEN_DLC_CAMPAIGN_REGISTRATION_ID }}\"" >> terraform.tfvars
         echo "use_nat_instance = ${{ vars.TF_VAR_USE_NAT_INSTANCE || 'true' }}" >> terraform.tfvars
         echo "build_nat_ami = ${{ vars.TF_VAR_BUILD_NAT_AMI || 'true' }}" >> terraform.tfvars
@@ -766,7 +765,6 @@ jobs:
         echo "healthchecks_registration_open = ${{ vars.TF_VAR_HEALTHCHECKS_REGISTRATION_OPEN || 'false' }}" >> terraform.tfvars
         echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
         echo "quiesced = ${{ vars.TF_VAR_QUIESCED || 'false' }}" >> terraform.tfvars
-        echo "use_eum_sms = ${{ vars.TF_VAR_USE_EUM_SMS || 'false' }}" >> terraform.tfvars
         echo "ten_dlc_campaign_registration_id = \"${{ vars.TF_VAR_TEN_DLC_CAMPAIGN_REGISTRATION_ID }}\"" >> terraform.tfvars
         echo "use_nat_instance = ${{ vars.TF_VAR_USE_NAT_INSTANCE || 'true' }}" >> terraform.tfvars
         echo "build_nat_ami = ${{ vars.TF_VAR_BUILD_NAT_AMI || 'true' }}" >> terraform.tfvars
@@ -797,7 +795,6 @@ jobs:
         if [ $TF_EXIT -ne 0 ]; then
           if grep -q 'aws_pinpointsmsvoicev2_phone_number' /tmp/tf-apply.log && grep -q "timeout while waiting for state to become 'ACTIVE'" /tmp/tf-apply.log; then
             echo "::warning::Phone number provisioning timed out. Untainting so the next run re-checks instead of re-leasing."
-            terraform untaint 'module.pool.aws_pinpointsmsvoicev2_phone_number.sms[0]' 2>/dev/null || true
             terraform untaint 'module.pool.aws_pinpointsmsvoicev2_phone_number.ten_dlc[0]' 2>/dev/null || true
             exit 0
           fi

--- a/.github/workflows/quiesce.yml
+++ b/.github/workflows/quiesce.yml
@@ -120,7 +120,6 @@ jobs:
           echo "healthchecks_registration_open = ${{ vars.TF_VAR_HEALTHCHECKS_REGISTRATION_OPEN || 'false' }}" >> terraform.tfvars
           echo "prod = ${{ vars.TF_VAR_PROD }}" >> terraform.tfvars
           echo "sinkhole = ${{ vars.TF_VAR_SINKHOLE || 'false' }}" >> terraform.tfvars
-          echo "use_eum_sms = ${{ vars.TF_VAR_USE_EUM_SMS || 'false' }}" >> terraform.tfvars
           echo "ten_dlc_campaign_registration_id = \"${{ vars.TF_VAR_TEN_DLC_CAMPAIGN_REGISTRATION_ID }}\"" >> terraform.tfvars
           echo "use_nat_instance = ${{ vars.TF_VAR_USE_NAT_INSTANCE || 'true' }}" >> terraform.tfvars
           echo "build_nat_ami = ${{ vars.TF_VAR_BUILD_NAT_AMI || 'true' }}" >> terraform.tfvars

--- a/changelog.d/tfn-resource.removed.md
+++ b/changelog.d/tfn-resource.removed.md
@@ -1,0 +1,5 @@
+- **Toll-free phone number.** The AWS End User Messaging toll-free
+  number and its `use_eum_sms` feature flag are gone; the 10DLC number
+  (`ten_dlc_campaign_registration_id`) is now the only SMS origination
+  path. Applying this change releases the account's toll-free number,
+  which requires its verification registration to be deleted first.

--- a/docs/github.md
+++ b/docs/github.md
@@ -98,7 +98,6 @@ These variables gate the optional monitoring stack. See [monitoring.md](./monito
 | Variable | Example | Notes |
 | --- | --- | --- |
 | `TF_VAR_TEN_DLC_CAMPAIGN_REGISTRATION_ID` | `registration-0123456789abcdef` | Registration id of this account's approved 10DLC campaign. When set, Terraform provisions a 10DLC phone number against the campaign and the post-apply step converges its HELP/STOP/START keywords. Leave unset until the campaign is approved. See [sms-10dlc.md](./sms-10dlc.md) for the registration runbook. |
-| `TF_VAR_USE_EUM_SMS` | `false` | Legacy toll-free number path, superseded by the 10DLC variable above. Default `false`. |
 
 ## Claude automation tool allowlist
 

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -137,7 +137,6 @@ module "pool" {
   bucket_arn             = module.bucket.bucket_arn
   ecs_cluster_name       = module.ecs.cluster_name
   healthcheck_ping_param = local.hc_ping_assign_osid
-  use_eum_sms            = var.use_eum_sms
   invitation_code        = var.invitation_code
 
   ten_dlc_campaign_registration_id = var.ten_dlc_campaign_registration_id

--- a/terraform/infra/modules/user_pool/main.tf
+++ b/terraform/infra/modules/user_pool/main.tf
@@ -50,24 +50,6 @@ resource "aws_cognito_user_pool" "users" {
   }
 }
 
-# AWS End User Messaging toll-free number, superseded by the 10DLC
-# number below and staged for release: deletion protection is disabled
-# here so a follow-up change can remove the resource (the provider's
-# destroy calls ReleasePhoneNumber directly and fails while protection
-# is on, so this must land in an apply of its own first).
-resource "aws_pinpointsmsvoicev2_phone_number" "sms" {
-  count                       = var.use_eum_sms ? 1 : 0
-  iso_country_code            = "US"
-  message_type                = "TRANSACTIONAL"
-  number_capabilities         = ["SMS"]
-  number_type                 = "TOLL_FREE"
-  deletion_protection_enabled = false
-
-  timeouts {
-    create = "1m"
-  }
-}
-
 # AWS End User Messaging 10DLC number used by the SNS SMS path. Created
 # only once the account's 10DLC campaign registration is approved and
 # its id is supplied; requesting a number against an unapproved or

--- a/terraform/infra/modules/user_pool/outputs.tf
+++ b/terraform/infra/modules/user_pool/outputs.tf
@@ -19,8 +19,8 @@ output "admin_group_name" {
 }
 
 output "sms_phone_number" {
-  value       = var.ten_dlc_campaign_registration_id != "" ? aws_pinpointsmsvoicev2_phone_number.ten_dlc[0].phone_number : (var.use_eum_sms ? aws_pinpointsmsvoicev2_phone_number.sms[0].phone_number : "")
-  description = "AWS End User Messaging phone number for SMS verification (10DLC when a campaign registration id is set, else the legacy toll-free number). Empty string when neither is provisioned."
+  value       = var.ten_dlc_campaign_registration_id != "" ? aws_pinpointsmsvoicev2_phone_number.ten_dlc[0].phone_number : ""
+  description = "AWS End User Messaging 10DLC phone number for SMS verification. Empty string when no campaign registration id is set."
 }
 
 output "user_pool_domain" {

--- a/terraform/infra/modules/user_pool/variables.tf
+++ b/terraform/infra/modules/user_pool/variables.tf
@@ -72,12 +72,6 @@ variable "healthcheck_ping_param" {
   default     = ""
 }
 
-variable "use_eum_sms" {
-  type        = bool
-  description = "Feature flag: when true, provision the AWS End User Messaging toll-free phone number that backs SNS-based SMS delivery. When false, no EUM phone number is created."
-  default     = false
-}
-
 variable "ten_dlc_campaign_registration_id" {
   type        = string
   description = "Registration id (registration-...) of this account's APPROVED 10DLC campaign in AWS End User Messaging. When set, a 10DLC phone number is provisioned against that campaign to back SNS-based SMS delivery. Empty string skips the number."

--- a/terraform/infra/outputs.tf
+++ b/terraform/infra/outputs.tf
@@ -26,7 +26,7 @@ output "mail_domain_ds_records" {
 
 output "sms_phone_number" {
   value       = module.pool.sms_phone_number
-  description = "AWS End User Messaging phone number for SMS verification (10DLC when a campaign registration id is set, else the legacy toll-free number). Empty when neither is provisioned."
+  description = "AWS End User Messaging 10DLC phone number for SMS verification. Empty when no campaign registration id is set."
 }
 
 output "alert_sink_function_url" {

--- a/terraform/infra/variables.tf
+++ b/terraform/infra/variables.tf
@@ -177,15 +177,9 @@ variable "lambda_pinned_hashes" {
   default     = {}
 }
 
-variable "use_eum_sms" {
-  type        = bool
-  description = "Feature flag: when true, provision the AWS End User Messaging toll-free phone number for Cognito SMS via SNS. When false, the EUM phone number is not created and Cognito's sms_configuration block falls through to the shared AWS SMS pool (which is sandboxed without registration)."
-  default     = false
-}
-
 variable "ten_dlc_campaign_registration_id" {
   type        = string
-  description = "Registration id (registration-...) of this account's APPROVED 10DLC campaign in AWS End User Messaging. When set, a 10DLC phone number is provisioned against that campaign for Cognito SMS via SNS. Empty string skips the number (the account then relies on the toll-free number if use_eum_sms is true)."
+  description = "Registration id (registration-...) of this account's APPROVED 10DLC campaign in AWS End User Messaging. When set, a 10DLC phone number is provisioned against that campaign for Cognito SMS via SNS. Empty string skips the number, and Cognito's sms_configuration block falls through to the shared AWS SMS pool (which is sandboxed without registration)."
   default     = ""
 }
 


### PR DESCRIPTION
Second half of the two-apply dance started in #706 (deletion protection is now off in stage). Removes:

- `aws_pinpointsmsvoicev2_phone_number.sms` (the toll-free number)
- `use_eum_sms` at module and root level, its `main.tf` pass-through, and its tfvars lines in `infra.yml` and `quiesce.yml`
- the toll-free arm of the `sms_phone_number` output, the `sms[0]` line in the apply-timeout untaint guard, and the legacy row in `docs/github.md`

`terraform validate` passes, `fmt -check` clean, no `use_eum_sms` references remain outside the historical `docs/0.x` planning record.

**Before merging** — the apply releases +18444593106, and AWS refuses to release a number with a registration attached. Delete the stage TFV registration first (CloudShell):

~~~sh
aws pinpoint-sms-voice-v2 delete-registration \
  --registration-id registration-6f49b9b10efa435d9428aa6ef0c416ed
~~~

**After the stage apply succeeds** — `TF_VAR_USE_EUM_SMS` can be deleted from the stage GitHub environment (no remaining consumer).

**Before promoting to main** — same dance for prod: delete prod's TFV registration (`registration-480bdc1243ce4856bfc0c86a9cca275d`) so prod's release doesn't bounce, and note prod's toll-free number still has deletion protection ON until the #706 promotion applies there — promote #706's state and this change in that order (they can ride one promotion only if prod's flip applies before this destroy plans, which one merge commit cannot guarantee; two promotions is the safe sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)