### PR TITLE
Clear a default From address the account can't send from

### DIFF
--- a/apple/Cabalmail/PreferencesSyncCoordinator.swift
+++ b/apple/Cabalmail/PreferencesSyncCoordinator.swift
@@ -38,6 +38,12 @@ final class PreferencesSyncCoordinator {
     /// Debounce window for pushes: a quick flurry of toggles collapses to one
     /// write. Matches `NavStateCoordinator`'s cursor-save cadence.
     private let saveDebounce: Duration = .seconds(1)
+    /// Set by `stop()`. `start()`/`reconcile()` run their server pull as a
+    /// detached task the caller doesn't hold, so sign-out can land while a
+    /// fetch is in flight; without this guard the late response would apply
+    /// the *previous* account's settings into whatever scope `Preferences`
+    /// has activated by then — the cross-account leak, resurrected.
+    private var stopped = false
 
     init(client: CabalmailClient, preferences: Preferences) {
         self.client = client
@@ -48,14 +54,19 @@ final class PreferencesSyncCoordinator {
     /// local edits. Safe to call once per wired session.
     func start() async {
         await pullFromServer()
+        // A sign-out during the pull above must not re-attach the observer
+        // (`stop()` already detached it for good).
+        guard !stopped else { return }
         preferences.onLocalChange = { [weak self] in
             self?.scheduleSave()
         }
     }
 
-    /// Detaches the local-edit observer and cancels any pending push. Called on
-    /// sign-out before the coordinator is released.
+    /// Detaches the local-edit observer, cancels any pending push, and marks
+    /// the coordinator dead so an in-flight server pull is discarded instead
+    /// of applied. Called on sign-out before the coordinator is released.
     func stop() {
+        stopped = true
         saveTask?.cancel()
         saveTask = nil
         preferences.onLocalChange = nil
@@ -73,6 +84,9 @@ final class PreferencesSyncCoordinator {
     /// user has never synced) leaves the local defaults in place.
     private func pullFromServer() async {
         guard let remote = try? await client.fetchAppPreferences(), !remote.isEmpty else { return }
+        // The fetch may have raced a sign-out; this account's values must
+        // not land in the next account's (already re-activated) scope.
+        guard !stopped else { return }
         preferences.applyRemote(remote)
         // Record the applied set so the value we just wrote in doesn't read as
         // a local edit and echo straight back out.

--- a/apple/Cabalmail/ViewModels/ComposeViewModel.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel.swift
@@ -80,6 +80,13 @@ final class ComposeViewModel {
     /// active states.
     var richSelection: RichTextEditorController.Selection = .init()
 
+    /// True when `fromAddress` was pre-filled from the default-From
+    /// preference rather than the seed. `refreshAddresses` uses this to
+    /// drop a pre-fill the account can't actually send from (a revoked or
+    /// leaked-in default) without touching a reply seed's deliberate
+    /// "From = original addressee" choice.
+    private let fromSeededFromPreference: Bool
+
     /// Immutable compose-context bits; only set during init from a reply /
     /// forward / new-message seed, never mutated after. Access defaults to
     /// `internal` so `ComposeViewModel+Internals.swift` can read them.
@@ -133,6 +140,7 @@ final class ComposeViewModel {
         // requires replies to reuse the address the correspondent already
         // wrote to.
         self.fromAddress = seed.fromAddress ?? preferences.defaultFromAddress
+        self.fromSeededFromPreference = seed.fromAddress == nil && preferences.defaultFromAddress != nil
         self.toText = seed.to.joined(separator: ", ")
         self.ccText = seed.cc.joined(separator: ", ")
         self.bccText = seed.bcc.joined(separator: ", ")
@@ -201,6 +209,19 @@ final class ComposeViewModel {
             availableAddresses = try await client.addresses(forceRefresh: forceRefresh)
         } catch {
             errorMessage = "Couldn't load addresses: \(error)"
+            return
+        }
+        // The preference-seeded pre-fill is only trustworthy once the real
+        // address list confirms it. A default that isn't in the list — a
+        // revoked address, or one leaked in from another account before
+        // preferences were account-scoped — must not sit in the From field
+        // of a message the user is about to send. Reconciling the
+        // preference also pushes the cleared value to the server, healing
+        // the synced copy that keeps re-applying it at sign-in.
+        preferences.reconcileDefaultFromAddress(available: availableAddresses.map(\.address))
+        if fromSeededFromPreference, let current = fromAddress, !availableAddresses.isEmpty,
+           !availableAddresses.contains(where: { $0.address == current }) {
+            fromAddress = nil
         }
     }
 

--- a/apple/Cabalmail/Views/SettingsView.swift
+++ b/apple/Cabalmail/Views/SettingsView.swift
@@ -258,6 +258,12 @@ struct SettingsView: View {
         if let addresses = try? await client.addresses(forceRefresh: force) {
             availableAddresses = addresses
                 .sorted { $0.address.localizedCaseInsensitiveCompare($1.address) == .orderedAscending }
+            // Actually clear a dangling default (revoked, or leaked in from
+            // another account pre-scoping) rather than leaving the masked
+            // "None" the picker binding shows — the underlying value would
+            // otherwise keep pre-filling compose, and selecting "None" can't
+            // remove it because the picker already reads as "None".
+            preferences.reconcileDefaultFromAddress(available: addresses.map(\.address))
         }
     }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Settings/Preferences.swift
@@ -345,6 +345,26 @@ public final class Preferences {
         return Value(rawValue: raw) ?? fallback
     }
 
+    // MARK: - Reconciliation
+
+    /// Clears the default From address when it isn't one of the account's
+    /// own addresses. Callers pass the freshly fetched address list; an
+    /// empty list is treated as inconclusive (a transient fetch hiccup must
+    /// not wipe a valid default), so nothing is cleared.
+    ///
+    /// A dangling default reaches this state two ways: the address was
+    /// revoked from another device, or the value predates per-account
+    /// scoping and leaked in from a different account — possibly laundered
+    /// through the server's per-user preferences row, which "server wins on
+    /// login" then re-applies on every sign-in. Clearing here goes through
+    /// the normal persistence hooks, so the sync coordinator pushes the
+    /// cleared value back to the server and the bad row heals durably.
+    public func reconcileDefaultFromAddress(available: [String]) {
+        guard let current = defaultFromAddress, !available.isEmpty else { return }
+        guard !available.contains(current) else { return }
+        defaultFromAddress = nil
+    }
+
     // MARK: - Server sync marshalling
 
     /// Wire keys for the server-synced `app` map (the `set_preferences` Lambda

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/PreferencesReconcileTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/PreferencesReconcileTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import CabalmailKit
+
+/// `Preferences.reconcileDefaultFromAddress(available:)` — clearing a
+/// default From address the account can't actually send from. Split from
+/// `PreferencesTests` for the SwiftLint type-body cap.
+@MainActor
+final class PreferencesReconcileTests: XCTestCase {
+    private static let domain = "cabal.example.com"
+
+    private func makeActivated(
+        store: InMemoryPreferenceStore? = nil
+    ) -> Preferences {
+        let preferences = Preferences(store: store ?? InMemoryPreferenceStore())
+        preferences.activate(controlDomain: Self.domain, username: "chris")
+        return preferences
+    }
+
+    private func scopedDefaultFromKey() throws -> String {
+        let scope = try XCTUnwrap(Preferences.scopeIdentifier(
+            controlDomain: Self.domain, username: "chris"
+        ))
+        return "\(Preferences.Key.defaultFromAddress.rawValue).\(scope)"
+    }
+
+    /// A default From that isn't in the account's address list — revoked, or
+    /// leaked in from another account before per-account scoping — is cleared,
+    /// and the clear fires `onLocalChange` so the sync coordinator pushes it
+    /// to the server and heals the synced copy that keeps re-applying it.
+    func testClearsDanglingDefaultFromAndFiresOnLocalChange() throws {
+        let store = InMemoryPreferenceStore()
+        let preferences = makeActivated(store: store)
+        preferences.defaultFromAddress = "apple@testsubdomain.example.com"
+        var localChangeCount = 0
+        preferences.onLocalChange = { localChangeCount += 1 }
+
+        preferences.reconcileDefaultFromAddress(
+            available: ["mine@sub.example.com", "other@sub.example.com"]
+        )
+
+        XCTAssertNil(preferences.defaultFromAddress)
+        XCTAssertNil(store.stringValue(forKey: try scopedDefaultFromKey()))
+        XCTAssertEqual(localChangeCount, 1)
+    }
+
+    func testKeepsDefaultFromThatIsInTheList() {
+        let preferences = makeActivated()
+        preferences.defaultFromAddress = "mine@sub.example.com"
+        preferences.reconcileDefaultFromAddress(
+            available: ["mine@sub.example.com", "other@sub.example.com"]
+        )
+        XCTAssertEqual(preferences.defaultFromAddress, "mine@sub.example.com")
+    }
+
+    /// An empty list is inconclusive (a transient fetch hiccup), not proof
+    /// the default is dangling — nothing is cleared.
+    func testTreatsEmptyListAsInconclusive() {
+        let preferences = makeActivated()
+        preferences.defaultFromAddress = "mine@sub.example.com"
+        preferences.reconcileDefaultFromAddress(available: [])
+        XCTAssertEqual(preferences.defaultFromAddress, "mine@sub.example.com")
+    }
+
+    func testNoDefaultIsANoOp() {
+        let preferences = makeActivated()
+        var localChangeCount = 0
+        preferences.onLocalChange = { localChangeCount += 1 }
+        preferences.reconcileDefaultFromAddress(available: ["mine@sub.example.com"])
+        XCTAssertNil(preferences.defaultFromAddress)
+        XCTAssertEqual(localChangeCount, 0)
+    }
+}

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/PreferencesTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/PreferencesTests.swift
@@ -337,4 +337,5 @@ final class PreferencesTests: XCTestCase {
         preferences.applyRemote(["theme": "lunar-eclipse", "unknown_key": "x"])
         XCTAssertEqual(preferences.theme, .dark)
     }
+
 }

--- a/changelog.d/apple-dangling-default-from.fixed.md
+++ b/changelog.d/apple-dangling-default-from.fixed.md
@@ -1,0 +1,11 @@
+- Apple: **Compose no longer pre-fills a From address the account can't
+  send from.** A default From address that isn't in the account's own
+  address list — one revoked from another device, or one that leaked in
+  from a different account before settings were account-scoped and then
+  kept re-applying at sign-in via the server-synced copy — is now cleared
+  when the address list loads (in compose and in Settings), and the
+  cleared value is pushed to the server so the synced copy heals too.
+  Settings previously masked the dangling value as "None" while compose
+  kept using it, with no way to remove it from the UI. Also hardened the
+  sign-out path so a preference fetch still in flight for the previous
+  account is discarded instead of being applied to the next account.


### PR DESCRIPTION
## Problem

On the Mac client, clicking compose pre-filled the From field with an address from a *different* Cabalmail account previously tested on the same machine — an address the signed-in account cannot send from. The Settings "Default From" picker simultaneously showed **None**.

## Root cause

Three layers stacked up:

1. **Server row poisoned.** Cross-device preference sync shipped 2026-07-16; per-account scoping shipped 2026-07-17. In between (and from any earlier device-wide leak), the tested account's default From was pushed into the victim account's `cabal-user-preferences` row. Confirmed live in prod: the `chris` row carries `apple`'s address. "Server wins on login" re-applies it on every sign-in, so the shipped scoping fix never heals it.
2. **Settings masks instead of reconciling.** `defaultFromBinding` displays "None" when the stored default isn't in the address list, while the underlying preference keeps the leaked value — and selecting "None" is a no-op because the picker already reads as None. Invisible and unfixable from the UI.
3. **Narrow residual race.** `PreferencesSyncCoordinator.stop()` didn't discard an in-flight `start()` pull, so a slow fetch for the signed-out account could apply its settings into the next account's freshly activated scope.

## Fix

- `Preferences.reconcileDefaultFromAddress(available:)`: clears a default From not present in the account's own address list, via the normal persistence hooks so the sync coordinator pushes the clear to the server — the poisoned row heals durably the first time the fixed build loads addresses (compose or Settings). An empty list is treated as inconclusive and clears nothing.
- `ComposeViewModel.refreshAddresses` drops a preference-seeded From pre-fill the loaded list doesn't contain; reply seeds ("From = original addressee") are untouched.
- `PreferencesSyncCoordinator.stop()` marks the coordinator dead; an in-flight pull is discarded instead of applied, and `start()` won't re-attach the observer after stop.

This also fixes the single-account variant: a default From revoked from another device no longer keeps pre-filling compose.

## Tests

- New `PreferencesReconcileTests` (kit): clears dangling + fires `onLocalChange`, keeps valid, empty-list inconclusive, nil no-op. Full `swift test`: 355 tests, 0 failures.
- macOS app-layer suite (`xcodebuild test -scheme CabalmailMac`): 12 tests, 0 failures.
- swiftlint: clean (new test class split out to respect the type-body cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)