### PR TITLE
Dashboard: show TestFlight beta state and expiry in the build ledger

### DIFF
--- a/changelog.d/apple-release-dashboard.added.md
+++ b/changelog.d/apple-release-dashboard.added.md
@@ -5,6 +5,9 @@
   resolves the first build carrying it in each lane (and whether a build
   exists at all before App Store Connect attaches it to a group),
   dereferences marketing and build (`CFBundleVersion`) versions, and reads
-  each build's App Store Connect status. Tracks the branch from
-  `origin/stage`, and can attach a build to a TestFlight group from the
-  build ledger.
+  each build's App Store Connect status. The status mirrors the add-a-build
+  dialog's TestFlight beta state (Ready to Test / Testing / Not yet
+  testable, plus days until expiry), queried directly per build since the
+  builds-list `include=buildBetaDetail` is unreliable. Tracks the branch
+  from `origin/stage`, and can attach a build to a TestFlight group from
+  the build ledger.

--- a/scripts/apple-dashboard-app.py
+++ b/scripts/apple-dashboard-app.py
@@ -310,6 +310,7 @@ PAGE = r"""<!DOCTYPE html>
   .grp.prod{border-color:color-mix(in srgb,var(--good) 45%,transparent)}
   .grp.beta{border-color:color-mix(in srgb,var(--mac) 45%,transparent)}
   .apppill{display:inline-flex; align-items:center; gap:6px; font-weight:600; font-size:12.5px}
+  .expnote{font-size:10.5px; color:var(--muted); font-variant-numeric:tabular-nums; margin-top:2px}
   .assign{font:inherit; font-size:12px; padding:3px 7px; border-radius:6px; border:1px solid var(--border); background:var(--surface); color:var(--ink-2); max-width:140px; cursor:pointer}
   .assign:hover{color:var(--ink)}
   .assign:disabled{opacity:.5; cursor:default}
@@ -441,7 +442,8 @@ function renderAll(){
   renderFeatures(); renderLedger();
 
   document.getElementById('footer').innerHTML=
-    `<b>Built</b> = the first build that carried the feature (merged to the <code>stage</code> <i>branch</i>, uploaded to App Store Connect) — it can exist before Apple attaches it to any test group. <b>Stage/Prod/Beta</b> = the first build attached to that TestFlight <i>group</i>. Each cell is the earliest build whose number (a Unix timestamp, <code>date -u +%s</code>) is ≥ when the entry landed on <code>stage</code> (recovered from git); every build from there onward carries it. A feature's first stage build can sit under an earlier marketing version than the one it was cut into. Prod happens only when a version is cut to <code>main</code>; beta is assigned manually. (If a feature's true first build has aged out of TestFlight, the earliest build still in App Store Connect is shown.)`;
+    `<b>Built</b> = the first build that carried the feature (merged to the <code>stage</code> <i>branch</i>, uploaded to App Store Connect) — it can exist before Apple attaches it to any test group. <b>Stage/Prod/Beta</b> = the first build attached to that TestFlight <i>group</i>. Each cell is the earliest build whose number (a Unix timestamp, <code>date -u +%s</code>) is ≥ when the entry landed on <code>stage</code> (recovered from git); every build from there onward carries it. A feature's first stage build can sit under an earlier marketing version than the one it was cut into. Prod happens only when a version is cut to <code>main</code>; beta is assigned manually. (If a feature's true first build has aged out of TestFlight, the earliest build still in App Store Connect is shown.) `+
+    `<b>Apple status</b> mirrors the add-a-build dialog: <b>Ready to Test</b> / <b>Testing</b> mean the build can be (or is) in a test group; <b>Not yet testable</b> means it processed (Valid) but TestFlight hasn't surfaced it yet, so adding it to a group will fail until it flips to Ready to Test.`;
 }
 
 /* ---------- feature matrix (per-feature lanes) ---------- */
@@ -504,6 +506,12 @@ function renderLedger(){
 }
 function th(key,label){ const a=sortKey===key?(sortDir===1?' ▲':' ▼'):''; return `<th onclick="setSort('${key}')">${label}${a}</th>`; }
 function setSort(key){ if(sortKey===key) sortDir*=-1; else {sortKey=key; sortDir=1;} renderLedgerRows(); }
+function expNote(r){
+  if(r.expired || !r.expires) return '';
+  const days=Math.ceil((new Date(r.expires)-Date.now())/86400000);
+  if(!isFinite(days) || days<0) return '';
+  return `<div class="expnote">expires in ${days}d</div>`;
+}
 function renderLedgerRows(){
   if(!MODEL) return;
   const appF=document.getElementById('f-app').value, platF=document.getElementById('f-plat').value, laneF=document.getElementById('f-lane').value, q=document.getElementById('f-q').value.trim().toLowerCase();
@@ -523,7 +531,7 @@ function renderLedgerRows(){
     <td class="num mono">${esc(r.build_number)}</td>
     <td class="num mono" style="color:var(--ink-2)">${esc(r.build_date||'—')}</td>
     <td class="num mono" style="color:var(--ink-2)">${esc((r.uploaded||'').replace('T',' ').replace(/:\d\dZ?$/,'').replace('Z',''))||'—'}</td>
-    <td>${pill(r.status_label,r.status_role)}</td>
+    <td>${pill(r.status_label,r.status_role)}${expNote(r)}</td>
     <td>${r.lanes.length? r.lanes.map(l=>`<span class="grp ${l}">${LANE_LABEL[l]}</span>`).join('') : '<span class="lane-none">—</span>'}</td>
     <td>${assignSelect(r)}</td>
   </tr>`).join('');

--- a/scripts/apple-release-dashboard.py
+++ b/scripts/apple-release-dashboard.py
@@ -383,7 +383,7 @@ def fetch_app(app, token_factory):
         f"/v1/builds?filter[app]={app_id}"
         "&sort=-uploadedDate&limit=200"
         "&include=preReleaseVersion,buildBetaDetail,betaGroups"
-        "&fields[builds]=version,uploadedDate,processingState,expired,"
+        "&fields[builds]=version,uploadedDate,processingState,expired,expirationDate,"
         "preReleaseVersion,buildBetaDetail,betaGroups"
         "&fields[preReleaseVersions]=version,platform"
         "&fields[buildBetaDetails]=internalBuildState,externalBuildState"
@@ -427,6 +427,8 @@ def fetch_app(app, token_factory):
                 "uploaded": attrs.get("uploadedDate", ""),
                 "processing_state": attrs.get("processingState", ""),
                 "expired": bool(attrs.get("expired")),
+                "expiration": attrs.get("expirationDate", ""),
+                "beta_detail_missing": False,
                 "marketing_version": marketing,
                 "platform": platform,
                 "internal_state": internal_state,
@@ -435,7 +437,61 @@ def fetch_app(app, token_factory):
                 "lanes": lanes,
             }
         )
+    # The builds-list `include=buildBetaDetail` is unreliable: ASC often omits
+    # the detail resource / relationship linkage even for builds TestFlight
+    # already shows as Ready to Test. Query the details directly (batched) for
+    # whatever the include failed to cover. A build still absent after that
+    # genuinely has no beta detail yet - the "ripening" gap between
+    # processingState=VALID and Ready to Test - and cannot be added to a test
+    # group, which the status functions surface as "Not yet testable".
+    missing = [b for b in builds if not b["internal_state"] and not b["expired"]]
+    if missing:
+        details = fetch_beta_details_by_build([b["id"] for b in missing], token_factory)
+        recovered = 0
+        for b in missing:
+            if b["id"] in details:
+                b["internal_state"], b["external_state"] = details[b["id"]]
+                recovered += 1
+            else:
+                b["beta_detail_missing"] = True
+        sys.stderr.write(
+            f"  beta details: {recovered} recovered by direct query, "
+            f"{len(missing) - recovered} not yet surfaced by TestFlight\n"
+        )
     return {"found": True, "app_id": app_id, "groups": list(groups.values()), "builds": builds}
+
+
+def fetch_beta_details_by_build(build_ids, token_factory, chunk=50):
+    """Fetch buildBetaDetails directly, batched via filter[build].
+
+    Returns {build_id: (internal_state, external_state)}. A build with no
+    entry has no beta detail resource at all - TestFlight has not surfaced
+    it for testing yet. A buildBetaDetail shares its build's id, so the
+    result keys straight off det["id"].
+    """
+    out = {}
+    for i in range(0, len(build_ids), chunk):
+        ids = ",".join(build_ids[i:i + chunk])
+        q = (
+            f"/v1/buildBetaDetails?filter[build]={ids}"
+            "&fields[buildBetaDetails]=internalBuildState,externalBuildState"
+            "&limit=200"
+        )
+        try:
+            data, _ = api_get_all(q, token_factory)
+        except urllib.error.HTTPError as err:
+            sys.stderr.write(
+                f"  buildBetaDetails query failed (HTTP {err.code}); "
+                "those statuses fall back to the processing state\n"
+            )
+            continue
+        for det in data:
+            attrs = det.get("attributes", {})
+            out[det["id"]] = (
+                attrs.get("internalBuildState", "") or "",
+                attrs.get("externalBuildState", "") or "",
+            )
+    return out
 
 
 def classify_lanes(group_ids, groups):
@@ -558,11 +614,24 @@ def _proc_status(build):
     )
 
 
+def _internal_or_processing(build):
+    """Internal beta state - what App Store Connect's add-a-build dialog shows
+    (Ready to Test / Testing / ...). A VALID build with no beta detail at all
+    is in TestFlight's hidden pre-Ready gap: it processed fine but cannot be
+    added to a test group yet."""
+    st = BETA_STATE.get(build["internal_state"])
+    if st:
+        return st
+    if build.get("beta_detail_missing") and build["processing_state"] == "VALID":
+        return ("Not yet testable", "warning")
+    return _proc_status(build)
+
+
 def internal_status(build):
     """Status as it applies to an internal group (stage/prod)."""
     if build["expired"]:
         return ("Expired", "muted")
-    return BETA_STATE.get(build["internal_state"]) or _proc_status(build)
+    return _internal_or_processing(build)
 
 
 def external_status(build):
@@ -579,7 +648,7 @@ def overall_status(build):
         return ("Expired", "muted")
     if build["external_state"] in MEANINGFUL_EXTERNAL:
         return BETA_STATE[build["external_state"]]
-    return BETA_STATE.get(build["internal_state"]) or _proc_status(build)
+    return _internal_or_processing(build)
 
 
 def lane_summary(builds, version, app_key):
@@ -831,6 +900,7 @@ def assemble(repo_versions, fragments, frag_dates, landings, tag_dates, asc):
                     "lanes": b["lanes"],
                     "groups": b["groups"],
                     "expired": b["expired"],
+                    "expires": b.get("expiration", ""),
                 }
             )
     ledger.sort(key=lambda x: x["uploaded"] or "", reverse=True)
@@ -1018,6 +1088,7 @@ HTML_TEMPLATE = r"""<!DOCTYPE html>
   .grp.prod{border-color:color-mix(in srgb,var(--good) 45%,transparent)}
   .grp.beta{border-color:color-mix(in srgb,var(--mac) 45%,transparent)}
   .apppill{display:inline-flex; align-items:center; gap:6px; font-weight:600; font-size:12.5px}
