### PR TITLE
Unsubscribe on folder delete; make unsubscribe work for deleted mailboxes

### DIFF
--- a/changelog.d/delete-folder-phantom-subscription.fixed.md
+++ b/changelog.d/delete-folder-phantom-subscription.fixed.md
@@ -1,0 +1,5 @@
+- **Phantom subscription after folder delete.** Deleting a folder now also
+  drops its IMAP subscription, so it no longer lingers in clients' Subscribed
+  list. Unsubscribing also no longer selects the target mailbox first, so a
+  stale subscription left behind by an earlier delete can be cleared instead
+  of failing with a 502.

--- a/lambda/api/_shared/helper.py
+++ b/lambda/api/_shared/helper.py
@@ -786,8 +786,14 @@ def subscribe_folder(folder, host, user):
     return return_value
 
 def unsubscribe_folder(folder, host, user):
-    '''Unsubscribes the user from an IMAP folder.'''
-    client = get_imap_client(host, user, folder)
+    '''Unsubscribes the user from an IMAP folder.
+
+    Selects INBOX rather than the target folder: UNSUBSCRIBE does not require
+    the mailbox to be selected, and it must keep working after the mailbox is
+    deleted -- Dovecot keeps LSUB entries for deleted mailboxes, and clearing
+    such an entry is the only way to stop the folder haunting clients'
+    Subscribed list.'''
+    client = get_imap_client(host, user, 'INBOX')
     return_value = client.unsubscribe_folder(folder)
     client.logout()
     return return_value

--- a/lambda/api/_shared/tests/test_folder_subscriptions.py
+++ b/lambda/api/_shared/tests/test_folder_subscriptions.py
@@ -1,0 +1,126 @@
+'''Unit tests for helper's folder-subscription functions.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_folder_subscriptions.py
+
+helper.py's third-party imports (boto3, botocore, imap_session) are faked in
+sys.modules before import, so the suite needs no AWS access and never dials an
+IMAP server. The fake imap_session mirrors the behavior under test: like the
+real open_imap_client, it selects the requested folder at connect time and
+fails when that mailbox does not exist.'''
+import os
+import sys
+import types
+import unittest
+
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# --- fake boto3 / botocore ---------------------------------------------------
+
+
+class _FakeSSMExceptions:
+    class ParameterNotFound(Exception):
+        pass
+
+
+class _FakeSSM:
+    exceptions = _FakeSSMExceptions
+
+    def get_parameter(self, Name=None, **_kwargs):  # pylint: disable=invalid-name
+        if Name == '/cabal/maintenance/imap':
+            raise _FakeSSMExceptions.ParameterNotFound()
+        return {"Parameter": {"Value": "fake-master-password"}}
+
+
+class _FakeResource:
+    def Table(self, _name):  # pylint: disable=invalid-name
+        return types.SimpleNamespace()
+
+
+_boto3 = types.ModuleType("boto3")
+_boto3.resource = lambda _name, **_kw: _FakeResource()
+_boto3.client = lambda name, **_kw: _FakeSSM() if name == 'ssm' else types.SimpleNamespace()
+_boto3.session = types.SimpleNamespace(Config=lambda **_kw: None)
+sys.modules['boto3'] = _boto3
+
+_botocore = types.ModuleType("botocore")
+_botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+
+class _ClientError(Exception):
+    pass
+
+
+_botocore_exceptions.ClientError = _ClientError
+_botocore.exceptions = _botocore_exceptions
+sys.modules['botocore'] = _botocore
+sys.modules['botocore.exceptions'] = _botocore_exceptions
+
+# --- fake imap_session -------------------------------------------------------
+
+# Mailboxes that "exist" on the fake server; open_imap_client selects the
+# requested folder and fails for anything else, like the real one.
+EXISTING_FOLDERS = set()
+OPENED = []
+
+
+class _SelectFailed(Exception):
+    pass
+
+
+class _FakeImapClient:
+    def __init__(self):
+        self.unsubscribed = []
+        self.logged_out = False
+
+    def unsubscribe_folder(self, folder):
+        self.unsubscribed.append(folder)
+        return b'UNSUBSCRIBE completed.'
+
+    def logout(self):
+        self.logged_out = True
+
+
+def _open_imap_client(host, user, folder, _read_only, _mpw):
+    if folder not in EXISTING_FOLDERS:
+        raise _SelectFailed(f"select failed: Mailbox doesn't exist: {folder}")
+    client = _FakeImapClient()
+    OPENED.append({'host': host, 'user': user, 'folder': folder, 'client': client})
+    return client
+
+
+_imap_session = types.ModuleType("imap_session")
+_imap_session.open_imap_client = _open_imap_client
+sys.modules['imap_session'] = _imap_session
+
+import helper  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class UnsubscribeFolderTest(unittest.TestCase):
+
+    def setUp(self):
+        EXISTING_FOLDERS.clear()
+        EXISTING_FOLDERS.update({'INBOX', 'Archive'})
+        OPENED.clear()
+
+    def test_unsubscribe_survives_deleted_mailbox(self):
+        # QA0723 has been deleted; only its LSUB entry remains. Clearing the
+        # subscription must not require selecting the dead mailbox.
+        helper.unsubscribe_folder('QA0723', None, 'testuser')
+        client = OPENED[-1]['client']
+        self.assertEqual(client.unsubscribed, ['QA0723'])
+        self.assertTrue(client.logged_out)
+
+    def test_unsubscribe_existing_folder_still_works(self):
+        helper.unsubscribe_folder('Archive', None, 'testuser')
+        client = OPENED[-1]['client']
+        self.assertEqual(client.unsubscribed, ['Archive'])
+        self.assertTrue(client.logged_out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/delete_folder/function.py
+++ b/lambda/api/delete_folder/function.py
@@ -1,5 +1,6 @@
 '''Delete a new folder and returns updated folder list'''
 import json
+import logging
 from helper import get_imap_client # pylint: disable=import-error
 from helper import get_folder_list # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
@@ -24,6 +25,14 @@ def handler(event, _context):
         }
     client = get_imap_client(None, user, 'INBOX')
     client.delete_folder(name)
