### PR TITLE
Return to the mail scene when an iPad compose window closes

### DIFF
--- a/apple/Cabalmail/CabalmailApp.swift
+++ b/apple/Cabalmail/CabalmailApp.swift
@@ -24,6 +24,10 @@ struct CabalmailApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // Lets a closing compose window re-activate this scene on
+                // iPadOS instead of dropping to the home screen (no-op on
+                // other platforms; see MainSceneActivation.swift).
+                .recordsMainSceneSession()
                 .environment(appState)
                 .environment(preferences)
                 .preferredColorScheme(colorScheme(for: preferences.theme))

--- a/apple/Cabalmail/Views/ComposeWindowScene.swift
+++ b/apple/Cabalmail/Views/ComposeWindowScene.swift
@@ -105,7 +105,17 @@ private struct ComposeWindowContent: View {
                 client: client,
                 draftStore: client.draftStore,
                 preferences: preferences,
-                onClose: { dismissWindow() }
+                onClose: {
+                    // iPadOS shows the home screen when the frontmost
+                    // scene is dismissed with no sibling activated; bring
+                    // the main mail scene forward first so closing compose
+                    // lands back on the split view (see
+                    // MainSceneActivation.swift).
+                    #if os(iOS)
+                    MainMailScene.activate()
+                    #endif
+                    dismissWindow()
+                }
             ))
             .environment(appState)
             .environment(preferences)

--- a/apple/Cabalmail/Views/MainSceneActivation.swift
+++ b/apple/Cabalmail/Views/MainSceneActivation.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+#if os(iOS)
+import UIKit
+
+/// iPadOS-only scene bookkeeping for closing a compose window.
+///
+/// `dismissWindow()` destroys the compose scene, but when that scene is
+/// the frontmost one iPadOS does not activate a sibling scene on its own —
+/// it drops the user on the home screen, which reads as a crash (the send
+/// keeps running as a background task). Re-activating the main mail scene
+/// before the dismissal keeps the app frontmost, so Send / Save Draft /
+/// Discard land back on the split view the way the iPhone sheet path does.
+///
+/// The main scene has no stable, documented marker among
+/// `UIApplication.shared.openSessions` (SwiftUI owns the session
+/// configuration), so the main window records its own session here via
+/// `recordsMainSceneSession()` and the closing compose window reads it
+/// back.
+@MainActor
+enum MainMailScene {
+    /// The main mail window's scene session, recorded by
+    /// `recordsMainSceneSession()`. Weak: a discarded scene must not be
+    /// kept alive by this bookkeeping.
+    static weak var session: UISceneSession?
+
+    /// Brings the main mail scene to the foreground, if one was recorded.
+    /// No-op otherwise (e.g. a mailto: cold launch straight into compose —
+    /// there is no mail scene to return to).
+    static func activate() {
+        guard let session else { return }
+        UIApplication.shared.activateSceneSession(
+            for: UISceneSessionActivationRequest(session: session),
+            errorHandler: nil
+        )
+    }
+}
+
+/// Empty `UIViewRepresentable` whose only job is to reach the hosting
+/// `UIWindowScene` so the main window can record its scene session —
+/// the same window-hook trick `ComposeWindowCloseInterceptor` uses on
+/// macOS.
+private struct MainSceneSessionRecorder: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        // The window isn't attached during makeUIView; defer to the next
+        // runloop tick so UIKit has finished wiring the scene host.
+        DispatchQueue.main.async { [weak view] in
+            if let session = view?.window?.windowScene?.session {
+                MainMailScene.session = session
+            }
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        if let session = uiView.window?.windowScene?.session {
+            MainMailScene.session = session
+        }
+    }
+}
+
+extension View {
+    /// Records the hosting scene session as the main mail scene so a
+    /// closing compose window can re-activate it. Apply on the main
+    /// window's root content.
+    func recordsMainSceneSession() -> some View {
+        background(MainSceneSessionRecorder())
+    }
+}
+#else
+
+extension View {
+    /// macOS and visionOS activate a sibling window on their own when a
+    /// compose window closes; no scene bookkeeping needed.
+    func recordsMainSceneSession() -> some View { self }
+}
+#endif

--- a/changelog.d/ipad-send-home-screen.fixed.md
+++ b/changelog.d/ipad-send-home-screen.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Send no longer exits the app on iPad.** Closing a compose window
+  (Send / Save Draft / Discard) re-activates the main mail scene before the
+  compose scene is dismissed, so the app returns to the mail split view
+  instead of dropping to the home screen with the send finishing as a
+  background task.


### PR DESCRIPTION
## What was wrong

On iPad, tapping Send in the full-screen compose window dropped the whole app to the home screen. The send still completed (as a UIKit background task, with `risk of termination` warnings), but the experience read as a crash. Reproduced 2/2 by the tester; Cancel takes the same code path.

## Root cause

iPad compose opens as its own scene (`WindowGroup(for: Draft.self)`, see `ComposeWindowScene.swift`) and closes via the bare `dismissWindow()` environment action. When the dismissed scene is the frontmost one, iPadOS does not activate a sibling scene on its own — it backgrounds the app and shows the home screen. macOS and visionOS activate a sibling window themselves, and iPhone uses the sheet path, so only iPadOS was affected.

## The fix

- New `apple/Cabalmail/Views/MainSceneActivation.swift` (iOS branch): the main window records its `UISceneSession` via a tiny `UIViewRepresentable` window hook (same trick as the macOS `ComposeWindowCloseInterceptor`), and `MainMailScene.activate()` re-activates that session with `UIApplication.activateSceneSession(for:)`.
- `ComposeWindowContent.onClose` calls `MainMailScene.activate()` before `dismissWindow()` on iOS; other platforms are a no-op (`recordsMainSceneSession()` compiles to `self`).
- Fallback stays graceful: if no main scene was ever recorded (mailto: cold launch straight into compose), activation is skipped and behavior is unchanged.

## Test evidence

This layer is genuinely unit-untestable: it is UIKit scene-session glue (`UISceneSession` / `activateSceneSession`), which neither the CabalmailKit `swift test` suite nor the macOS XCTest app suite can exercise (both run on macOS; there is no iOS UI-test target). Verified live instead, on the original repro:

- iPad Pro 11" sim (iOS 26.5), this branch's build: compose → From/To/subject → Send. Send spinner completes **in the foreground** and the app cross-fades back to the mail split view — no home screen. Screenshots: /tmp/755-06-send-t1.png (spinner), /tmp/755-07-send-t5.png (transition to split view), /tmp/755-08-final.png (landed on INBOX + "No message selected").
- The tester's identical repro on stage @ 2c66e345 showed the home screen at the same timestamps.
- `swiftlint` clean on the three touched files; full iPad sim build succeeds.

Addresses #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)