### PR TITLE
Never block the compose From picker on the rich-text editor bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Versioned subdirectories of `docs/` (e.g. `docs/0.4.0/`, `docs/0.7.0/`, `docs/0.
 - Local test: `cd lambda/api/[function_dir] && python -m function`
 
 ### Apple Clients (`apple/`)
-- Generate Xcode project: `cd apple && xcodegen generate` (regenerates `Cabalmail.xcodeproj` from `project.yml`; not committed)
+- Generate Xcode project: `cd apple && xcodegen generate` (regenerates `Cabalmail.xcodeproj` from `project.yml`; not committed. Also materializes the gitignored marked/turndown web assets via `scripts/sync-vendored.sh` — needs node/npm the first time. Building from a checkout without those assets produces an app whose rich-text bridge never boots; run `swift test` setups through the same script.)
 - Kit tests: `cd apple/CabalmailKit && swift test` (the bulk of the Apple-side coverage — networking, parsing, caching, auth)
 - App-layer tests: `cd apple && xcodebuild test -workspace Cabalmail.xcworkspace -scheme CabalmailMac -destination 'platform=macOS' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` — XCTest suite for the app target's view models (`apple/CabalmailTests/`, e.g. bulk-selection/move flows against a `FakeImapClient`). `swift test` does **not** compile or run these, and `apple.yml` runs them only on push to a named branch, not on PRs — so run them locally before merging a change to a shared protocol (e.g. `ImapClient`) or a view model.
 - iOS build sanity check: `cd apple && xcodebuild -workspace Cabalmail.xcworkspace -scheme Cabalmail -destination 'generic/platform=iOS' build CODE_SIGNING_ALLOWED=NO`

--- a/apple/Cabalmail/ViewModels/ComposeViewModel.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel.swift
@@ -169,6 +169,12 @@ final class ComposeViewModel {
         self.editorController.onContentChanged = { [weak self] in
             self?.richMirrorsMarkdown = false
         }
+        // A bridge that dies while bootstrapping never posts `ready`, so
+        // the rich pane (and send-time conversion) is out of commission
+        // for this compose. Say so instead of failing silently (#734).
+        self.editorController.onBridgeError = { [weak self] message in
+            self?.errorMessage = "Rich-text editor failed to load: \(message)"
+        }
     }
 
     /// Cancel the autosave loops. Called from the view's `onDisappear` and
@@ -200,8 +206,15 @@ final class ComposeViewModel {
                 await self?.autosaveToServer()
             }
         }
+        // Load the address list concurrently with the editor seed rather
+        // than after it. The seed blocks on the WebKit bridge bootstrap,
+        // and a bridge that never comes up (broken editor-bridge.js, a
+        // killed content process) would otherwise park `start()` before
+        // the address load, leaving the From picker permanently empty and
+        // compose unusable (#734).
+        async let addressLoad: Void = refreshAddresses()
         await seedRichFromMarkdown()
-        await refreshAddresses()
+        await addressLoad
     }
 
     func refreshAddresses(forceRefresh: Bool = false) async {

--- a/apple/CabalmailKit/Sources/CabalmailKit/Compose/RichTextEditorController.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Compose/RichTextEditorController.swift
@@ -129,6 +129,12 @@ public final class RichTextEditorController: NSObject {
     public var onSelectionChanged: (@MainActor (Selection) -> Void)?
     /// Fires once after the editor finishes bootstrapping.
     public var onReady: (@MainActor () -> Void)?
+    /// Fires when the editor page reports a script error — most notably a
+    /// failure while loading or evaluating marked / turndown /
+    /// editor-bridge.js, after which the bridge never posts `ready` and
+    /// every editor await stays parked. Hosts should surface this to the
+    /// user; the controller only records and forwards it.
+    public var onBridgeError: (@MainActor (String) -> Void)?
 
     private var pendingReadyContinuations: [CheckedContinuation<Void, Never>] = []
 
@@ -269,6 +275,12 @@ public final class RichTextEditorController: NSObject {
             pendingReadyContinuations.removeAll()
             for continuation in waiters { continuation.resume() }
             onReady?()
+        case "error":
+            let message = payload["message"] as? String ?? "unknown script error"
+            let source = payload["source"] as? String ?? ""
+            let described = source.isEmpty ? message : "\(message) (\(source))"
+            NSLog("[RichTextEditor] bridge script error: %@", described)
+            onBridgeError?(described)
         case "input":
             onContentChanged?()
         case "selection":

--- a/apple/CabalmailKit/Sources/CabalmailKit/Compose/WebAssets/editor.html
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Compose/WebAssets/editor.html
@@ -4,6 +4,29 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 <title>Cabalmail rich text editor</title>
+<script>
+  // Relay page-level script errors to native. Inline and installed before
+  // the library <script> tags so a failure while loading or evaluating
+  // marked / turndown / editor-bridge.js (which would prevent the bridge's
+  // "ready" post and park every native await) is surfaced instead of
+  // silently hanging the compose surface (#734).
+  // Capture phase: resource-load failures (a missing <script src>) fire on
+  // the element and don't bubble, so a bubble-phase listener would only see
+  // runtime throws.
+  window.addEventListener('error', function (event) {
+    var handlers = window.webkit && window.webkit.messageHandlers;
+    if (!handlers || !handlers.cabal) return;
+    var target = event.target;
+    var message = event.message
+      ? String(event.message)
+      : 'failed to load ' + String((target && target.src) || 'resource').split('/').pop();
+    handlers.cabal.postMessage({
+      type: 'error',
+      message: message,
+      source: String(event.filename || '').split('/').pop()
+    });
+  }, true);
+</script>
 <style>
   :root {
     color-scheme: light dark;

--- a/apple/project.yml
+++ b/apple/project.yml
@@ -16,6 +16,14 @@ configFiles:
   Release: Base.xcconfig
 
 options:
+  # Materialize the gitignored marked + turndown bundles before generating.
+  # A project generated without them still builds, but the app's rich-text
+  # bridge throws on load and never reports ready, which used to leave the
+  # compose From picker permanently empty (#734). CI also runs the script
+  # explicitly; here it covers local and agent-driven builds, where the
+  # generate step is the one universal entry point. Needs node/npm on the
+  # first run (the script skips `npm ci` once the sources are present).
+  preGenCommand: scripts/sync-vendored.sh
   bundleIdPrefix: com.cabalmail
   deploymentTarget:
     iOS: "18.0"

--- a/changelog.d/ios-from-picker-empty.fixed.md
+++ b/changelog.d/ios-from-picker-empty.fixed.md
@@ -1,0 +1,10 @@
+- Apple: **Compose From picker no longer blocked by the rich-text
+  editor.** The compose sheet loaded its address list only after the
+  WebKit editor bridge finished bootstrapping, so a bridge that failed to
+  come up left the From menu permanently empty — composing was impossible
+  without minting a new address per message. The address list now loads
+  concurrently with the editor seed, and a bridge script failure is
+  reported in the compose error banner instead of hanging silently.
+  `xcodegen generate` also materializes the vendored marked/turndown
+  bundles automatically, removing the broken-local-build shape that
+  triggered the hang.


### PR DESCRIPTION
Fixes #734 (iOS: compose From picker never lists the account's addresses).

## Root cause

`ComposeViewModel.start()` sequenced `refreshAddresses()` **behind** `seedRichFromMarkdown()`, which awaits the WebKit editor bridge's `ready` signal with no timeout. In the tester's build (and any locally generated build where `apple/scripts/sync-vendored.sh` was never run — the vendored `marked.umd.js`/`turndown.js` are gitignored), `editor-bridge.js` throws at load (`new window.TurndownService(...)` with the library missing), `ready` never posts, and `start()` parks forever before the address load. The From picker stays empty with no error, exactly as filed. Confirmed against the tester's own checkout at `a0248cf5`: its `WebAssets/` has only `editor.html` + `editor-bridge.js`. CI runs the sync script, which is why TestFlight builds never showed this.

## Changes

- **`ComposeViewModel.start()`**: address list loads concurrently with the editor seed (`async let`) — the From picker never waits on the bridge, and there's no added latency for reply seeds.
- **`editor.html` + `RichTextEditorController` + `ComposeViewModel`**: a capture-phase error handler relays script/resource failures to native, which surfaces them in the compose error banner ("Rich-text editor failed to load: …") instead of hanging silently — the "errorMessage being swallowed" half of the report.
- **`project.yml`**: `preGenCommand: scripts/sync-vendored.sh` — `xcodegen generate` now materializes the vendored bundles, so local/agent builds can't produce the broken bundle in the first place. CLAUDE.md updated to match.

## Verification (iPhone 17 sim, iOS 26.5, stage)

1. Reproduced the filed symptom on an instrumented build: log shows `start()` entering the editor seed and never returning; menu shows only "Create new address…".
2. With the fix but a still-broken bundle: From menu lists the account's address, and the editor-failure banner renders.
3. With the synced bundle: full flow round-trips — pick From from the menu, type in the rich editor, Send → "Message sent." toast.
4. `swift test` (CabalmailKit): 360 tests, 0 failures. `xcodebuild test` (CabalmailMac app-layer suite): TEST SUCCEEDED. swiftlint clean on changed files.

Residual (pre-existing, much less likely now that the broken-bundle shape is gone): if the bridge dies, Send/draft-save still await editor conversions without a timeout — the failure is now at least surfaced in the banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)