### PR TITLE
Dashboard: disable add-to-group for builds the attach API can't act on

### DIFF
--- a/changelog.d/apple-release-dashboard.added.md
+++ b/changelog.d/apple-release-dashboard.added.md
@@ -10,4 +10,6 @@
   testable, plus days until expiry), queried directly per build since the
   builds-list `include=buildBetaDetail` is unreliable. Tracks the branch
   from `origin/stage`, and can attach a build to a TestFlight group from
-  the build ledger.
+  the build ledger; the control is disabled while a build is in a state
+  the attach API can't act on (not yet testable, expired, processing or
+  compliance holds).

--- a/scripts/apple-dashboard-app.py
+++ b/scripts/apple-dashboard-app.py
@@ -544,6 +544,8 @@ function assignSelect(r){
   const groups=(MODEL.groups&&MODEL.groups[r.app_key])||[];
   const avail=groups.filter(g=>g.id && !r.groups.includes(g.name));
   if(!avail.length) return '<span class="lane-none">—</span>';
+  if(r.attachable===false)
+    return `<select class="assign" disabled title="Can’t be added to a test group right now: ${esc(r.status_label)}"><option>＋ add to…</option></select>`;
   return `<select class="assign" data-build="${esc(r.id)}" onchange="assignBuild(this)" title="Add this build to a TestFlight group">`+
     `<option value="">＋ add to…</option>`+
     avail.map(g=>`<option value="${esc(g.id)}" data-name="${esc(g.name)}">${esc(g.name)}${g.internal?'':' · external'}</option>`).join('')+

--- a/scripts/apple-release-dashboard.py
+++ b/scripts/apple-release-dashboard.py
@@ -711,6 +711,32 @@ def first_build_any_after(builds, ts):
     return min(cand, key=lambda b: _int_build(b["build_number"]) or 0)
 
 
+# Internal states under which adding the build to a test group can't work:
+# the delivery is broken, or TestFlight still owes a step (processing, export
+# compliance) that the plain build->betaGroups POST cannot complete. External
+# review states are NOT here - a build waiting on / rejected from external
+# review is still fully attachable to internal groups.
+UNATTACHABLE_INTERNAL = {
+    "PROCESSING", "PROCESSING_EXCEPTION", "MISSING_EXPORT_COMPLIANCE",
+    "IN_EXPORT_COMPLIANCE_REVIEW", "EXPIRED",
+}
+
+
+def attachable(build):
+    """Whether attaching this build to a TestFlight group can succeed.
+
+    Unknown states (no beta detail recovered, but not confirmed missing)
+    stay attachable - a failed attempt surfaces its own error, which beats
+    falsely locking the control."""
+    if build["expired"]:
+        return False
+    if build["processing_state"] and build["processing_state"] != "VALID":
+        return False
+    if build.get("beta_detail_missing"):
+        return False
+    return build["internal_state"] not in UNATTACHABLE_INTERNAL
+
+
 def built_status(build):
     """Status for the 'Built' cell: the build exists, independent of groups."""
     if build["expired"]:
@@ -901,6 +927,7 @@ def assemble(repo_versions, fragments, frag_dates, landings, tag_dates, asc):
                     "groups": b["groups"],
                     "expired": b["expired"],
                     "expires": b.get("expiration", ""),
+                    "attachable": attachable(b),
                 }
             )
     ledger.sort(key=lambda x: x["uploaded"] or "", reverse=True)


### PR DESCRIPTION
## Summary

Follow-up to #727. The Build ledger's "＋ add to…" control is now disabled — same footprint, tooltip names the blocking status — when the build→betaGroups POST can't do anything useful:

- **Not yet testable** (no beta detail yet — TestFlight's pre-Ready gap)
- **Expired**
- **Processing / Processing failed / Failed / Invalid** (delivery unfinished or broken)
- **Missing export compliance / Export compliance review** (the API attach can't answer the compliance questions ASC's dialog would ask, so the build wouldn't distribute)

Attachability is computed in the engine from the underlying ASC fields (`expired`, `processingState`, `internalBuildState`, detail-missing), not the display label. Deliberately still enabled:

- External review states (Waiting for Review / In Review / Rejected) — those only gate the external group; the build is fully attachable to internal groups.
- Unknown state (e.g. a transient buildBetaDetails query failure falls back to "Valid") — a failed attach surfaces its own toast, which beats falsely locking the control.

## Testing

- `attachable()` unit-checked across all 12 state combinations (ready/testing/gated/expired/processing/failed/compliance/unknown/external-rejected).
- Verified pre-existing `--mock` / `--dump-asc` payloads without the new key leave the control enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)