+    try:
+        # Dovecot keeps LSUB entries for deleted mailboxes, so drop the
+        # subscription too or the folder lingers in clients' Subscribed list.
+        # Best-effort: the delete already succeeded, and a subscription
+        # hiccup must not turn that into an error response.
+        client.unsubscribe_folder(name)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logging.warning('could not unsubscribe deleted folder %r', name)
     response = get_folder_list(client)
     client.logout()
     return {

--- a/lambda/api/delete_folder/tests/test_function.py
+++ b/lambda/api/delete_folder/tests/test_function.py
@@ -1,0 +1,101 @@
+'''Unit tests for the delete_folder handler.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/delete_folder/tests/test_function.py
+
+function.py's helper import is faked in sys.modules before import, so the
+suite needs no boto3 / AWS and never dials an IMAP server. The fake client
+records operations in order, which is what the assertions inspect.'''
+import json
+import os
+import sys
+import types
+import unittest
+
+# function.py lives one directory up.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# --- fake helper -------------------------------------------------------------
+
+
+class _FakeImapClient:
+    def __init__(self):
+        self.ops = []
+        self.unsubscribe_error = None
+        self.logged_out = False
+
+    def delete_folder(self, name):
+        self.ops.append(f'delete:{name}')
+
+    def unsubscribe_folder(self, name):
+        if self.unsubscribe_error is not None:
+            raise self.unsubscribe_error
+        self.ops.append(f'unsubscribe:{name}')
+
+    def list_folders(self):
+        return []
+
+    def logout(self):
+        self.logged_out = True
+
+
+CLIENT = _FakeImapClient()
+FOLDER_LIST = {'folders': ['INBOX'], 'sub_folders': ['INBOX']}
+
+
+def _parse_json_body(event):
+    return json.loads(event['body']), None
+
+
+def _validate_folder_name(name):
+    if not name:
+        raise ValueError('missing folder name')
+    return name
+
+
+_helper = types.ModuleType("helper")
+_helper.get_imap_client = lambda _host, _user, _folder: CLIENT
+_helper.get_folder_list = lambda _client: FOLDER_LIST
+_helper.parse_json_body = _parse_json_body
+_helper.validate_folder_name = _validate_folder_name
+_helper.maintenance_guard = lambda handler: handler
+sys.modules['helper'] = _helper
+
+import function  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _event(name):
+    return {
+        'body': json.dumps({'name': name}),
+        'requestContext': {
+            'authorizer': {'claims': {'cognito:username': 'testuser'}}
+        },
+    }
+
+
+class DeleteFolderTest(unittest.TestCase):
+
+    def setUp(self):
+        CLIENT.ops.clear()
+        CLIENT.unsubscribe_error = None
+        CLIENT.logged_out = False
+
+    def test_delete_also_unsubscribes(self):
+        # Dovecot keeps LSUB entries for deleted mailboxes, so the handler
+        # must drop the subscription right after the delete.
+        response = function.handler(_event('QA0723'), None)
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(CLIENT.ops, ['delete:QA0723', 'unsubscribe:QA0723'])
+        self.assertTrue(CLIENT.logged_out)
+
+    def test_unsubscribe_failure_does_not_fail_the_delete(self):
+        CLIENT.unsubscribe_error = RuntimeError('UNSUBSCRIBE rejected')
+        response = function.handler(_event('QA0723'), None)
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(CLIENT.ops, ['delete:QA0723'])
+        self.assertTrue(CLIENT.logged_out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What was wrong

Deleting a folder left its IMAP subscription behind (Dovecot keeps LSUB entries for deleted mailboxes), so the folder haunted clients' Subscribed list forever. The escape hatch was broken too: `PUT /unsubscribe_folder` 502'd for any folder whose mailbox no longer exists, so the phantom was permanent.

## Root cause

Two compounding defects (both called out in #756's thread):

1. `lambda/api/delete_folder/function.py` called `client.delete_folder(name)` only — nothing dropped the LSUB entry.
2. `helper.unsubscribe_folder` passed the *target* folder to `get_imap_client`, which SELECTs the folder it's given. IMAP `UNSUBSCRIBE` does not require the mailbox selected — or even to exist — so the SELECT was both unnecessary and fatal for exactly the case that matters (a dead mailbox's stale subscription): `select failed: Mailbox doesn't exist` → unhandled → 502.

## The fix

- `delete_folder` now unsubscribes right after the delete, best-effort: the delete already succeeded, so a subscription hiccup logs a warning instead of turning the response into an error.
- `helper.unsubscribe_folder` selects `INBOX` instead of the target, with a comment explaining why.

## Test evidence

Both layers get regression tests under the repo's stdlib-unittest fake-module pattern (no AWS/IMAP needed):

- `lambda/api/_shared/tests/test_folder_subscriptions.py` — the fake `imap_session` mirrors the real one's connect-time SELECT and fails for nonexistent mailboxes; `test_unsubscribe_survives_deleted_mailbox` errors before the fix, passes after.
- `lambda/api/delete_folder/tests/test_function.py` — asserts the handler's op order is `delete` then `unsubscribe` (fails before), and that an unsubscribe failure still returns 200.
- `pylint --rcfile .pylintrc` on the touched files: 10.00/10.

Not verified against a live Dovecot (read-only AWS; the Lambda isn't deployed from this branch) — the tester's retest on stage is the live check.

Addresses #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)