### PR TITLE
Fade and collapse a swiped-away message row

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Optimistic.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Optimistic.swift
@@ -72,10 +72,60 @@ extension MessageListViewModel {
         }
     }
 
-    /// Reinsert an envelope previously removed by an optimistic dispose.
-    /// Tries to restore the original index; falls back to UID-sorted
-    /// insertion if the list has shifted (e.g. a refresh fired during the
-    /// in-flight move).
+    /// Leg of the two-stage row-disposal animation a row is currently in.
+    /// `nil` (absent from `rowDisposalPhases`) is the normal, settled state.
+    enum RowDisposalPhase: Equatable {
+        /// Full height, fading to transparent. Nothing moves yet.
+        case fading
+        /// Transparent, collapsing from `rowHeight` to zero. This is the leg
+        /// that closes the gap and shifts the rows below up.
+        case collapsing
+    }
+
+    /// Duration of each leg of the row-disposal animation, in seconds. Fast
+    /// enough not to slow triage down, long enough for the eye to register
+    /// that something left the list.
+    static let rowFadeDuration: TimeInterval = 0.15
+    static let rowCollapseDuration: TimeInterval = 0.15
+
+    /// Starts the two-stage disposal animation for a row and hands back the
+    /// task driving it, so the caller can keep the envelope in `envelopes`
+    /// until both legs have played out — or cancel it if the write fails and
+    /// the row has to come back.
+    ///
+    /// Fade first, collapse second, deliberately sequential: the row goes
+    /// transparent at full height (nothing moves, so the eye catches the
+    /// change), and only then does the gap close. Removing the envelope
+    /// outright reads as though nothing happened — under the index-addressed
+    /// list it isn't even a row removal, just every slot below re-pointing at
+    /// the next envelope, with no transition of any kind — which invites a
+    /// second swipe on whatever slid into the vacated position.
+    func beginRowDisposal(uid: UInt32) -> Task<Void, Never> {
+        rowDisposalPhases[uid] = .fading
+        return Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.rowFadeDuration))
+            // A cancellation here means the write failed and the caller is
+            // restoring the row, so the collapse must not fire. `endRowDisposal`
+            // owns clearing the phase.
+            guard !Task.isCancelled, let self else { return }
+            rowDisposalPhases[uid] = .collapsing
+            try? await Task.sleep(for: .seconds(Self.rowCollapseDuration))
+        }
+    }
+
+    /// Clears a row's disposal phase. Called once the envelope has actually
+    /// left `envelopes` (housekeeping — the row is gone) and on the failure
+    /// path, where it's the whole revert: the envelope never left, so dropping
+    /// the phase snaps the row back to full height and opacity.
+    func endRowDisposal(uid: UInt32) {
+        rowDisposalPhases[uid] = nil
+    }
+
+    /// Reinsert an envelope previously removed by an optimistic move (the
+    /// dispose path never removes it until the move has landed, so it has
+    /// nothing to reinsert). Tries to restore the original index; falls back
+    /// to UID-sorted insertion if the list has shifted (e.g. a refresh fired
+    /// during the in-flight move).
     func restoreEnvelope(_ envelope: Envelope, at originalIndex: Int?) {
         guard !envelopes.contains(where: { $0.uid == envelope.uid }) else { return }
         if let originalIndex, originalIndex <= envelopes.count {

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Refresh.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Refresh.swift
@@ -390,7 +390,13 @@ extension MessageListViewModel {
         let disappeared: [UInt32]
         if !fetched.isEmpty, windowFitsTopPage || fetchSpansFolder {
             let fetchedUIDs = Set(fetched.map(\.uid))
-            disappeared = envelopes.map(\.uid).filter { !fetchedUIDs.contains($0) }
+            // A row we're removing ourselves is exempt: a refresh landing in
+            // the moment between a dispose's move committing and the row
+            // finishing its fade-then-collapse would otherwise see it absent
+            // from the fetch and yank it out instantly -- the very jump the
+            // animation exists to avoid. `dispose(_:)` removes it either way.
+            disappeared = envelopes.map(\.uid)
+                .filter { !fetchedUIDs.contains($0) && !pendingRemovedUIDs.contains($0) }
         } else {
             disappeared = []
         }

--- a/apple/Cabalmail/ViewModels/MessageListViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel.swift
@@ -211,8 +211,10 @@ final class MessageListViewModel {
     // write paths in the sibling extensions (`+Optimistic`, `+Move`, `+Bulk`)
     // and the merge in `+Refresh` can reach them.
 
-    /// UIDs optimistically removed from `envelopes` (dispose or move) whose
-    /// server-side move is still in flight. Besides the merge shield this
+    /// UIDs on their way out of `envelopes` (dispose or move) whose
+    /// server-side move is still in flight — including, on the dispose path,
+    /// the few hundred milliseconds where the row is still present but
+    /// animating out (`rowDisposalPhases`). Besides the merge shield this
     /// doubles as `dispose(_:)`'s re-entrance guard: a duplicate rapid-swipe
     /// tap whose UID is already enqueued short-circuits, preventing
     /// re-entrant `ForEach(model.envelopes)` diffing while several in-flight
@@ -226,6 +228,12 @@ final class MessageListViewModel {
     /// `AppState.pendingFlagWriteUIDs` (its write lifecycle lives in the detail
     /// view model); `shieldFetched` consults both.
     var pendingFlagUIDs: Set<UInt32> = []
+
+    /// Rows mid-disposal animation, keyed by UID. A disposed row stays in
+    /// `envelopes` while it fades and then collapses (see `beginRowDisposal`
+    /// in `+Optimistic`), so the list closes the gap visibly instead of
+    /// instantaneously. Empty except during those ~300ms.
+    var rowDisposalPhases: [UInt32: RowDisposalPhase] = [:]
 
     init(scope: MessageListScope, client: CabalmailClient, preferences: Preferences, appState: AppState) {
         self.scope = scope
@@ -496,20 +504,29 @@ final class MessageListViewModel {
     /// the source and moves it in the same call — one round trip instead of
     /// a STORE followed by a MOVE.
     ///
-    /// Optimistic UI: the row is removed from `envelopes` before the
-    /// server round trip so the swipe feels instant. If the move fails the
-    /// envelope is reinserted at its prior index. Cache pruning still waits
-    /// for server confirmation — without that gate, a transient failure
-    /// would leave the persistent snapshot disagreeing with the server.
+    /// Optimistic UI: the row is disposed of locally before the server round
+    /// trip so the swipe feels instant, but it leaves the list on the two-leg
+    /// fade-then-collapse animation rather than blinking out (see
+    /// `beginRowDisposal`). If the move fails the row simply comes back — it
+    /// never left `envelopes`. Cache pruning still waits for server
+    /// confirmation — without that gate, a transient failure would leave the
+    /// persistent snapshot disagreeing with the server.
     func dispose(_ envelope: Envelope) async {
         guard pendingRemovedUIDs.insert(envelope.uid).inserted else { return }
         defer { pendingRemovedUIDs.remove(envelope.uid) }
 
         let destination = preferences.disposeAction.destinationFolder
         let source = sourceFolder(for: envelope)
-        let originalIndex = envelopes.firstIndex { $0.uid == envelope.uid }
         let wasUnread = !envelope.flags.contains(.seen)
-        envelopes.removeAll { $0.uid == envelope.uid }
+        // Start the row animation but deliberately DON'T await it before the
+        // move: a swipe landing just as the app is backgrounded has only a
+        // brief window to reach the network, so the request goes out first and
+        // the animation plays alongside it. The envelope leaves `envelopes`
+        // once both have settled. Until then the row renders transparent /
+        // collapsed and takes no hits, so it can't be swiped twice, and
+        // holding it in place keeps every absolute row index stable — the
+        // index-addressed list would otherwise shift the rows below instantly.
+        let disposal = beginRowDisposal(uid: envelope.uid)
         // Optimistic count drop for the source folder: the dispose path
         // marks the message `\Seen` before moving, so an unread message
         // both loses its unread state AND leaves the folder. One -1 covers
@@ -532,9 +549,20 @@ final class MessageListViewModel {
                 destination: destination,
                 markSeen: wasUnread
             )
+            // Both mutations in one synchronous step so the list sees a single
+            // update: the envelope is gone AND the phase is cleared, which
+            // leaves the vacated slot rendering the next envelope at full
+            // height with nothing left to animate.
+            await disposal.value
+            envelopes.removeAll { $0.uid == envelope.uid }
+            endRowDisposal(uid: envelope.uid)
             await pruneCachesAfter(move: source, uid: envelope.uid)
         } catch {
-            restoreEnvelope(envelope, at: originalIndex)
+            // The row never left `envelopes`, so clearing the phase is the
+            // whole revert. Cancel the animation first: a failure during the
+            // fade would otherwise still collapse the row we're restoring.
+            disposal.cancel()
+            endRowDisposal(uid: envelope.uid)
             if wasUnread {
                 appState.applyUnreadDelta(folderPath: source, delta: 1)
             }

--- a/apple/Cabalmail/Views/DisposingRow.swift
+++ b/apple/Cabalmail/Views/DisposingRow.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Plays a message row out of the list in two legs — fade at full height,
+/// then collapse to zero height — while the view model holds the envelope in
+/// place. `MessageListViewModel.dispose(_:)` drops the envelope only once both
+/// legs have run (see `beginRowDisposal`).
+///
+/// Why an animation at all: the removal itself is instantaneous, and under the
+/// index-addressed virtualized list it isn't even a row removal — every slot
+/// below simply re-points at the next envelope — so the rows snap up with no
+/// transition whatsoever. That reads as "nothing happened," which invites a
+/// second swipe on whatever slid into the vacated spot. Fading first, at full
+/// height, gives the eye something to catch before anything moves.
+///
+/// Why a separate view rather than modifiers on the row: this is where
+/// `rowDisposalPhases` is read, so a phase flip invalidates only the realized
+/// rows' wrappers. Read from `MessageListView`'s body instead, each flip would
+/// re-run the entire list body — `filteredEnvelopes` (O(loaded rows)) and
+/// every visible row with it.
+struct DisposingRow<Content: View>: View {
+    let model: MessageListViewModel
+    let uid: UInt32
+    let rowHeight: CGFloat
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        let phase = model.rowDisposalPhases[uid]
+        content()
+            .opacity(phase == nil ? 1 : 0)
+            // No `.clipped()`: the row keeps its intrinsic `rowHeight` and
+            // overflows this frame as it collapses, but it's fully transparent
+            // by then, so there's nothing to clip — and settled rows (all of
+            // them, nearly all the time) skip the clip cost.
+            .frame(height: phase == .collapsing ? 0 : rowHeight, alignment: .top)
+            // Hit testing goes off with the fade, so the second swipe this
+            // animation exists to prevent can't land on the outgoing row.
+            .allowsHitTesting(phase == nil)
+            .animation(animation(for: phase), value: phase)
+    }
+
+    /// Animation for the leg the row is entering. `nil` for the return to the
+    /// settled state, which covers the failed-write revert and — more
+    /// importantly — the moment the envelope leaves `envelopes` and this slot
+    /// re-points at the next one: that has to land at full height instantly,
+    /// not animate the incoming row back open.
+    private func animation(for phase: MessageListViewModel.RowDisposalPhase?) -> Animation? {
+        switch phase {
+        case .fading:
+            .easeOut(duration: MessageListViewModel.rowFadeDuration)
+        case .collapsing:
+            .easeOut(duration: MessageListViewModel.rowCollapseDuration)
+        case nil:
+            nil
+        }
+    }
+}

--- a/apple/Cabalmail/Views/MessageListView+Selection.swift
+++ b/apple/Cabalmail/Views/MessageListView+Selection.swift
@@ -208,10 +208,18 @@ extension MessageListView {
     /// the virtualized and filtered paths.
     @ViewBuilder
     private func messageRow(_ envelope: Envelope, model: MessageListViewModel, visible: [Envelope]) -> some View {
-        if scenePhase == .background {
-            placeholderRow()
-        } else {
-            activeMessageRow(envelope, model: model, visible: visible)
+        // The disposal transition is a wrapper VIEW, not modifiers applied
+        // here: reading `rowDisposalPhases` in this body would register the
+        // dependency on `MessageListView` itself, so each of a dispose's two
+        // phase flips would re-run the whole list body -- `filteredEnvelopes`
+        // (O(loaded rows)) and every visible row with it. Inside the wrapper
+        // the invalidation stops at the already-built rows.
+        DisposingRow(model: model, uid: envelope.uid, rowHeight: rowHeight) {
+            if scenePhase == .background {
+                placeholderRow()
+            } else {
+                activeMessageRow(envelope, model: model, visible: visible)
+            }
         }
     }
 

--- a/apple/CabalmailTests/RowDisposalTests.swift
+++ b/apple/CabalmailTests/RowDisposalTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// The swipe-to-dispose row animation: a disposed row fades at full height,
+// then collapses to zero, and only then leaves `envelopes`. The timing is
+// load-bearing rather than decorative — an instant removal in the index-
+// addressed list isn't even a row removal (every slot below just re-points at
+// the next envelope), so with no transition the eye reads it as "nothing
+// happened" and the user swipes again on whatever slid into place.
+@MainActor
+final class RowDisposalTests: XCTestCase {
+
+    func testDisposalFadesAtFullHeightBeforeCollapsing() async throws {
+        let model = try TestFixtures.makeModel(
+            imap: FakeImapClient(),
+            envelopes: [TestFixtures.makeEnvelope(uid: 1)]
+        )
+
+        let started = ContinuousClock.now
+        let disposal = model.beginRowDisposal(uid: 1)
+        XCTAssertEqual(
+            model.rowDisposalPhases[1], .fading,
+            "the fade starts immediately, at full height, so nothing shifts yet"
+        )
+        await disposal.value
+        XCTAssertEqual(model.rowDisposalPhases[1], .collapsing)
+        // Both legs are sleeps, so this is a guaranteed lower bound: the point
+        // of the animation is that it takes long enough to be perceived.
+        XCTAssertGreaterThanOrEqual(ContinuousClock.now - started, .milliseconds(300))
+    }
+
+    func testCancelledDisposalNeverReachesTheCollapse() async throws {
+        let model = try TestFixtures.makeModel(
+            imap: FakeImapClient(),
+            envelopes: [TestFixtures.makeEnvelope(uid: 1)]
+        )
+
+        let disposal = model.beginRowDisposal(uid: 1)
+        disposal.cancel()
+        await disposal.value
+
+        XCTAssertEqual(
+            model.rowDisposalPhases[1], .fading,
+            "a cancellation mid-fade (failed write, row coming back) must not fall through to the collapse"
+        )
+    }
+
+    func testDisposeRemovesTheRowOnlyAfterTheAnimation() async throws {
+        let imap = FakeImapClient()
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+
+        let disposeTask = Task { await model.dispose(model.envelopes[0]) }
+        // Yield until the move has gone out — it's issued before the animation
+        // is awaited, so the wire call must not be held up by the 300ms.
+        while await imap.moveCalls.isEmpty {
+            await Task.yield()
+        }
+        XCTAssertEqual(
+            model.envelopes.map(\.uid), [1, 2],
+            "the row stays in place (and every row index stays stable) while it animates out"
+        )
+        XCTAssertNotNil(model.rowDisposalPhases[1])
+
+        await disposeTask.value
+
+        XCTAssertEqual(model.envelopes.map(\.uid), [2])
+        XCTAssertTrue(model.rowDisposalPhases.isEmpty)
+        let moves = await imap.moveCalls
+        XCTAssertEqual(moves.count, 1)
+        XCTAssertEqual(moves.first?.uids, [1])
+    }
+
+    func testFailedDisposeLeavesTheRowInPlace() async throws {
+        let imap = FakeImapClient()
+        await imap.scriptMoveResults([.failure(CabalmailError.network("boom"))])
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: [TestFixtures.makeEnvelope(uid: 1), TestFixtures.makeEnvelope(uid: 2)]
+        )
+
+        await model.dispose(model.envelopes[0])
+
+        // The revert is just dropping the phase: the envelope never left, so
+        // there's no reinsertion to get the ordering wrong.
+        XCTAssertEqual(model.envelopes.map(\.uid), [1, 2])
+        XCTAssertTrue(model.rowDisposalPhases.isEmpty)
+        XCTAssertNotNil(model.errorMessage)
+    }
+}

--- a/changelog.d/swipe-dispose-row-animation.changed.md
+++ b/changelog.d/swipe-dispose-row-animation.changed.md
@@ -1,0 +1,6 @@
+- Apple: **Swipe-to-dispose now fades and collapses the row.** Archiving or
+  trashing a message from a swipe used to remove its row instantly, which the
+  eye can read as nothing having happened — and invites a second swipe on
+  whatever slid up into the vacated spot. The row now fades out over 150ms at
+  full height, then collapses to zero height over another 150ms, and only then
+  leaves the list. A failed move puts the row straight back.


### PR DESCRIPTION
Swipe-to-archive / swipe-to-trash removed the row instantly. Under the index-addressed virtualized list that isn't even a row removal — every slot below simply re-points at the next envelope — so the rows snap up with no transition of any kind. That reads as "nothing happened," and invites a second swipe on whatever slid into the vacated spot.

## What changed

The disposed row now leaves in two 150ms legs:

1. **Fade** at full height. Nothing moves, so the eye catches the change before any layout shifts.
2. **Collapse** to zero height. The gap closes and the rows below slide up.

Only then does the envelope leave `envelopes`. Holding it there is what keeps every absolute row index stable across the animation — and it means the final removal is visually a no-op (the collapsed slot and the removed slot put the following rows in exactly the same place).

Other details:

- The IMAP move still goes out **before** the animation is awaited. A swipe landing just as the app is backgrounded has only a brief window to reach the network, and that ordering is deliberate (same reasoning as the mark-seen/move round-trip collapse).
- The outgoing row takes no hits (`allowsHitTesting(false)`) from the moment the fade starts, so the second swipe this exists to prevent can't land on it either.
- A failed move needs no reinsertion any more: the envelope never left the list, so dropping the phase is the whole revert (and it cancels the animation, so a mid-fade failure doesn't collapse the row it's restoring).
- `applyRefreshPage` no longer treats a row we're removing ourselves as "disappeared", so a refresh landing inside those 300ms can't yank the row out mid-animation.
- The transition lives in a small wrapper view (`DisposingRow`) rather than modifiers on the row, so a phase flip invalidates only the realized rows — read from `MessageListView`'s body it would re-run the whole list body, `filteredEnvelopes` included.

## Verification

- `swift`/`xcodebuild` builds clean for macOS and iOS; `swiftlint --strict` clean.
- New `RowDisposalTests` (4 tests, 35/35 in the app suite): fade precedes collapse, a cancelled disposal never reaches the collapse, `dispose` keeps the row in place until the animation finishes (and issues the move before it), and a failed move leaves the row exactly where it was.
- Visual behaviour checked in a standalone SwiftUI harness on the iPhone 17 simulator — same modifier chain over the same embedded-`List` row structure, legs stretched to 1.2s to capture frames: the row fades at full height with the rows below unmoved, then the gap closes, and the removal itself produces no further jump. **Not** verified in the real app on-device/simulator: that simulator is signed out of stage and I don't have the test account's password.

Scoped to the swipe path, as reported. The context-menu Archive/Delete, the bulk action bar, Delete Forever in Trash, and the reader's dispose button still remove their rows instantly — say the word and they can share the same primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)