### PR TITLE
Add default-mail-app entitlement now that Apple granted it

### DIFF
--- a/apple/Cabalmail/Cabalmail.entitlements
+++ b/apple/Cabalmail/Cabalmail.entitlements
@@ -4,21 +4,20 @@
 <dict>
     <!--
         This file is wired into the iOS target's signing via
-        `apple/project.yml` (CODE_SIGN_ENTITLEMENTS). One entitlement
-        remains absent on purpose: `com.apple.developer.mail-client`,
-        which Apple grants case-by-case via:
+        `apple/project.yml` (CODE_SIGN_ENTITLEMENTS).
+
+        `com.apple.developer.mail-client` is an Apple-managed
+        entitlement, granted per team case-by-case via:
 
           https://developer.apple.com/contact/request/default-mail-client
 
-        Once Apple approves the request and the matching provisioning
-        profile has been regenerated to carry the entitlement, add:
-
-          <key>com.apple.developer.mail-client</key>
-          <true/>
-
-        See the "Setting Cabalmail as the default mail handler" section
-        in apple/README.md for the full rollout.
+        Signed archives fail if the provisioning profile doesn't carry
+        it — a fork building before Apple approves its own request must
+        remove the key. See "Setting Cabalmail as the default mail
+        handler" in docs/apple.md for the request and rollout steps.
     -->
+    <key>com.apple.developer.mail-client</key>
+    <true/>
 
     <!--
         Push notifications (docs/0.11.0/push-notifications.md). The value

--- a/changelog.d/default-mail-app.added.md
+++ b/changelog.d/default-mail-app.added.md
@@ -1,0 +1,5 @@
+- Apple: **Cabalmail can be the default mail app on iOS and iPadOS.**
+  Apple granted the managed mail-client entitlement, so the app now
+  appears in Settings → Apps → Mail → Default Mail App. Pick it there
+  and mailto: links from Safari and other apps open a Cabalmail
+  compose window pre-filled from the link.

--- a/docs/apple.md
+++ b/docs/apple.md
@@ -632,29 +632,28 @@ appear in Settings → Apps → Mail → Default Mail App, even though
    the unit tests in `CabalmailKit/Tests/CabalmailKitTests/MailtoURLTests.swift`
    cover the parser. Apple reviews and grants the entitlement
    against your team.
-2. After approval, regenerate the iOS distribution provisioning
-   profile in App Store Connect (the profile must list the new
-   entitlement). Pull the regenerated profile into CI's
-   `IOS_APP_STORE_PROFILE_UUID` secret.
-3. Edit `apple/Cabalmail/Cabalmail.entitlements` (already wired into
-   the iOS target's `CODE_SIGN_ENTITLEMENTS` via `project.yml`) to
-   add the key:
+2. After approval, enable the **Default Mail App** capability on the
+   `com.cabalmail.Cabalmail` App ID (Identifiers → the App ID →
+   Capabilities). Editing the capabilities flips the App ID's
+   existing profiles to Invalid, so re-issue the iOS App Store
+   profile and refresh the `IOS_APP_STORE_PROFILE` secret — see
+   [Creating provisioning profiles](#creating-provisioning-profiles).
+3. `apple/Cabalmail/Cabalmail.entitlements` (wired into the iOS
+   target's `CODE_SIGN_ENTITLEMENTS` via `project.yml`) carries the
+   matching key:
 
    ```xml
    <key>com.apple.developer.mail-client</key>
    <true/>
    ```
 
-   The file ships empty so the path is set up from day one; only the
-   key needs to be added when approval lands.
+   Signed archives fail while the provisioning profile lacks the
+   entitlement, so a fork must remove this key until its own request
+   is approved and the profile regenerated.
 
-4. Regenerate the Xcode project (`xcodegen generate`) and ship a new
-   TestFlight build against the updated profile.
+4. Ship a new TestFlight build against the updated profile.
 
-Adding the `<true/>` value *before* Apple approves the entitlement
-will break CI signing — the profile won't carry it, and codesign will
-refuse. Apple's rules also forbid combining
-`com.apple.developer.mail-client` with
+Apple's rules forbid combining `com.apple.developer.mail-client` with
 `com.apple.developer.web-browser` in the same app — pick one.
 
 Once the entitlement lands and the user picks Cabalmail in Settings,


### PR DESCRIPTION
Apple assigned the **Default Mail App** managed capability to the team for `com.cabalmail.Cabalmail`. The portal side is already done (capability enabled on the App ID, iOS App Store profile re-issued, `IOS_APP_STORE_PROFILE` secret refreshed), so this PR ships the matching build-side change:

- Add `com.apple.developer.mail-client` to `apple/Cabalmail/Cabalmail.entitlements` (the file's comment block had reserved the spot).
- Update the "Setting Cabalmail as the default mail handler" rollout in `docs/apple.md` to describe the shipped state, keep the fork caveat (a fork must remove the key until its own grant lands), and fix the stale `IOS_APP_STORE_PROFILE_UUID` secret name.
- Changelog fragment (`Apple:`-prefixed) so the change lands in TestFlight notes.

After merge, the stage TestFlight build's archive is the first signed build against the re-issued profile — its upload legs double as verification that the profile/secret refresh took. Once a build with the entitlement is installed, Cabalmail appears in Settings → Apps → Mail → Default Mail App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)