### PR TITLE
Update the filter-pill counts on optimistic flag changes

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Optimistic.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Optimistic.swift
@@ -52,8 +52,24 @@ extension MessageListViewModel {
     func applyOptimisticFlag(uid: UInt32, flag: Flag, add: Bool) {
         guard let index = envelopes.firstIndex(where: { $0.uid == uid }) else { return }
         var flags = envelopes[index].flags
+        let flipped = flags.contains(flag) != add
         if add { flags.insert(flag) } else { flags.remove(flag) }
         envelopes[index] = rebuildEnvelope(envelopes[index], flags: flags)
+        // Keep the Unread/Flagged pill counts in step with the optimistic row
+        // state — STATUS only corrects them on the next refresh, so without
+        // this the pills lag every flag/read change until a server round trip.
+        // Every optimistic flag path (list toggle, detail-view signal, bulk,
+        // and their reverts) funnels through here, so adjusting on a real flip
+        // only can't double-count.
+        guard flipped else { return }
+        switch flag {
+        case .seen:
+            unseen = max(0, unseen + (add ? -1 : 1))
+        case .flagged:
+            flagged = max(0, flagged + (add ? 1 : -1))
+        default:
+            break
+        }
     }
 
     /// Reinsert an envelope previously removed by an optimistic dispose.

--- a/apple/CabalmailTests/MessageListPillCountTests.swift
+++ b/apple/CabalmailTests/MessageListPillCountTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Regression tests for #737: the All/Unread/Flagged filter-pill counts read
+// `unseen` / `flagged`, which only STATUS used to write — so a flag or read
+// change (row swipe, detail-view toolbar, mark-as-read on open) updated the
+// row's own indicators but left the pill counts stale until the next server
+// refetch. `applyOptimisticFlag` now adjusts the counters whenever a flag
+// actually flips, which covers every optimistic path (list toggle,
+// detail-view signal, bulk, and their error reverts) without double-counting.
+@MainActor
+final class MessageListPillCountTests: XCTestCase {
+
+    private func makeModel(imap: FakeImapClient = FakeImapClient()) throws -> MessageListViewModel {
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [
+                TestFixtures.makeEnvelope(uid: 1),                  // unread
+                TestFixtures.makeEnvelope(uid: 2, flags: [.seen]),  // read
+            ]
+        )
+        // Server-sourced STATUS counts as of the last refresh.
+        model.totalMessages = 2
+        model.unseen = 1
+        model.flagged = 0
+        return model
+    }
+
+    func testDetailOriginatedFlagToggleUpdatesFlaggedPill() throws {
+        let model = try makeModel()
+        // The reader's flag toggle reaches the list via applyFlagChange.
+        model.applyFlagChange(uid: 2, flag: .flagged, added: true)
+        XCTAssertEqual(model.flagged, 1, "flagging from the reader bumps the Flagged pill")
+        // A duplicate signal for an already-flagged row must not double-count.
+        model.applyFlagChange(uid: 2, flag: .flagged, added: true)
+        XCTAssertEqual(model.flagged, 1)
+        model.applyFlagChange(uid: 2, flag: .flagged, added: false)
+        XCTAssertEqual(model.flagged, 0)
+    }
+
+    func testDetailOriginatedMarkAsReadUpdatesUnreadPill() throws {
+        let model = try makeModel()
+        // Mark-as-read on open reaches the list via the same signal.
+        model.applyFlagChange(uid: 1, flag: .seen, added: true)
+        XCTAssertEqual(model.unseen, 0, "reading from the reader drops the Unread pill")
+        model.applyFlagChange(uid: 1, flag: .seen, added: false)
+        XCTAssertEqual(model.unseen, 1)
+    }
+
+    func testListToggleUpdatesAndFailureReverts() async throws {
+        let imap = FakeImapClient()
+        let model = try makeModel(imap: imap)
+        // Successful swipe/context-menu toggle adjusts the pill...
+        await model.setFlag(.seen, add: true, envelope: model.envelopes[0])
+        XCTAssertEqual(model.unseen, 0)
+        // ...and a failed write reverts the count along with the row.
+        await imap.scriptFlagResults([.failure(CabalmailError.protocolError("boom"))])
+        await model.setFlag(.flagged, add: true, envelope: model.envelopes[1])
+        XCTAssertEqual(model.flagged, 0, "failed flag write reverts the Flagged pill")
+    }
+
+    func testUnrelatedFlagLeavesPillsAlone() throws {
+        let model = try makeModel()
+        model.applyFlagChange(uid: 1, flag: .answered, added: true)
+        XCTAssertEqual(model.unseen, 1)
+        XCTAssertEqual(model.flagged, 0)
+    }
+}

--- a/changelog.d/optimistic-pill-counts.fixed.md
+++ b/changelog.d/optimistic-pill-counts.fixed.md
@@ -1,0 +1,6 @@
+- Apple: **Unread/Flagged filter-pill counts update instantly.** Flagging or
+  reading a message (row swipe, reader toolbar, mark-as-read on open) updated
+  the row's own indicators but left the All/Unread/Flagged pill counts stale
+  until the next server refetch; the counts now follow every optimistic flag
+  change (including bulk operations and error rollbacks) and still reconcile
+  to server truth on refresh.


### PR DESCRIPTION
## What was wrong

Flagging a message from the reader toolbar (or marking it read via mark-as-read-on-open) updated the row's own indicators immediately, but the All/Unread/Flagged filter-chip counts stayed stale until a fresh envelope/STATUS fetch — reproduced by the tester in both directions on stage.

## Root cause

The pills read `model.unseen` / `model.flagged` (`MessageListView+Filter.swift`), and the **only** writer of those counters was `applyStatusCounts` — server STATUS at refresh time. None of the optimistic flag paths touched them: the list's `setFlag` adjusts the *sidebar badge* (`appState.applyUnreadDelta`) but not the pills, and the detail view's `onFlagChanged` signal lands in `applyFlagChange` → `applyOptimisticFlag`, which only rewrote the row's flag set.

## The fix

Per the preferred pattern stated on the issue (optimistic update, eventual consistency on refresh): `applyOptimisticFlag` — the shared primitive every optimistic flag path funnels through (list swipe/context menu, detail-view signal, bulk operations, and all of their error reverts) — now adjusts `unseen`/`flagged` whenever a flag *actually flips*. The flip guard means duplicate signals and no-op toggles can't double-count, and revert paths (which call the same primitive in the opposite direction) stay symmetric. STATUS remains authoritative on the next refresh.

## Test evidence

New `MessageListPillCountTests` (CabalmailMac XCTest suite): reader-originated flag toggle including duplicate-signal no-double-count, reader-originated mark-as-read both directions, list-toggle success + failed-write rollback, and an unrelated-flag guard. The first three fail before the fix and pass after (verified by stash-reverting the change); full suite 20 tests, 0 failures. `swiftlint` from `apple/`: clean.

Addresses #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)