+  .expnote{font-size:10.5px; color:var(--muted); font-variant-numeric:tabular-nums; margin-top:2px}
   .empty{color:var(--muted); padding:30px 12px; text-align:center}
   .notfound{background:color-mix(in srgb,var(--critical) 10%,transparent); border:1px solid color-mix(in srgb,var(--critical) 35%,transparent); border-radius:var(--radius); padding:12px 16px; margin-bottom:16px; font-size:13px}
   footer{margin-top:28px; color:var(--muted); font-size:12px; border-top:1px solid var(--grid); padding-top:14px}
@@ -1211,7 +1282,7 @@ function renderLedger(){
     <td class="num mono">${esc(r.build_number)}</td>
     <td class="num mono" style="color:var(--ink-2)">${esc(r.build_date||'—')}</td>
     <td class="num mono" style="color:var(--ink-2)">${esc((r.uploaded||'').replace('T',' ').replace(/:\d\dZ?$/,'').replace('Z',''))||'—'}</td>
-    <td>${pill(r.status_label,r.status_role)}</td>
+    <td>${pill(r.status_label,r.status_role)}${expNote(r)}</td>
     <td>${r.lanes.length? r.lanes.map(l=>`<span class="grp ${l}">${LANE_LABEL[l]}</span>`).join('') : '<span class="lane-none">—</span>'}</td>
   </tr>`).join('');
 
@@ -1228,6 +1299,12 @@ function th(key,label){
   return `<th onclick="setSort('${key}')">${label}${arrow}</th>`;
 }
 function setSort(key){ if(sortKey===key) sortDir*=-1; else {sortKey=key; sortDir=1;} renderLedger(); }
+function expNote(r){
+  if(r.expired || !r.expires) return '';
+  const days = Math.ceil((new Date(r.expires) - Date.now())/86400000);
+  if(!isFinite(days) || days < 0) return '';
+  return `<div class="expnote">expires in ${days}d</div>`;
+}
 
 /* ---------- tabs ---------- */
 document.querySelectorAll('.tab').forEach(t=>t.addEventListener('click',()=>{
@@ -1246,7 +1323,8 @@ document.getElementById('footer').innerHTML =
   `Marketing version = <code>CFBundleShortVersionString</code> (from CHANGELOG.md). `+
   `Build # = <code>CFBundleVersion</code>, a Unix timestamp set by <code>apple.yml</code> (<code>date -u +%s</code>) — dereferenced to a date in the ledger. `+
   `Lanes: <b>Stage</b>/<b>Prod</b> are internal TestFlight groups (stage→stage, main→prod); <b>Beta</b> is an external group. `+
-  `Apple status is the App Store Connect build beta state at generation time.`;
+  `Apple status is the App Store Connect build beta state at generation time — what the add-a-build dialog shows. `+
+  `<b>Not yet testable</b> = the build processed (Valid) but TestFlight hasn't surfaced it for testing yet; it can't be added to a test group until it flips to Ready to Test.`;
 
 renderFeatures();
 renderLedger();


### PR DESCRIPTION
## Summary

The Build ledger's Apple Status column showed "Valid" (the delivery `processingState`) for every build, including ones App Store Connect's add-a-build dialog shows as "Testing" or "Ready to Test". The engine already asked for `buildBetaDetail.internalBuildState` via `include=buildBetaDetail` on the builds list, but ASC rarely honors that include, so the status always fell back to the processing state.

- Batch-query `/v1/buildBetaDetails?filter[build]=id,id,...` directly for any non-expired build the include failed to cover (chunked, a couple of extra calls per refresh — no per-build N+1).
- A build with **no beta detail resource at all** is in TestFlight's hidden pre-Ready gap (the known attach defect): it now shows **"Not yet testable"** (amber) instead of "Valid", so the ledger answers "can I add this build to a group yet?" at a glance.
- Ripened builds now show the same states as the ASC dialog: **Ready to Test** / **Testing** (and the existing review/rejection/compliance states when applicable).
- Added the dialog's expiry info: a muted "expires in Nd" note under the status pill (from the build's `expirationDate`).
- Applies to both the Flask app and the static generator (shared engine); feature-matrix lane cells pick up the corrected states too. Footers explain the new state.

## Testing

- `overall_status` unit-checked against synthetic builds (Testing / Ready to Test / gated→Not yet testable / unknown→Valid fallback / expired / external review states).
- `assemble` verified tolerant of pre-existing `--dump-asc` / `--mock` payloads that lack the new keys.
- Static generator rendered end-to-end from a mock payload: gated build renders "Not yet testable" (warning), testing build renders "Testing" (good), expiry threaded into the ledger rows.
- Live ASC path not exercised here (no ASC key in this sandbox) — worth one manual refresh against the real API to confirm the direct query populates as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)