### PR TITLE
Apple: land on INBOX before the folder list loads

### DIFF
--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -28,9 +28,10 @@ struct FolderListView: View {
     /// view's own `.searchable` query.
     var activeFilterText: String { externalFilter?.wrappedValue ?? filterQuery }
     /// Called exactly once, the first time the folder list successfully
-    /// loads. `MailRootView` uses it to seed a default `selection` so the
-    /// signed-in user doesn't land on an empty "select a folder" screen
-    /// (which would also hide the compose entry point on the message list).
+    /// loads. `MailRootView` uses it to complete the launch INBOX landing:
+    /// the fetched INBOX replaces the provisional `Folder(path: "INBOX")`
+    /// its launch task pre-selected (so the message list never waited on
+    /// this fetch), and the saved-position resume probe runs.
     var onFoldersLoaded: ([Folder]) -> Void = { _ in }
 
     // Section expand/collapse state - persisted so the sidebar comes up the
@@ -183,9 +184,9 @@ struct FolderListView: View {
                 model = newModel
                 // Race the inbox STATUS against the folder list so the
                 // inbox badge is correct by the time the user's eyes
-                // reach it — the message list itself starts loading the
-                // moment `onFoldersLoaded` fires below, so anything we
-                // can finish before then is free.
+                // reach it — the INBOX message list is already loading
+                // (the parent lands on it before this list returns), so
+                // anything finished before the sidebar draws is free.
                 async let inbox: () = newModel.refreshInboxCount()
                 await newModel.loadFolderList()
                 _ = await inbox

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -19,6 +19,14 @@ struct MailRootView: View {
     @State private var selectedFolder: Folder?
     @State private var selectedEnvelope: Envelope?
     @State private var selectedAddress: Address?
+    /// Whether the launch `.task` has already landed on the provisional
+    /// INBOX (see there). Never reset — a later re-appearance with a
+    /// deliberately cleared selection must not yank the user back to INBOX.
+    @State private var didProvisionalLand = false
+    /// Set alongside the provisional landing and consumed by the sidebar's
+    /// first `onFoldersLoaded`, which swaps the fetched INBOX into the
+    /// selection and probes the resume cursor (`finishInboxLanding`).
+    @State private var awaitingLaunchReconcile = false
     /// Override for the message detail's folder context when the selected
     /// envelope is a cross-folder search result. `MessageListView` reports
     /// the source folder via `onSearchResultSelected`; we wrap it in a
@@ -247,7 +255,12 @@ struct MailRootView: View {
         // the folder changes keeps the detail column from briefly rendering
         // an old message against the new mailbox, and matches the plan's
         // "switching folders clears the filter" rule.
-        .onChange(of: selectedFolder) { _, folder in
+        .onChange(of: selectedFolder) { old, folder in
+            // A same-path change is a metadata reconcile — the launch landing
+            // swapping its provisional `Folder(path: "INBOX")` for the fetched
+            // one (`finishInboxLanding`). Same mailbox, so keep the user's
+            // message selection and don't re-record the cursor.
+            guard old?.path != folder?.path else { return }
             selectedEnvelope = nil
             selectedAddress = nil
             crossFolderDetail = nil
@@ -339,8 +352,8 @@ struct MailRootView: View {
             // cold launch from a tapped push notification routes as soon as
             // the session is wired, which precedes the first render, so the
             // `.onChange` above never fires for it. Draining it here also
-            // pre-empts the sidebar's INBOX landing (`onFoldersLoaded`
-            // guards on `selectedFolder == nil`).
+            // pre-empts the provisional INBOX landing below (and with it
+            // the sidebar's launch reconcile).
             if let coordinator = appState.navCoordinator,
                let request = coordinator.navigateRequest {
                 coordinator.navigateRequest = nil
@@ -348,6 +361,22 @@ struct MailRootView: View {
                 if selectedFolder?.path != request.folder {
                     selectedFolder = Folder(path: request.folder)
                 }
+            }
+            // Land on a provisional INBOX immediately — before the folder
+            // list returns — so the message list (and its on-disk envelope
+            // cache) starts loading without waiting on `/list_folders`. The
+            // message machinery only needs the path; the sidebar's first
+            // `onFoldersLoaded` swaps in the fetched folder and probes the
+            // resume cursor (`finishInboxLanding`). Seeded as subscribed so
+            // the list doesn't flash the unsubscribed-folder banner before
+            // the real subscription state arrives; gated on a wired client
+            // because the list's one-shot `.task` can't create its model
+            // without one. INBOX itself is guaranteed to exist (RFC 3501).
+            if !didProvisionalLand, selectedFolder == nil, appState.client != nil {
+                didProvisionalLand = true
+                awaitingLaunchReconcile = true
+                appState.navCoordinator?.armProvisionalLanding()
+                selectedFolder = Folder(path: "INBOX", isSubscribed: true)
             }
             if searchModel == nil, let client = appState.client {
                 searchModel = MessageListViewModel(
@@ -417,32 +446,50 @@ struct MailRootView: View {
 // SwiftLint's `type_body_length` cap, matching the pattern used by
 // `MessageListView` and its `+Filter` / `+Search` siblings.
 extension MailRootView {
-    /// First-load folder selection: always land on INBOX, then — in the
-    /// background — check whether the saved cursor is still a usable resume
-    /// target (folder present, recorded message still in the folder's initial
-    /// window) and, if so, offer a "pick up where you left off" toast rather
-    /// than jumping there. Tapping it drives the same `navigateRequest` path as
-    /// the cross-client resume. The INBOX landing's own cursor write is held
-    /// back (`armProvisionalLanding`) so a still-valid saved position survives
-    /// until the user resumes or navigates on their own; if there's nothing to
-    /// resume, INBOX is recorded normally once the probe returns.
-    private func landOnInboxAndOfferResume(from folders: [Folder]) {
+    /// Completes the launch INBOX landing once the folder list arrives. The
+    /// launch `.task` has usually already selected a provisional
+    /// `Folder(path: "INBOX")` so the message list didn't wait on
+    /// `/list_folders`; here the fetched INBOX is swapped into the selection —
+    /// `Folder` equality spans attributes/subscription, and the sidebar's row
+    /// highlight only matches once the tag values agree. Same path, so the
+    /// mounted list (`.id(selectedFolder.path)`) survives untouched and the
+    /// same-path guard on `.onChange` keeps the swap from clearing state.
+    /// Then — in the background — check whether the saved cursor is still a
+    /// usable resume target (folder present, recorded message still in the
+    /// folder's initial window) and, if so, offer a "pick up where you left
+    /// off" toast rather than jumping there. Tapping it drives the same
+    /// `navigateRequest` path as the cross-client resume. The INBOX landing's
+    /// own cursor write is held back (`armProvisionalLanding`) so a
+    /// still-valid saved position survives until the user resumes or navigates
+    /// on their own; if there's nothing to resume, INBOX is recorded normally
+    /// once the probe returns.
+    private func finishInboxLanding(from folders: [Folder]) {
         let inbox = folders.first { folder in
             folder.path.caseInsensitiveCompare("INBOX") == .orderedSame
         } ?? folders.first
-        appState.navCoordinator?.armProvisionalLanding()
-        selectedFolder = inbox
+        if let current = selectedFolder {
+            // Provisional landing already on screen. If a navigate request
+            // (push-notification launch) has moved the selection elsewhere,
+            // leave it be — the probe below still runs but its post-guard
+            // keeps it silent.
+            if current.path.caseInsensitiveCompare("INBOX") == .orderedSame, let inbox { selectedFolder = inbox }
+        } else {
+            // The client wasn't wired when the launch task ran, so there was
+            // no provisional landing: land now, as before.
+            appState.navCoordinator?.armProvisionalLanding()
+            selectedFolder = inbox
+        }
         Task {
             let candidate = await appState.navCoordinator?.launchResumeCandidate(folders: folders)
             // If the user already navigated off INBOX while the probe ran, leave
             // them be rather than surfacing a now-stale prompt.
-            guard selectedFolder?.path == inbox?.path else { return }
+            guard let inbox, selectedFolder?.path == inbox.path else { return }
             if let candidate {
                 appState.showToast(
                     .resumeNavigation(folderName: Folder(path: candidate.folder).name, cursor: candidate),
                     duration: 10
                 )
-            } else if let inbox {
+            } else {
                 // Nothing to resume: materialize the INBOX landing we suppressed.
                 appState.navCoordinator?.recordFolder(inbox.path)
             }
@@ -590,15 +637,17 @@ extension MailRootView {
                 selection: $selectedFolder,
                 externalFilter: isWideSidebar ? $folderListFilter : nil,
                 onFoldersLoaded: { folders in
-                    // First load: land on INBOX and, if a saved position is
+                    // First load: swap the fetched INBOX into the launch
+                    // task's provisional landing and, if a saved position is
                     // still reachable, offer a resume toast (see
-                    // `landOnInboxAndOfferResume`). The Compose button lives
-                    // on the message-list toolbar, so a nil-selection state
-                    // would leave the user no way to start a new message;
-                    // INBOX is always present
-                    // (`FolderListViewModel.sortForSidebar` pins it first).
-                    guard selectedFolder == nil else { return }
-                    landOnInboxAndOfferResume(from: folders)
+                    // `finishInboxLanding`). Guarded so a later re-fire (the
+                    // sidebar remounts on an iPad layout swap) can't re-seed
+                    // the selection out from under the user; the nil check
+                    // covers a launch whose client wasn't wired in time for
+                    // the provisional landing.
+                    guard awaitingLaunchReconcile || selectedFolder == nil else { return }
+                    awaitingLaunchReconcile = false
+                    finishInboxLanding(from: folders)
                 }
             )
         }

--- a/apple/Cabalmail/Views/VisionSectionView.swift
+++ b/apple/Cabalmail/Views/VisionSectionView.swift
@@ -63,9 +63,11 @@ struct VisionSectionView: View {
         .task { await landOnInboxIfNeeded() }
         // A folder pick in the Folders tab jumps to Mail. Guarded on the current
         // tab so the launch / resume folder changes (which target Mail
-        // themselves) don't trigger a redundant switch.
-        .onChange(of: selectedFolder) { _, folder in
-            if folder != nil, selection == .folders { selection = .mail }
+        // themselves) don't trigger a redundant switch, and on the path so the
+        // launch landing's same-folder metadata reconcile (see
+        // `landOnInboxIfNeeded`) doesn't yank the user out of Folders.
+        .onChange(of: selectedFolder) { old, folder in
+            if folder != nil, old?.path != folder?.path, selection == .folders { selection = .mail }
         }
         // ⌘, opens Settings — its own tab here, rather than the iPad sheet.
         .onChange(of: appState.settingsRequestTick) { _, _ in
@@ -111,31 +113,45 @@ struct VisionSectionView: View {
         }
     }
 
-    /// Loads the folder list once at launch — independent of the lazily-created
-    /// Folders tab — and lands on INBOX, offering a resume toast if the saved
-    /// cursor is still reachable. Mirrors `MailRootView.landOnInboxAndOfferResume`,
-    /// but sources its own folder list because there's no always-mounted sidebar
-    /// to hand one over.
+    /// Lands on INBOX at launch, offering a resume toast if the saved cursor
+    /// is still reachable. Mirrors `MailRootView`'s provisional landing: a
+    /// synthetic `Folder(path: "INBOX")` is selected immediately so the Mail
+    /// tab's message list starts loading without waiting on `/list_folders`
+    /// (the message machinery only needs the path; seeded as subscribed so
+    /// the list doesn't flash the unsubscribed-folder banner). The fetched
+    /// INBOX is swapped in once the list arrives — sourced from its own
+    /// `FolderListViewModel` because there's no always-mounted sidebar to
+    /// hand one over.
     private func landOnInboxIfNeeded() async {
         guard !didLand, selectedFolder == nil, let client = appState.client else { return }
+        didLand = true
+        appState.navCoordinator?.armProvisionalLanding()
+        selectedFolder = Folder(path: "INBOX", isSubscribed: true)
         let model = FolderListViewModel(client: client, appState: appState)
         await model.loadFolderList()
         let folders = model.folders
-        guard !didLand, !folders.isEmpty else { return }
-        didLand = true
+        guard !folders.isEmpty else { return }
         let inbox = folders.first { $0.path.caseInsensitiveCompare("INBOX") == .orderedSame } ?? folders.first
-        appState.navCoordinator?.armProvisionalLanding()
-        selectedFolder = inbox
+        // Swap the fetched INBOX into the provisional selection so the Folders
+        // tab's row highlight matches (`Folder` equality spans attributes /
+        // subscription). Same path — the mounted message list survives, and
+        // `VisionMailPane`'s same-path guard keeps the swap from clearing the
+        // open message. Skipped if the user already navigated elsewhere.
+        if let current = selectedFolder,
+           current.path.caseInsensitiveCompare("INBOX") == .orderedSame,
+           let inbox {
+            selectedFolder = inbox
+        }
         let candidate = await appState.navCoordinator?.launchResumeCandidate(folders: folders)
         // If the user already navigated off INBOX while the probe ran, leave
         // them be rather than surfacing a now-stale prompt.
-        guard selectedFolder?.path == inbox?.path else { return }
+        guard let inbox, selectedFolder?.path == inbox.path else { return }
         if let candidate {
             appState.showToast(
                 .resumeNavigation(folderName: Folder(path: candidate.folder).name, cursor: candidate),
                 duration: 10
             )
-        } else if let inbox {
+        } else {
             // Nothing to resume: materialize the INBOX landing we suppressed.
             appState.navCoordinator?.recordFolder(inbox.path)
         }
@@ -162,8 +178,11 @@ private struct VisionMailPane: View {
         }
         // Switching folders clears the open message and any multi-selection so
         // the reader can't briefly show an old message against the new mailbox,
-        // then records the folder move for the cross-client cursor.
-        .onChange(of: selectedFolder) { _, folder in
+        // then records the folder move for the cross-client cursor. A same-path
+        // change is the launch landing's metadata reconcile — same mailbox, so
+        // keep the open message and don't re-record the cursor.
+        .onChange(of: selectedFolder) { old, folder in
+            guard old?.path != folder?.path else { return }
             selectedEnvelope = nil
             listSelectionCount = 0
             if let path = folder?.path {

--- a/changelog.d/apple-inbox-first-launch.changed.md
+++ b/changelog.d/apple-inbox-first-launch.changed.md
@@ -1,0 +1,5 @@
+- Apple: **INBOX loads first at launch.** The app now lands on INBOX
+  immediately and starts loading its messages (including the instant
+  cached-envelope paint on a warm reopen) without waiting for the folder
+  list to arrive; the sidebar fills in alongside instead of gating the
+  first screen of mail.


### PR DESCRIPTION
## Summary

At launch the Apple clients previously waited for `/list_folders` to return before selecting INBOX, because the initial selection was derived from the fetched folder array — so the first screen of mail (and the instant cached-envelope paint on warm reopen) was gated on a fetch it didn't need. The message-list machinery only needs the folder *path*.

- The launch task in `MailRootView` (and `landOnInboxIfNeeded` in `VisionSectionView`) now selects a provisional `Folder(path: "INBOX", isSubscribed: true)` immediately, so `MessageListView` mounts and starts loading (cache hydrate + `/list_messages`/`/list_envelopes`) in parallel with the folder-list fetch. Seeded as subscribed to avoid flashing the unsubscribed-folder banner; INBOX existence is guaranteed by RFC 3501.
- When the folder list arrives, `finishInboxLanding` swaps the fetched INBOX into the selection (`Folder` equality spans attributes/subscription, so the sidebar row highlight needs the real value; same path means the mounted list — `.id(selectedFolder.path)` — is untouched) and runs the saved-cursor resume probe exactly as before, including `armProvisionalLanding` suppression of the landing's cursor write.
- Same-path guards on the `selectedFolder` `.onChange` handlers (MailRootView, VisionMailPane, VisionSectionView tab-jump) make the reconcile swap a no-op for user-visible state: no cleared message selection, no re-recorded nav cursor, no tab yank.
- Push-notification navigate requests still pre-empt the landing; a sidebar remount on iPad layout swaps can't re-seed the selection (`didProvisionalLand` / `awaitingLaunchReconcile`).
- The subscribed-folder counts backfill remains sequenced after the list load, unchanged.

## Testing

- `xcodebuild test` (CabalmailMac scheme): 12/12 pass
- visionOS and iOS `xcodebuild build`: both succeed (VisionSectionView only compiles on visionOS)
- `swiftlint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)