### PR TITLE
Warn on missing lifecycle labels; self-pointing --repo for Apple dashboards

### DIFF
--- a/changelog.d/apple-dashboard-self-repo.changed.md
+++ b/changelog.d/apple-dashboard-self-repo.changed.md
@@ -1,0 +1,5 @@
+- **Self-pointing `--repo` for the Apple release dashboards.**
+  `apple-dashboard-app.py` and `apple-release-dashboard.py` now default
+  `--repo` to the checkout containing the script (matching the triage
+  dashboard) instead of the current directory, so they work from any
+  working directory without flags.

--- a/changelog.d/triage-dashboard.added.md
+++ b/changelog.d/triage-dashboard.added.md
@@ -6,6 +6,8 @@
   events, and new-tab links to each issue and PR. Closed and non-cycle
   issues are omitted. Per-row triage actions: Accept adds the `accepted`
   label (queuing the nightly fixer), and Close posts a required comment
-  before closing the issue as not-planned or completed. Data comes live
-  from the GitHub GraphQL API through `gh` (or a `GITHUB_TOKEN`), with the
-  same refresh/auto-refresh/theme chrome as the Apple dashboard.
+  before closing the issue as not-planned or completed. A banner warns
+  when a configured lifecycle label doesn't exist in the repo (fresh forks
+  don't inherit labels). Data comes live from the GitHub GraphQL API
+  through `gh` (or a `GITHUB_TOKEN`), with the same
+  refresh/auto-refresh/theme chrome as the Apple dashboard.

--- a/scripts/apple-dashboard-app.py
+++ b/scripts/apple-dashboard-app.py
@@ -26,7 +26,7 @@ Run:
     export ASC_KEY_ID=XXXXXXXXXX
     export ASC_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     export ASC_KEY_PATH=~/AuthKey_XXXXXXXXXX.p8
-    python3 scripts/apple-dashboard-app.py --repo .   # from the repo root
+    python3 scripts/apple-dashboard-app.py   # --repo defaults to this checkout
     # then open http://127.0.0.1:5057
 
 --mock <file.json> serves a captured/synthetic ASC payload (offline preview).
