### PR TITLE
Recover from spurious URL cancellations on the envelope list's first load

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel.swift
@@ -237,8 +237,16 @@ final class MessageListViewModel {
 
     func loadInitial() async {
         guard envelopes.isEmpty else { return }
-        await hydrateFromCache()
-        await refresh()
+        // Unstructured, model-owned task, so a cancellation of the view's
+        // `.task` (SwiftUI fires it mid-push transition — same class as the
+        // detail view's #403) can't propagate into the first fetch. The view
+        // only runs this once per model, so a cancelled first load would
+        // paint `network("cancelled")` over an empty list with nothing left
+        // to retry it. Mirrors `refreshFromPull`.
+        await Task {
+            await self.hydrateFromCache()
+            await self.refresh()
+        }.value
         scheduleBottomPrefetch()
     }
 

--- a/apple/CabalmailKit/Sources/CabalmailKit/Auth/HTTPTransport.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Auth/HTTPTransport.swift
@@ -25,9 +25,11 @@ public protocol HTTPTransport: Sendable {
 ///    (`-1005`) before the request can finish. The assertion buys roughly
 ///    30 seconds after backgrounding for the request to complete.
 /// 2. **Transient-error retry + normalization.** On
-///    `URLError.networkConnectionLost` or `URLError.timedOut`, retries
-///    once after a short backoff (Apple's own guidance for `-1005`). Any
-///    `URLError` that escapes is normalized into
+///    `URLError.networkConnectionLost`, `URLError.timedOut`, or a spurious
+///    `URLError.cancelled` (one that arrives while our own Task is NOT
+///    cancelled — URLSession drops data tasks on its own; see fe73f2f0),
+///    retries once after a short backoff (Apple's own guidance for `-1005`).
+///    Any `URLError` that escapes is normalized into
 ///    `CabalmailError.network(localizedDescription)` so callers and toast
 ///    UIs see a readable message instead of the verbose NSError dump.
 public struct URLSessionHTTPTransport: HTTPTransport {
@@ -74,6 +76,14 @@ public struct URLSessionHTTPTransport: HTTPTransport {
         switch err.code {
         case .networkConnectionLost, .timedOut:
             return true
+        case .cancelled:
+            // URLSession occasionally fails a data task with `.cancelled`
+            // that nobody asked for (the class fe73f2f0 recovered from on
+            // the body fetch — that recovery went dead when this transport
+            // started normalizing URLError before callers could see the
+            // code). Only a cancellation that didn't come from our own Task
+            // is transient; a cooperative cancel propagates immediately.
+            return !Task.isCancelled
         default:
             return false
         }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/HTTPTransportTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/HTTPTransportTests.swift
@@ -50,6 +50,31 @@ final class HTTPTransportTests: XCTestCase {
         XCTAssertEqual(ScriptedURLProtocol.callCount, 2)
     }
 
+    func testRetriesOnceOnSpuriousCancel() async throws {
+        // A `.cancelled` failure while our own Task is NOT cancelled is
+        // URLSession dropping the data task on its own — transient, retried.
+        ScriptedURLProtocol.script(
+            failures: [URLError(.cancelled)],
+            responses: [(Data("{}".utf8), 200)]
+        )
+        let transport = makeTransport()
+        let (_, response) = try await transport.perform(sampleRequest())
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(ScriptedURLProtocol.callCount, 2)
+    }
+
+    func testCancelledIsNotRetryableInsideCancelledTask() async {
+        // A cooperative cancel (our own Task was cancelled) must propagate,
+        // not spin a retry.
+        let task = Task { () -> Bool in
+            while !Task.isCancelled { await Task.yield() }
+            return URLSessionHTTPTransport.isRetryableTransportError(URLError(.cancelled))
+        }
+        task.cancel()
+        let retryable = await task.value
+        XCTAssertFalse(retryable)
+    }
+
     func testPersistentNetworkConnectionLostSurfacesAsCabalmailNetworkError() async throws {
         ScriptedURLProtocol.script(failures: [
             URLError(.networkConnectionLost),

--- a/apple/CabalmailTests/MessageListInitialLoadTests.swift
+++ b/apple/CabalmailTests/MessageListInitialLoadTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Regression tests for #736: the first visit to a folder runs `loadInitial()`
+// inside the view's structured `.task`, which SwiftUI can cancel mid-push
+// transition. Because the view only calls `loadInitial()` once per model, a
+// cancelled first fetch painted `network("cancelled")` over an empty list
+// with nothing left to reload. The load now runs on an unstructured,
+// model-owned task (the `refreshFromPull` pattern), so it completes even when
+// the caller's task is cancelled. `FakeImapClient` mirrors the production
+// transport by failing with `network("cancelled")` when the caller's Task is
+// cancelled.
+@MainActor
+final class MessageListInitialLoadTests: XCTestCase {
+
+    private func makeScriptedImap() async -> FakeImapClient {
+        let imap = FakeImapClient()
+        await imap.scriptInitialLoad(
+            status: FolderStatus(messages: 1, unseen: 1, uidValidity: 7, uidNext: 2),
+            topEnvelopes: [TestFixtures.makeEnvelope(uid: 1)]
+        )
+        return imap
+    }
+
+    func testLoadInitialSurvivesCallerTaskCancellation() async throws {
+        let imap = await makeScriptedImap()
+        let model = try TestFixtures.makeModel(imap: imap, envelopes: [])
+        // Cancel before the load body ever runs — the worst-case ordering of
+        // the mid-push `.task` cancellation.
+        let task = Task { await model.loadInitial() }
+        task.cancel()
+        await task.value
+        XCTAssertNil(model.errorMessage, "a cancelled caller must not paint an error")
+        XCTAssertEqual(model.envelopes.map(\.uid), [1], "the first load completes despite the cancel")
+    }
+
+    func testLoadInitialPopulatesWithoutCancellation() async throws {
+        let imap = await makeScriptedImap()
+        let model = try TestFixtures.makeModel(imap: imap, envelopes: [])
+        await model.loadInitial()
+        XCTAssertNil(model.errorMessage)
+        XCTAssertEqual(model.envelopes.map(\.uid), [1])
+    }
+}

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -42,6 +42,16 @@ actor FakeImapClient: ImapClient {
         moveResults = results
     }
 
+    // Initial-load script (status + top page), used by the loadInitial
+    // tests. Unscripted, both members keep trapping.
+    private var statusResult: FolderStatus?
+    private var topEnvelopesResult: [Envelope]?
+
+    func scriptInitialLoad(status: FolderStatus, topEnvelopes: [Envelope]) {
+        statusResult = status
+        topEnvelopesResult = topEnvelopes
+    }
+
     func setFlags(
         folder: String,
         uids: [UInt32],
@@ -76,7 +86,14 @@ actor FakeImapClient: ImapClient {
     func deleteFolder(path: String) async throws { try trapVoid() }
     func subscribe(path: String) async throws { try trapVoid() }
     func unsubscribe(path: String) async throws { try trapVoid() }
-    func status(path: String, flagged: Bool) async throws -> FolderStatus { try trap() }
+    func status(path: String, flagged: Bool) async throws -> FolderStatus {
+        // Mirror the production transport: a URLSession data task whose
+        // surrounding Task is cancelled fails with `URLError.cancelled`,
+        // which `URLSessionHTTPTransport` normalizes to `network(...)`.
+        if Task.isCancelled { throw CabalmailError.network("cancelled") }
+        guard let statusResult else { return try trap() }
+        return statusResult
+    }
     func envelopes(
         folder: String, range: ClosedRange<UInt32>, sort: SortCriterion
     ) async throws -> [Envelope] { try trap() }
@@ -85,7 +102,12 @@ actor FakeImapClient: ImapClient {
     ) async throws -> [Envelope] { try trap() }
     func topEnvelopes(
         folder: String, limit: UInt32, totalMessages: UInt32, sort: SortCriterion
-    ) async throws -> [Envelope] { try trap() }
+    ) async throws -> [Envelope] {
+        // Cancellation-sensitive for the same reason as `status(path:flagged:)`.
+        if Task.isCancelled { throw CabalmailError.network("cancelled") }
+        guard let topEnvelopesResult else { return try trap() }
+        return topEnvelopesResult
+    }
     func fetchBody(folder: String, uid: UInt32) async throws -> RawMessage { try trap() }
     func fetchPart(folder: String, uid: UInt32, partId: String) async throws -> Data { try trap() }
     func append(folder: String, message: Data, flags: Set<Flag>) async throws { try trapVoid() }

--- a/changelog.d/envelope-fetch-cancel-retry.fixed.md
+++ b/changelog.d/envelope-fetch-cancel-retry.fixed.md
@@ -1,0 +1,7 @@
+- Apple: **First visit to a folder no longer shows a red network("cancelled")
+  error.** The message list's initial fetch ran inside a SwiftUI task that
+  can be cancelled mid-push transition, painting the error over an empty
+  list with nothing left to reload it; the first load now runs on a
+  model-owned task that survives the transition. The HTTP transport also
+  retries a spurious URLSession cancellation once, restoring the recovery
+  the body fetch lost when transport-level error normalization landed.


### PR DESCRIPTION
## What was wrong

First visit to an unsubscribed folder (Drafts, Sent) showed a red `network("cancelled")` error over an empty list, with only the banner's manual retry as an escape. Reproduced 2/2 by the tester on stage.

## Root cause

Two defects in the same class:

1. **The list's first load is cancellable and unrepeatable.** `loadInitial()` runs inside the view's structured `.task`, which SwiftUI can cancel mid-push transition (the same mechanism as the detail view's #403 note). The cancellation propagates into the URLSession request, which fails with `URLError.cancelled`; the transport normalizes that to `CabalmailError.network("cancelled")` and `refresh()` paints it. Because the view guards model creation with `model == nil`, the re-fired `.task` never reloads — the error sticks.
2. **The May 10 spurious-cancel recovery is dead code.** fe73f2f0 taught `MessageDetailViewModel.load()` to retry a stray `URLError.cancelled`; the May 27 transport commit (2c0f03a6) then began normalizing every `URLError` into `CabalmailError.network(localizedDescription)`, so the detail VM's `catch let urlError as URLError` can never match and no caller can see the error code anymore.

## The fix

- `loadInitial()` now runs its work on an unstructured, model-owned task (the documented `refreshFromPull` pattern), so a mid-push cancellation of the view's `.task` can't kill the first fetch.
- `URLSessionHTTPTransport` treats a `.cancelled` that arrives while our own Task is **not** cancelled as transient and retries once (same posture as the existing `-1005`/timeout retry), restoring the fe73f2f0 recovery at the layer that now owns URLError codes — for every endpoint, not just the body fetch. A cooperative cancel still propagates immediately.

## Test evidence

- New `HTTPTransportTests.testRetriesOnceOnSpuriousCancel` (scripted URLProtocol: fail-then-succeed, asserts 2 attempts) and `testCancelledIsNotRetryableInsideCancelledTask`.
- New `MessageListInitialLoadTests.testLoadInitialSurvivesCallerTaskCancellation`: fails before the fix with exactly the reported symptom (`XCTAssertNil failed: "network("cancelled")"`, empty list), passes after. Verified by stash-reverting the view-model change and re-running.
- Full `swift test` (CabalmailKit): 362 tests, 0 failures. CabalmailMac XCTest suite: 18 tests, 0 failures. `swiftlint` from `apple/`: clean.

Addresses #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)