### PR TITLE
Refer to code scanning alerts by URL, never bare #-numbers

### DIFF
--- a/.github/workflows/code-scanning-alerts.yml
+++ b/.github/workflows/code-scanning-alerts.yml
@@ -181,6 +181,16 @@ jobs:
             ${{ steps.alerts.outputs.summary }}
             ]]></untrusted-alerts>
 
+            Alert numbers are code scanning alert IDs, unrelated to this
+            repository's issue and PR numbers. In everything you write
+            (PR body, commit messages, issue comments), refer to them as
+            "alert <n>" with a link to
+            https://github.com/${{ github.repository }}/security/code-scanning/<n>
+            and NEVER as a bare #<n>: GitHub autolinks #-numbers to
+            whatever issue or PR happens to have that number and
+            cross-posts a mention into its timeline, which misleads the
+            reviewer into thinking you worked the issue tracker.
+
             Do all work on a branch named
             code-scanning/batch-${{ github.run_id }}. The scheduled
             in-flight guard keys off the code-scanning/ prefix, so do
@@ -193,7 +203,7 @@ jobs:
                file present in this checkout): read the flagged code,
                fix the root cause minimally in place, and make one
                commit per alert:
-               "fix: resolve <rule> in <path> (alert #<n>)".
+               "fix: resolve <rule> in <path> (code scanning alert <n>)".
                Follow the repo's changelog convention: add a
                changelog.d/<slug>.security.md fragment (see
                changelog.d/README.md) describing the fix.
@@ -228,10 +238,13 @@ jobs:
 
             If you made at least one commit, open a single pull
             request with base ${{ github.ref_name }} titled
-            "fix: draw down high and critical code scanning alerts"
-            whose body lists every alert in the batch with its
-            disposition: fixed here, needs rebuild/redeploy, or needs
-            manual attention (and why).
+            "fix: draw down high and critical code scanning alerts".
+            Open the body with a provenance line — "Batch from the
+            Security -> Code scanning dashboard:
+            https://github.com/${{ github.repository }}/security/code-scanning" —
+            then list every alert in the batch with its disposition:
+            fixed here, needs rebuild/redeploy, or needs manual
+            attention (and why).
 
             If the batch produced no committable change, do not open
             an empty PR. Instead find an open issue titled


### PR DESCRIPTION
## What happened with the first nightly (PR #754)

The batch was actually sourced correctly: it processed code scanning alerts 38 ([the CodeQL sanitization finding in `react/admin/src/Email/index.jsx`](https://github.com/cabalmail/cabal-infra/security/code-scanning/38)), [76](https://github.com/cabalmail/cabal-infra/security/code-scanning/76) (private key in the imap image), and [543](https://github.com/cabalmail/cabal-infra/security/code-scanning/543)/[544](https://github.com/cabalmail/cabal-infra/security/code-scanning/544)/[548](https://github.com/cabalmail/cabal-infra/security/code-scanning/548) (the `cabal-imap` python3 CVEs), and the diff matched alert 38 exactly.

But the PR body wrote them as bare `#38`/`#543`/`#544`/`#548`, and GitHub autolinked those to the unrelated repo issues/PRs holding the same numbers ("Use IMAP's native Seen flag", a worktree PR, "Release 0.10.32", the fetch_bimi fix) — and cross-posted "mentioned" events into their timelines. Net effect: a correctly-sourced batch read as if Claude had worked the issue tracker.

## Fix

Prompt-only change to `code-scanning-alerts.yml`:

- Everywhere it writes (PR body, commits, issue comments), refer to alerts as `alert <n>` with the full `security/code-scanning/<n>` URL — bare `#<n>` is explicitly forbidden, with the why spelled out.
- Commit message template changed to `(code scanning alert <n>)`.
- Each batch PR must open with a provenance line linking the Code scanning dashboard.

Since #754 was closed without merging, the in-flight guard won't trip, so tonight's run will regenerate the same batch (including the alert-38 fix) with the corrected formatting once this is live on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)