@@ -606,7 +606,8 @@ renderIntervalMenu(); fetchData();
 def main():
     global ENGINE, REPO_ROOT, MOCK_PATH, REF, FETCH
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--repo", default=".", help="Path to the cabal-infra repo root (default: cwd)")
+    ap.add_argument("--repo", default=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                    help="Path to the cabal-infra repo root (default: the checkout containing this script)")
     ap.add_argument("--engine", help="Path to apple-release-dashboard.py (default: next to this file)")
     ap.add_argument("--mock", help="Serve a captured/synthetic ASC JSON file instead of calling the API")
     ap.add_argument("--ref", default="origin/stage",

--- a/scripts/apple-release-dashboard.py
+++ b/scripts/apple-release-dashboard.py
@@ -25,8 +25,9 @@ reach api.appstoreconnect.apple.com:
     export ASC_KEY_ID=XXXXXXXXXX
     export ASC_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     export ASC_KEY_PATH=~/AuthKey_XXXXXXXXXX.p8
-    python3 scripts/apple-release-dashboard.py --repo . \
-        --out apple-dashboard.html && open apple-dashboard.html   # from the repo root
+    python3 scripts/apple-release-dashboard.py \
+        --out apple-dashboard.html && open apple-dashboard.html
+    # --repo defaults to the checkout containing the script
 
 `--mock <file.json>` renders from a captured/synthetic ASC payload instead
 of calling the API - useful for previewing the layout or running offline.
@@ -1363,7 +1364,8 @@ renderLedger();
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--repo", default=".", help="Path to the cabal-infra repo root (default: cwd)")
+    ap.add_argument("--repo", default=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                    help="Path to the cabal-infra repo root (default: the checkout containing this script)")
     ap.add_argument("--out", default="apple-dashboard.html", help="Output HTML path")
     ap.add_argument("--mock", help="Render from a captured/synthetic ASC JSON file instead of the API")
     ap.add_argument("--dump-asc", help="Write the normalized ASC payload to this JSON path")

--- a/scripts/triage-dashboard.py
+++ b/scripts/triage-dashboard.py
@@ -64,7 +64,7 @@ FALLBACK_COLORS = {
 QUERY = """
 query($owner: String!, $name: String!, $cursor: String) {
   repository(owner: $owner, name: $name) {
-    labels(first: 100) { nodes { name color } }
+    labels(first: 100) { totalCount nodes { name color } }
     issues(states: OPEN, first: 100, after: $cursor,
            orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount
@@ -180,12 +180,15 @@ def build_model():
     """Fetch open issues and shape the triage model served at /api/data."""
     owner, name = REPO_SLUG.split("/", 1)
     label_colors = dict(FALLBACK_COLORS)
+    repo_labels, all_labels_seen = set(), True
     nodes, cursor, total = [], None, 0
     while True:
         data = graphql({"owner": owner, "name": name, "cursor": cursor})
         repo = data["repository"]
         for lab in repo["labels"]["nodes"]:
             label_colors[lab["name"]] = lab["color"]
+            repo_labels.add(lab["name"])
+        all_labels_seen = repo["labels"]["totalCount"] <= len(repo["labels"]["nodes"])
         issues = repo["issues"]
         total = issues["totalCount"]
         nodes.extend(issues["nodes"])
@@ -231,6 +234,8 @@ def build_model():
         "generated": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
         "stages": [{"key": s, "color": label_colors.get(s, "8b8a86")} for s in STAGES],
         "accept_label": ACCEPT_LABEL,
+        "missing_labels": [s for s in dict.fromkeys(STAGES + [ACCEPT_LABEL])
+                           if s not in repo_labels] if all_labels_seen else [],
         "issues": rows,
         "open_total": total,
         "counts": counts,
@@ -363,6 +368,7 @@ PAGE = r"""<!DOCTYPE html>
   .rmenu-item[aria-selected="true"]{font-weight:600}
   .banner{border-radius:var(--radius); padding:12px 16px; margin-bottom:16px; font-size:13px}
   .banner.err{background:color-mix(in srgb,var(--critical) 12%,transparent); border:1px solid color-mix(in srgb,var(--critical) 40%,transparent); color:var(--critical)}
+  .banner.warn{background:color-mix(in srgb,var(--warning) 16%,transparent); border:1px solid color-mix(in srgb,var(--warning) 45%,transparent)}
   .stats{display:flex; gap:10px; flex-wrap:wrap; margin:18px 0 18px}
   .stat{background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:12px 16px; min-width:130px; font:inherit; color:var(--ink); text-align:left; cursor:pointer}
   .stat:hover{background:var(--surface-2)}
@@ -445,6 +451,7 @@ PAGE = r"""<!DOCTYPE html>
   </header>
 
   <div id="error"></div>
+  <div id="warn"></div>
   <div class="stats" id="stats"></div>
 
   <div class="controls">
@@ -520,6 +527,13 @@ function clearError(){ document.getElementById('error').innerHTML=''; }
 function renderAll(){
   if(!MODEL) return;
   document.getElementById('sub').textContent=`${MODEL.repo} · ${MODEL.issues.length} of ${MODEL.open_total} open issues are in the tester/fixer cycle · data ${MODEL.generated}`;
+  const miss=MODEL.missing_labels||[], one=miss.length===1;
+  document.getElementById('warn').innerHTML=miss.length?
+    `<div class="banner warn"><b>Label${one?'':'s'} missing from ${esc(MODEL.repo)}:</b> `+
+    miss.map(m=>`<code>${esc(m)}</code>`).join(', ')+
+    `. No issue can carry ${one?'this label, so its column stays':'these labels, so their columns stay'} empty`+
+    (miss.includes(MODEL.accept_label)?`, and Accept can't queue anything until <code>${esc(MODEL.accept_label)}</code> exists`:'')+
+    `. Create ${one?'it':'them'} under Issues → Labels on GitHub, or point <code>--stages</code>/<code>--accept-label</code> at labels this repo has.</div>`:'';
   renderStats(); renderRows();
 }
 


### PR DESCRIPTION
## Summary

Fork-friendliness follow-ups to #746/#748:

- **Triage dashboard: missing-label banner.** Each refresh already fetches the repo's labels; now any configured stage label (or the Accept label) that doesn't exist in the repo surfaces as a warning banner — "no issue can carry this label, so its column stays empty; Accept can't queue anything" — with a pointer to Issues → Labels or `--stages`/`--accept-label`. This matters for forks, which don't inherit labels; previously the failure mode was a silently empty table. The check is skipped (no false positives) if the repo has more labels than the single-page fetch covers.
- **Apple dashboards: self-pointing `--repo`.** `apple-dashboard-app.py` and its engine `apple-release-dashboard.py` now default `--repo` to the checkout containing the script instead of the cwd, matching the triage dashboard — no more pointing them at the repo when launched from elsewhere. (These dashboards read a local checkout rather than the GitHub API, so a path default is the equivalent of the triage dashboard's origin-remote slug detection.)

## Test plan

- [x] `--stages …,wont-reproduce` renders the banner, a zero stat tile, and an empty column; default stages return `missing_labels: []` and no banner (screenshot + API checked)
- [x] `apple-dashboard-app.py --help` from a foreign cwd shows the checkout-derived default; all three scripts `py_compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)