### PR TITLE
Share the 10DLC number with SNS via EUM resource policy

### DIFF
--- a/.github/scripts/put-sms-resource-policy.sh
+++ b/.github/scripts/put-sms-resource-policy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Converge the resource-based policy on the account's 10DLC phone
+# number in AWS End User Messaging, sharing it with Amazon SNS.
+#
+# Cognito publishes SMS through SNS, and SNS can only originate from an
+# End User Messaging phone number that has a resource policy granting
+# the sns.amazonaws.com service principal sms-voice:SendTextMessage --
+# "even if you are using the same AWS account" (AWS End User Messaging
+# SMS User Guide, "Request a phone number"). The console's number-
+# request wizard offers a checkbox that writes this policy; numbers
+# provisioned through the RequestPhoneNumber API (as Terraform does)
+# get no policy, and every SNS publish then fails silently with
+# "No origination identity available to send to destination number".
+#
+# Terraform cannot own this: the AWS provider exposes no resource for
+# EUM resource policies, so this runs as a post-apply step in
+# infra.yml. put-resource-policy is a full overwrite, making this
+# idempotent; steady-state it is a no-op rewrite of the same policy.
+#
+# No-op (exit 0) when the account has no 10DLC number yet - the number
+# only exists once the campaign registration is approved and its id is
+# supplied to Terraform.
+set -euo pipefail
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+NUMBER_ARNS=$(aws pinpoint-sms-voice-v2 describe-phone-numbers \
+  --query "PhoneNumbers[?NumberType=='TEN_DLC'].PhoneNumberArn" \
+  --output text)
+
+if [ -z "${NUMBER_ARNS}" ]; then
+  echo "[sms-resource-policy] no 10DLC phone number in this account; nothing to do"
+  exit 0
+fi
+
+for arn in ${NUMBER_ARNS}; do
+  echo "[sms-resource-policy] sharing ${arn} with Amazon SNS"
+  aws pinpoint-sms-voice-v2 put-resource-policy \
+    --resource-arn "${arn}" \
+    --policy "$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"Service": "sns.amazonaws.com"},
+      "Action": "sms-voice:SendTextMessage",
+      "Resource": "${arn}",
+      "Condition": {"StringEquals": {"aws:SourceAccount": "${ACCOUNT_ID}"}}
+    }
+  ]
+}
+EOF
+)" >/dev/null
+  echo "[sms-resource-policy] policy set on ${arn}"
+done

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -59,6 +59,7 @@ on:
       - '.github/scripts/record-lambda-hashes.sh'
       - '.github/scripts/post-apply-update-services.sh'
       - '.github/scripts/put-sms-keywords.sh'
+      - '.github/scripts/put-sms-resource-policy.sh'
       - '.github/scripts/annotate-terraform-outputs.sh'
 
 permissions:
@@ -111,6 +112,7 @@ jobs:
             - '.github/scripts/record-lambda-hashes.sh'
             - '.github/scripts/post-apply-update-services.sh'
             - '.github/scripts/put-sms-keywords.sh'
+            - '.github/scripts/put-sms-resource-policy.sh'
             - '.github/scripts/annotate-terraform-outputs.sh'
 
   bootstrap_build:
@@ -839,3 +841,11 @@ jobs:
         OPERATOR_NAME: ${{ vars.OPERATOR_NAME }}
         CONTROL_DOMAIN: ${{ vars.TF_VAR_CONTROL_DOMAIN }}
       run: ./.github/scripts/put-sms-keywords.sh
+    - name: set-sms-resource-policy
+      # Share the 10DLC number with Amazon SNS via an EUM resource
+      # policy - required for Cognito's SNS-path SMS even within the
+      # same account, and not expressible in Terraform (the provider
+      # has no EUM resource-policy resource). Without it every SNS
+      # publish is silently dropped with "No origination identity
+      # available". No-op when no 10DLC number exists.
+      run: ./.github/scripts/put-sms-resource-policy.sh

