### PR TITLE
Fix blank leading pane beside the iPad message list

### DIFF
--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -199,9 +199,16 @@ struct MailRootView: View {
                 // empty and permanently collapsed. Removing the system sidebar
                 // toggle keeps the content toolbar from offering to reveal the
                 // empty column — the custom button in `decoratedContentColumn`
-                // drives the panel instead.
+                // drives the panel instead. The zero column width matters:
+                // `splitVisibility`'s pinned `.doubleColumn` only holds until
+                // a rotation or window resize, when UIKit's split controller
+                // re-expands the sidebar on its own and the constant binding
+                // can't push back — tiling this column in as a blank leading
+                // pane. At width 0 the re-expanded column has no footprint,
+                // so the pane can never appear.
                 Color.clear
                     .toolbar(removing: .sidebarToggle)
+                    .navigationSplitViewColumnWidth(0)
             } else {
                 sidebar
             }

--- a/changelog.d/ipad-blank-sidebar.fixed.md
+++ b/changelog.d/ipad-blank-sidebar.fixed.md
@@ -1,0 +1,4 @@
+- Apple: **No more blank leading pane on iPad.** In landscape and resized
+  windows, the split view re-expanded its intentionally empty sidebar column
+  as a blank bar beside the message list. That column is now pinned to zero
+  width, so the floating folder panel is the only sidebar surface.


### PR DESCRIPTION
## Summary

On regular-width iPad, a blank pane appeared to the left of the message list in landscape and in resized windows (the folder-list overlay itself rendered correctly). The pane was the split view's intentionally empty sidebar column (`Color.clear` — the folder list lives in the floating panel instead): its visibility is pinned collapsed via a constant `.doubleColumn` binding, but on rotation or a window resize UIKit's split controller re-expands the sidebar on its own, and the constant binding can't push back, so the empty column tiled in as a blank bar. The column is now pinned to `navigationSplitViewColumnWidth(0)`, so even when the system re-expands it, it has no footprint.

## Verification

Reproduced and verified headlessly on the iPad Pro 11" (iOS 26.5) simulator, driving orientation with a throwaway XCUITest:

- Before: landscape showed the blank leading pane (matches the report).
- After: landscape shows the message list at the leading edge, no pane; the floating folder panel still opens over the list with its scrim; portrait is pixel-identical to the baseline.
- `swiftlint` clean; no shared-protocol or view-model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)