### PR TITLE
Align Cognito SMS templates with registered 10DLC campaign texts

### DIFF
--- a/changelog.d/cognito-sms-templates.fixed.md
+++ b/changelog.d/cognito-sms-templates.fixed.md
@@ -1,0 +1,5 @@
+- **Cognito SMS templates aligned with the registered 10DLC campaign
+  texts.** The verification message now carries the trailing period of
+  the registered sample, and an authentication (MFA) template is set so
+  that enabling SMS MFA later sends the registered brand text rather
+  than Cognito's unbranded default, which matches no registered sample.

--- a/terraform/infra/modules/user_pool/main.tf
+++ b/terraform/infra/modules/user_pool/main.tf
@@ -5,7 +5,15 @@
 resource "aws_cognito_user_pool" "users" {
   name                     = "cabal"
   auto_verified_attributes = ["phone_number"]
-  sms_verification_message = "Your Cabalmail verification code is {####}"
+
+  # Both templates must match messageSample1 registered with the 10DLC
+  # campaign (docs/sms-10dlc.md) - carriers vet live traffic against the
+  # registered samples, including the trailing period. The authentication
+  # message is unused until SMS MFA is enabled, but is set now so enabling
+  # MFA can never fall back to Cognito's unbranded default text, which
+  # matches no registered sample.
+  sms_verification_message   = "Your Cabalmail verification code is {####}."
+  sms_authentication_message = "Your Cabalmail verification code is {####}."
 
   sms_configuration {
     sns_caller_arn = aws_iam_role.users.arn


### PR DESCRIPTION
Cross-checked every SMS message documented in docs/sms-10dlc.md against what the application actually sends, and fixed the two template gaps found in the Cognito user pool.

## Verified as implemented
- HELP/STOP/START keyword auto-responses: `put-sms-keywords.sh`, wired as the `set-sms-keywords` post-apply step in `infra.yml`, matches the registered helpMessage/stopMessage.
- Consent surfaces: mandatory unchecked-by-default checkbox in `react/admin/src/SignUp` with brand, frequency, rates, and HELP/STOP disclosures; `front-door/terms.html` + `privacy.html` carry the disclosures; `front-door/opt-in-screenshot.png` present.
- Password-reset SMS: account recovery via `verified_phone_number` uses the verification template, matching registered messageSample1.

## Fixed here
- `sms_verification_message` gains the trailing period present in the registered messageSample1, so the deployed text matches the registered sample exactly.
- `sms_authentication_message` is now set to the same registered text. It is unused until SMS MFA is enabled (a known, deliberately deferred step), but without it a future MFA enablement would silently send Cognito's unbranded default — which matches no registered sample.

## Known gaps, deliberately not changed
- Sign-in MFA itself remains off (identity-hardening Phase 1, deferred by choice).
- Registered messageSample2 (password-changed notification) is not sent by anything; registering more samples than you send is not a compliance problem, only the reverse is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)