--- a/changelog.d/sms-sns-resource-policy.fixed.md
+++ b/changelog.d/sms-sns-resource-policy.fixed.md
@@ -1,0 +1,9 @@
+- **Cognito verification SMS never delivered.** The 10DLC phone number
+  lacked the End User Messaging resource policy that shares it with
+  Amazon SNS (required even within the owning account), so every
+  Cognito-originated send was silently dropped with "No origination
+  identity available to send to destination number". A new post-apply
+  step (`put-sms-resource-policy.sh`) now converges the policy on the
+  10DLC number, and `docs/sms-10dlc.md` documents the requirement, the
+  silent-failure signature, and an SNS-path smoke test. The CI role
+  needs one new grant: `sms-voice:PutResourcePolicy` (docs/aws.md).

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -79,6 +79,7 @@ After signing up, perform the following steps:
                     "sms-voice:DescribePhoneNumbers",
                     "sms-voice:ListTagsForResource",
                     "sms-voice:PutKeyword",
+                    "sms-voice:PutResourcePolicy",
                     "sms-voice:ReleasePhoneNumber",
                     "sms-voice:RequestPhoneNumber",
                     "sms-voice:TagResource",
@@ -97,7 +98,7 @@ After signing up, perform the following steps:
 
     (`kms:*` exists for DNSSEC signing (`TF_VAR_DNSSEC_ENABLED`, off by default). An enumerated grant was tried and abandoned: Terraform's key lifecycle touched new `kms:` actions on every apply stage - more than twenty in all - and chasing them one AccessDenied at a time is not worth it for a policy that already carries `iam:*`. If you don't intend to enable DNSSEC, you may shrink it to `kms:CreateGrant` and `kms:DescribeKey`, and omit the six `route53:` lines that mention `KeySigningKey` or `DNSSEC` - but not `route53:GetDNSSEC`, which Terraform reads unconditionally. See [DNSSEC](./dnssec.md).)
 
-    (If you don't intend to enable SMS verification through AWS End User Messaging (`TF_VAR_TEN_DLC_CAMPAIGN_REGISTRATION_ID`, unset by default), you may omit the eight `sms-voice:` lines. The 10DLC brand and campaign registration that precedes number provisioning is an operator-run CLI process with its own permissions, not part of this CI policy; see [10DLC SMS registration](./sms-10dlc.md).)
+    (If you don't intend to enable SMS verification through AWS End User Messaging (`TF_VAR_TEN_DLC_CAMPAIGN_REGISTRATION_ID`, unset by default), you may omit the nine `sms-voice:` lines. The 10DLC brand and campaign registration that precedes number provisioning is an operator-run CLI process with its own permissions, not part of this CI policy; see [10DLC SMS registration](./sms-10dlc.md).)
 
     (`imagebuilder:*` covers the EC2 Image Builder pipeline that bakes the custom NAT instance AMI. `scheduler:*` covers the EventBridge Scheduler schedules for certificate renewal and DMARC report processing.)
 

--- a/docs/sms-10dlc.md
+++ b/docs/sms-10dlc.md
@@ -247,24 +247,52 @@ Once the campaign shows `RegistrationStatus: COMPLETE`:
    target environment.
 2. Ensure the CI deploy role has `sms-voice` permissions including
    `RequestPhoneNumber`, `ReleasePhoneNumber`, `UpdatePhoneNumber`,
-   `DescribePhoneNumbers`, `PutKeyword`, and `DescribeKeywords`
-   (the per-account Terraform policy is hand-managed; see
-   [aws.md](./aws.md)).
+   `DescribePhoneNumbers`, `PutKeyword`, `DescribeKeywords`, and
+   `PutResourcePolicy` (the per-account Terraform policy is
+   hand-managed; see [aws.md](./aws.md)).
 3. Run `infra.yml` (any push touching `terraform/infra/**`, or a
    `workflow_dispatch`). Terraform requests the number against the
    campaign and waits for it to reach `ACTIVE`; the post-apply
    `set-sms-keywords` step then writes the HELP/STOP/START keyword
-   responses so they match the registered texts.
+   responses so they match the registered texts, and
+   `set-sms-resource-policy` shares the number with Amazon SNS.
+
+**The resource policy is load-bearing.** Cognito sends SMS via SNS,
+and SNS can only originate from an End User Messaging number whose
+resource policy grants `sns.amazonaws.com` the
+`sms-voice:SendTextMessage` action — *even within the owning account*.
+The console's number-request wizard writes this policy when its "share
+with Amazon SNS" box is checked, but numbers provisioned through the
+`RequestPhoneNumber` API (as Terraform does) start with no policy.
+Without it, every Cognito/SNS send fails with no error to the caller:
+`sns:Publish` succeeds, nothing is billed or delivered, and only the
+SNS delivery-status log (if enabled) records the reason —
+`No origination identity available to send to destination number`.
+Confusingly, the sandbox verification OTPs still arrive, because both
+verification services send outside the SNS publish path — receiving an
+OTP does not prove the path works.
 
 Verify:
 
 ```sh
 aws pinpoint-sms-voice-v2 describe-phone-numbers
 aws pinpoint-sms-voice-v2 describe-keywords --origination-identity <phone number id>
+aws pinpoint-sms-voice-v2 get-resource-policy --resource-arn <phone number ARN>
 aws pinpoint-sms-voice-v2 send-text-message \
   --destination-phone-number <your mobile> \
   --message-body "Cabalmail smoke test" \
   --origination-identity <phone number id>
+```
+
+`get-resource-policy` must show the `sns.amazonaws.com` statement
+described above. Note `send-text-message` exercises the End User
+Messaging path only; it delivers even when the SNS path is broken. To
+verify what Cognito actually uses, publish through SNS as well:
+
+```sh
+aws sns publish --phone-number <your mobile> \
+  --message "Cabalmail SNS-path smoke test" \
+  --message-attributes '{"AWS.SNS.SMS.SMSType":{"DataType":"String","StringValue":"Transactional"}}'
 ```
 
 Text STOP and then START to the number to confirm the keyword


### PR DESCRIPTION
## Root cause

Stage signup SMS never delivered. Bisection (SNS delivery-status logs + direct sends over both paths) showed every Cognito/SNS publish dying in ~67ms with `No origination identity available to send to destination number`, while EUM `SendTextMessage` from the same number delivered fine.

Per the AWS End User Messaging SMS User Guide ("Request a phone number"): *"You must use a Resource policy to share the phone number with Amazon Pinpoint or Amazon SNS even if you are using the same AWS account."* The console wizard writes that policy behind a checkbox; the `RequestPhoneNumber` API — which our Terraform uses — does not. So the 10DLC numbers in stage and prod were invisible to SNS, and Cognito's sends vanished with no error surfaced to the caller.

## Change

- New post-apply step `put-sms-resource-policy.sh` (same pattern as the keyword converger, since the provider has no EUM resource-policy resource): shares every 10DLC number in the account with `sns.amazonaws.com`, scoped by `aws:SourceAccount`. Idempotent full overwrite; no-op when no number exists.
- `docs/sms-10dlc.md`: documents the requirement, the silent-failure signature (sandbox OTPs still arrive — receiving one does not prove the path works), and adds `get-resource-policy` plus an SNS-path `sns publish` smoke test to the verify block (EUM `send-text-message` alone cannot catch this class of failure).
- `docs/aws.md`: adds `sms-voice:PutResourcePolicy` to the hand-managed CI grant list.

## Operator notes

- The CI role in each account needs the `sms-voice:PutResourcePolicy` grant before the post-apply step can succeed.
- Stage/prod can be fixed immediately with a one-off `put-resource-policy` from CloudShell (same JSON the script writes); the CI step then keeps it converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)