### PR TITLE
Self-service TOTP enrollment for MFA-gate locked-out accounts

### DIFF
--- a/changelog.d/mfa-block-banner-copy.fixed.md
+++ b/changelog.d/mfa-block-banner-copy.fixed.md
@@ -1,0 +1,6 @@
+- **Stale "Admin accounts" copy on the MFA sign-in block.** The
+  `require_admin_mfa` gate has covered all human users since the
+  all-users extension, but the React sign-in banner still claimed
+  "Admin accounts require multi-factor authentication". The fallback
+  banner (shown when no enrollment client is configured) now matches
+  the gate's actual scope.

--- a/changelog.d/mfa-locked-out-self-service.added.md
+++ b/changelog.d/mfa-locked-out-self-service.added.md
@@ -1,0 +1,10 @@
+- **Self-service MFA enrollment for locked-out accounts.** When the
+  `require_admin_mfa` gate is enforcing and rejects a password sign-in
+  because the account holds no MFA factor, the web app now offers a
+  "Set up authenticator app" flow instead of a dead end: it
+  re-authenticates through a dedicated enrollment app client that the
+  gate passes for factorless users only, shows the TOTP QR code, and
+  confirms the first code, after which the normal sign-in proceeds
+  with a TOTP challenge. The gate's rejection message now points at
+  the web app rather than a Security page the blocked user cannot
+  reach.

--- a/lambda/counter/require_admin_mfa/function.py
+++ b/lambda/counter/require_admin_mfa/function.py
@@ -12,10 +12,19 @@ factor before tokens are issued. Two independently-flagged gates:
   enroll before the gate hardens behind them.
 
 Each gate is audit-by-default (anything but "true" logs would_block and
-issues tokens); flip only after the affected population has enrolled,
-because enrollment requires a signed-in session - an enforced,
-un-enrolled user cannot sign in to enroll and needs operator rescue
-(flip the flag off, or aws cognito-idp admin-set-user-mfa-preference).
+issues tokens); enrollment requires a signed-in session, so an
+enforced, un-enrolled user cannot sign in through the normal app
+client. The self-service escape hatch is a dedicated enrollment app
+client (user_pool module, `mfa_enroll`): sign-ins through it are
+passed for users with NO factor - short-lived tokens whose only
+intended use is AssociateSoftwareToken / VerifySoftwareToken /
+SetUserMFAPreference from the web app's locked-out setup flow. Users
+who already hold a factor never reach the pass (they return early
+above it), and Cognito itself still demands their TOTP during the auth
+flow, so the enrollment client cannot be used to sidestep an enrolled
+second factor. The client's id is read from SSM (MFA_ENROLL_CLIENT_PARAM)
+rather than the environment because the pool -> trigger -> client ->
+pool reference chain would otherwise be a Terraform cycle.
 
 EXEMPT_USERS names the service and machine accounts that authenticate
 with a password and can never enroll (see require_admin_mfa.tf for the
@@ -41,8 +50,33 @@ exempt_users = {
     if name.strip()
 }
 grace_hours = int(os.environ.get('GRACE_HOURS', '48'))
+enroll_client_param = os.environ.get('MFA_ENROLL_CLIENT_PARAM', '')
 
 cognito = boto3.client('cognito-idp')
+ssm = boto3.client('ssm')
+
+# Lazily resolved id of the enrollment app client. Only successful
+# lookups are cached (for the container lifetime); a transient SSM
+# failure is retried on the next invocation instead of pinning the
+# escape hatch shut.
+_enroll_client = {'id': None}
+
+
+def _enroll_client_id():
+    '''Id of the enrollment app client, or '' when unconfigured or the
+    SSM read fails (the sign-in then blocks exactly as before).'''
+    if _enroll_client['id'] is not None:
+        return _enroll_client['id']
+    if not enroll_client_param:
+        return ''
+    try:
+        value = ssm.get_parameter(
+            Name=enroll_client_param
+        )['Parameter']['Value']
+    except Exception:  # pylint: disable=broad-exception-caught
+        return ''
+    _enroll_client['id'] = value
+    return value
 
 
 class AdminMfaRequired(Exception):
@@ -100,11 +134,21 @@ def handler(event, _context):
         return event
     enforced = enforce_admin if gate == 'admin' else enforce_user
     if enforced:
+        # Self-service escape hatch: a factorless sign-in through the
+        # dedicated enrollment client passes, so the web app's
+        # locked-out setup flow can associate and verify a TOTP.
+        # Enrolled users returned above and never reach this pass.
+        client_id = (event.get('callerContext') or {}).get('clientId', '')
+        if client_id and client_id == _enroll_client_id():
+            _log('enroll_pass', event, gate)
+            return event
         _log('blocked', event, gate)
+        # No trailing period: Cognito appends its own when it wraps
+        # this in "PreTokenGeneration failed with error ...".
         raise AdminMfaRequired(
             'This account requires multi-factor authentication. '
-            'Ask the operator to re-enable access, then enroll an '
-            'authenticator app under Security.'
+            'Sign in on the web app to set up an authenticator, '
+            'then try again'
         )
     _log('would_block', event, gate)
     return event

--- a/lambda/counter/require_admin_mfa/tests/test_function.py
+++ b/lambda/counter/require_admin_mfa/tests/test_function.py
@@ -1,0 +1,193 @@
+'''Unit tests for the require_admin_mfa pre-token-generation trigger.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/counter/require_admin_mfa/tests/test_function.py
+
+boto3 is faked in sys.modules before import, so the suite needs no AWS
+credentials and never touches the network. The module reads its flags
+from the environment at import time, so each test reloads it with the
+flag set it needs.
+'''
+import datetime
+import importlib
+import os
+import sys
+import types
+import unittest
+
+# function.py lives one directory up.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# --- fake boto3 ---------------------------------------------------------------
+
+ENROLL_CLIENT_ID = 'enroll-client-123'
+NORMAL_CLIENT_ID = 'admin-client-456'
+
+
+class _FakeCognito:
+    '''admin_get_user backed by a user dict set per test.'''
+
+    def __init__(self):
+        self.user = {}
+        self.error = None
+
+    def admin_get_user(self, **_kwargs):
+        if self.error:
+            raise self.error
+        return self.user
+
+
+class _FakeSsm:
+    '''get_parameter returning a canned value or raising per test.'''
+
+    def __init__(self):
+        self.value = ENROLL_CLIENT_ID
+        self.error = None
+        self.calls = 0
+
+    def get_parameter(self, **_kwargs):
+        self.calls += 1
+        if self.error:
+            raise self.error
+        return {'Parameter': {'Value': self.value}}
+
+
+FAKE_COGNITO = _FakeCognito()
+FAKE_SSM = _FakeSsm()
+
+_boto3 = types.ModuleType('boto3')
+_boto3.client = lambda name: FAKE_COGNITO if name == 'cognito-idp' else FAKE_SSM
+sys.modules['boto3'] = _boto3
+
+import function  # pylint: disable=wrong-import-position
+
+
+def _reload(**env):
+    '''Reload the module under a fresh environment (flags are read at
+    import time) and reset the fakes.'''
+    defaults = {
+        'ENFORCE_ADMIN_MFA': 'true',
+        'ENFORCE_USER_MFA': 'true',
+        'EXEMPT_USERS': 'master,dmarc',
+        'GRACE_HOURS': '48',
+        'MFA_ENROLL_CLIENT_PARAM': '/cabal/mfa_enroll_client_id',
+    }
+    defaults.update(env)
+    for key in list(defaults):
+        if defaults[key] is None:
+            os.environ.pop(key, None)
+            del defaults[key]
+    os.environ.update(defaults)
+    FAKE_COGNITO.user = {}
+    FAKE_COGNITO.error = None
+    FAKE_SSM.value = ENROLL_CLIENT_ID
+    FAKE_SSM.error = None
+    FAKE_SSM.calls = 0
+    importlib.reload(function)
+
+
+def _event(username='claude', client_id=NORMAL_CLIENT_ID, groups=None,
+           trigger='TokenGeneration_Authentication'):
+    return {
+        'userPoolId': 'us-east-1_test',
+        'userName': username,
+        'triggerSource': trigger,
+        'callerContext': {'clientId': client_id},
+        'request': {'groupConfiguration': {'groupsToOverride': groups or []}},
+    }
+
+
+def _user(mfa=None, created_hours_ago=100):
+    created = (datetime.datetime.now(datetime.timezone.utc)
+               - datetime.timedelta(hours=created_hours_ago))
+    return {'UserMFASettingList': mfa or [], 'UserCreateDate': created}
+
+
+class RequireAdminMfaTests(unittest.TestCase):
+    '''Gate decisions across client, enrollment, and flag combinations.'''
+
+    def test_enforced_unenrolled_normal_client_blocks(self):
+        _reload()
+        FAKE_COGNITO.user = _user()
+        with self.assertRaises(Exception) as ctx:
+            function.handler(_event(), None)
+        # Cognito appends its own period when it wraps the message;
+        # a trailing one here would render as "..".
+        self.assertFalse(str(ctx.exception).endswith('.'))
+        self.assertIn('multi-factor', str(ctx.exception))
+
+    def test_enforced_unenrolled_enroll_client_passes(self):
+        _reload()
+        FAKE_COGNITO.user = _user()
+        event = _event(client_id=ENROLL_CLIENT_ID)
+        self.assertIs(function.handler(event, None), event)
+
+    def test_enroll_client_pass_covers_admin_gate_too(self):
+        _reload()
+        FAKE_COGNITO.user = _user()
+        event = _event(client_id=ENROLL_CLIENT_ID, groups=['admin'])
+        self.assertIs(function.handler(event, None), event)
+
+    def test_enrolled_user_passes_regardless_of_client(self):
+        _reload()
+        FAKE_COGNITO.user = _user(mfa=['SOFTWARE_TOKEN_MFA'])
+        for client in (NORMAL_CLIENT_ID, ENROLL_CLIENT_ID):
+            event = _event(client_id=client)
+            self.assertIs(function.handler(event, None), event)
+
+    def test_ssm_failure_keeps_blocking_then_recovers(self):
+        _reload()
+        FAKE_COGNITO.user = _user()
+        FAKE_SSM.error = RuntimeError('throttled')
+        with self.assertRaises(Exception):
+            function.handler(_event(client_id=ENROLL_CLIENT_ID), None)
+        # The failure must not be cached: once SSM answers, the same
+        # container passes the enrollment client.
+        FAKE_SSM.error = None
+        event = _event(client_id=ENROLL_CLIENT_ID)
+        self.assertIs(function.handler(event, None), event)
+
+    def test_enroll_id_cached_after_success(self):
+        _reload()
+        FAKE_COGNITO.user = _user()
+        for _ in range(3):
+            with self.assertRaises(Exception):
+                function.handler(_event(), None)
+        self.assertEqual(FAKE_SSM.calls, 1)
+
+    def test_param_unset_blocks_without_ssm_call(self):
+        _reload(MFA_ENROLL_CLIENT_PARAM=None)
+        FAKE_COGNITO.user = _user()
+        with self.assertRaises(Exception):
+            function.handler(_event(client_id=ENROLL_CLIENT_ID), None)
+        self.assertEqual(FAKE_SSM.calls, 0)
+
+    def test_audit_mode_still_passes_unenrolled(self):
+        _reload(ENFORCE_USER_MFA='false')
+        FAKE_COGNITO.user = _user()
+        event = _event()
+        self.assertIs(function.handler(event, None), event)
+
+    def test_grace_window_passes_before_enroll_check(self):
+        _reload()
+        FAKE_COGNITO.user = _user(created_hours_ago=1)
+        event = _event()
+        self.assertIs(function.handler(event, None), event)
+        self.assertEqual(FAKE_SSM.calls, 0)
+
+    def test_exempt_user_passes_without_lookup(self):
+        _reload()
+        FAKE_COGNITO.error = AssertionError('must not be called')
+        event = _event(username='master')
+        self.assertIs(function.handler(event, None), event)
+
+    def test_lookup_failure_fails_open(self):
+        _reload()
+        FAKE_COGNITO.error = RuntimeError('throttled')
+        event = _event()
+        self.assertIs(function.handler(event, None), event)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/react/admin/src/App.jsx
+++ b/react/admin/src/App.jsx
@@ -24,6 +24,7 @@ import SignUp from './SignUp';
 import Login from './Login';
 import Verify from './Verify';
 import MfaChallenge from './MfaChallenge';
+import MfaSetup from './MfaSetup';
 import VerifyEmail from './VerifyEmail';
 import EnrollMfa from './EnrollMfa';
 import ForgotPassword from './ForgotPassword';
@@ -75,6 +76,7 @@ function loadSavedState() {
     verificationCode: null,
     view: "Login",
     poolData: null,
+    enroll_client_id: null,
     control_domain: null,
     imap_host: null,
     domains: {},
@@ -162,6 +164,13 @@ function App() {
   // challenge Cognito issued ('totp' | 'sms').
   const pendingMfaUserRef = useRef(null);
   const [mfaChallengeType, setMfaChallengeType] = useState('totp');
+  // Locked-out TOTP setup (#768): the CognitoUser authenticated through
+  // the enrollment app client (a stateful SDK object, so a ref) and the
+  // pending TOTP secret. The secret deliberately lives outside the
+  // persisted state bag so it never reaches localStorage.
+  const mfaSetupUserRef = useRef(null);
+  const [mfaSetupSecret, setMfaSetupSecret] = useState(null);
+  const [mfaSetupBusy, setMfaSetupBusy] = useState(false);
   // Post-login email gate: null when passed/skipped, else
   // { mode: 'add' | 'verify', address }. Not persisted - it is
   // re-derived from user attributes at each login.
@@ -283,6 +292,9 @@ function App() {
       UserPool = new CognitoUserPool(cognitoConfig.poolData);
       setState({
         poolData: cognitoConfig.poolData,
+        // Absent from a pre-#768 /config.js; the locked-out MFA setup
+        // flow feature-detects on it and falls back to a plain banner.
+        enroll_client_id: cognitoConfig.enrollClientId || null,
         control_domain,
         imap_host: control_domain.match(/^dev\./)
           ? control_domain.replace("dev.", "imap.")
@@ -618,14 +630,20 @@ function App() {
       onFailure: (err) => {
         _token = null;
         _expires = Math.floor(new Date() / 1000) - 1;
-        setState({ loggedIn: false, view: "Login" });
         // The require_admin_mfa pre-token-generation trigger (enforce
-        // mode) rejects un-enrolled admins; show its message rather than
-        // a generic failure so the reason is actionable.
+        // mode) rejects any un-enrolled account. Route to the
+        // self-service setup flow (#768) when the enrollment client is
+        // configured; otherwise surface an actionable banner.
         const mfaBlocked = err && /require.*multi-factor|admin accounts require/i.test(err.message || '');
+        if (mfaBlocked && state.enroll_client_id) {
+          setMfaSetupSecret(null);
+          setState({ loggedIn: false, view: "MfaSetup" });
+          return;
+        }
+        setState({ loggedIn: false, view: "Login" });
         setMessage(
           mfaBlocked
-            ? "Admin accounts require multi-factor authentication. Contact the operator to restore access."
+            ? "This account requires multi-factor authentication. Contact the operator to restore access."
             : "Login failed",
           true
         );
@@ -644,7 +662,7 @@ function App() {
         setState({ view: "MfaChallenge", verificationCode: null });
       }
     });
-  }, [state.userName, state.password, finishLogin, setState, setMessage]);
+  }, [state.userName, state.password, state.enroll_client_id, finishLogin, setState, setMessage]);
 
   const doSubmitMfaCode = useCallback((e) => {
     e.preventDefault();
@@ -667,6 +685,114 @@ function App() {
       mfaChallengeType === 'totp' ? 'SOFTWARE_TOKEN_MFA' : 'SMS_MFA'
     );
   }, [state.verificationCode, mfaChallengeType, finishLogin, setState, setMessage]);
+
+  // --- Locked-out TOTP setup handlers (#768) ---
+  //
+  // The gate rejects password logins for un-enrolled accounts, so the
+  // normal client can never yield a session to enroll with. These
+  // re-authenticate through the dedicated enrollment app client
+  // (enrollClientId from /config.js), which the gate passes for
+  // factorless users only, then run the same associate/verify/prefer
+  // sequence as the Security view against that short-lived session.
+
+  const beginMfaSetup = useCallback(() => {
+    if (!state.poolData || !state.enroll_client_id || !state.userName || !state.password) {
+      // The password never survives a reload (persistState strips it),
+      // so a revisit of this view has to restart from Login.
+      setState({ view: "Login" });
+      setMessage("Please enter your password again to continue.", true);
+      return;
+    }
+    const pool = new CognitoUserPool({
+      UserPoolId: state.poolData.UserPoolId,
+      ClientId: state.enroll_client_id,
+    });
+    const user = new CognitoUser({ Username: state.userName, Pool: pool });
+    const creds = new AuthenticationDetails({
+      Username: state.userName,
+      Password: state.password,
+    });
+    // Only an already-enrolled account draws a second-factor challenge
+    // here; normal sign-in is the right path for it.
+    const alreadyEnrolled = () => {
+      setMfaSetupBusy(false);
+      setState({ view: "Login" });
+      setMessage("This account already has an authenticator. Sign in normally.", true);
+    };
+    setMfaSetupBusy(true);
+    user.authenticateUser(creds, {
+      onSuccess: () => {
+        user.associateSoftwareToken({
+          associateSecretCode: (secret) => {
+            setMfaSetupBusy(false);
+            mfaSetupUserRef.current = user;
+            setMfaSetupSecret(secret);
+            setState({ verificationCode: null });
+          },
+          onFailure: () => {
+            setMfaSetupBusy(false);
+            setMessage("Could not start two-factor setup. Please try again.", true);
+          },
+        });
+      },
+      onFailure: () => {
+        setMfaSetupBusy(false);
+        setMessage("Could not start two-factor setup. Please try again.", true);
+      },
+      totpRequired: alreadyEnrolled,
+      mfaRequired: alreadyEnrolled,
+    });
+  }, [state.poolData, state.enroll_client_id, state.userName, state.password, setState, setMessage]);
+
+  const doConfirmMfaSetup = useCallback((e) => {
+    e.preventDefault();
+    const user = mfaSetupUserRef.current;
+    if (!user) {
+      // The enrollment session lives only in memory; a reload mid-setup
+      // loses it and the flow must restart.
+      setMfaSetupSecret(null);
+      setState({ view: "Login", verificationCode: null });
+      setMessage("Your setup session expired. Please log in again.", true);
+      return;
+    }
+    setMfaSetupBusy(true);
+    user.verifySoftwareToken(state.verificationCode, 'Cabalmail', {
+      onSuccess: () => {
+        user.setUserMfaPreference(
+          null,
+          { PreferredMfa: true, Enabled: true },
+          (err) => {
+            setMfaSetupBusy(false);
+            if (err) {
+              setMessage("Could not turn on two-factor authentication. Please try again.", true);
+              return;
+            }
+            // Drop the enrollment-client session; the normal sign-in
+            // (which now issues a TOTP challenge) is what counts.
+            mfaSetupUserRef.current = null;
+            user.signOut();
+            setMfaSetupSecret(null);
+            setState({ view: "Login", verificationCode: null });
+            setMessage("Two-factor authentication is on. Sign in again with a code from your app.", false);
+          }
+        );
+      },
+      onFailure: () => {
+        setMfaSetupBusy(false);
+        setMessage("That code did not match. Check your authenticator app and try again.", true);
+      },
+    });
+  }, [state.verificationCode, setState, setMessage]);
+
+  const cancelMfaSetup = useCallback((e) => {
+    e.preventDefault();
+    const user = mfaSetupUserRef.current;
+    if (user) user.signOut();
+    mfaSetupUserRef.current = null;
+    setMfaSetupSecret(null);
+    setMfaSetupBusy(false);
+    setState({ view: "Login", verificationCode: null });
+  }, [setState]);
 
   // --- VerifyEmail gate handlers (identity plan Phase 1) ---
 
@@ -904,6 +1030,19 @@ function App() {
             onSkip={skipEmailGate}
           />
         );
+      case "MfaSetup":
+        return (
+          <MfaSetup
+            userName={state.userName}
+            secret={mfaSetupSecret}
+            busy={mfaSetupBusy}
+            code={state.verificationCode}
+            onBegin={beginMfaSetup}
+            onCodeChange={doInputChange}
+            onSubmit={doConfirmMfaSetup}
+            onCancel={cancelMfaSetup}
+          />
+        );
       case "EnrollMfa":
         return (
           <EnrollMfa
@@ -1035,7 +1174,7 @@ function App() {
   // AuthShell gates (no Nav), so they live in this list alongside the
   // true pre-login views.
   const isPreLoginView = configUnavailable
-    || ["Login", "SignUp", "Verify", "MfaChallenge", "VerifyEmail",
+    || ["Login", "SignUp", "Verify", "MfaChallenge", "MfaSetup", "VerifyEmail",
       "EnrollMfa", "ForgotPassword", "ResetPassword"].includes(state.view);
 
   const shortcutCallbacks = useMemo(() => ({

--- a/react/admin/src/MfaSetup/MfaSetup.css
+++ b/react/admin/src/MfaSetup/MfaSetup.css
@@ -1,0 +1,20 @@
+/* Locked-out TOTP setup. The QR sits on a white card regardless of
+   theme so camera apps can read it. */
+.mfa-setup__qr {
+  display: inline-block;
+  padding: 8px;
+  background: #fff;
+  border-radius: 8px;
+  line-height: 0;
+  margin: 0 0 12px;
+}
+
+.mfa-setup__manual {
+  font-size: 0.85rem;
+  margin: 0 0 16px;
+  overflow-wrap: anywhere;
+}
+
+.mfa-setup__secret {
+  user-select: all;
+}

--- a/react/admin/src/MfaSetup/MfaSetup.test.jsx
+++ b/react/admin/src/MfaSetup/MfaSetup.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MfaSetup from './index';
+import AuthContext from '../contexts/AuthContext';
+
+const withAuth = (ui) => (
+  <AuthContext.Provider value={{ control_domain: 'example.com' }}>
+    {ui}
+  </AuthContext.Provider>
+);
+
+describe('MfaSetup', () => {
+  const defaultProps = {
+    userName: 'claude',
+    secret: null,
+    busy: false,
+    code: '',
+    onBegin: vi.fn(),
+    onCodeChange: vi.fn(),
+    onSubmit: vi.fn(e => e.preventDefault()),
+    onCancel: vi.fn(),
+  };
+
+  it('offers setup without leaking Cognito internals', () => {
+    render(withAuth(<MfaSetup {...defaultProps} />));
+    expect(
+      screen.getByRole('button', { name: 'Set up authenticator app' })
+    ).toBeInTheDocument();
+    // The stale admin-era copy (#770) and the raw trigger name must
+    // not appear anywhere on the locked-out screen.
+    expect(screen.queryByText(/admin accounts/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/PreTokenGeneration/)).not.toBeInTheDocument();
+  });
+
+  it('starts enrollment from the offer button', () => {
+    const onBegin = vi.fn();
+    render(withAuth(<MfaSetup {...defaultProps} onBegin={onBegin} />));
+    fireEvent.click(screen.getByRole('button', { name: 'Set up authenticator app' }));
+    expect(onBegin).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the QR, manual key, and code form once a secret exists', () => {
+    render(withAuth(<MfaSetup {...defaultProps} secret="SECRETKEY234567" />));
+    expect(screen.getByLabelText('TOTP enrollment QR code')).toBeInTheDocument();
+    expect(screen.getByText('SECRETKEY234567')).toBeInTheDocument();
+    expect(screen.getByLabelText('Code from your app')).toBeInTheDocument();
+  });
+
+  it('keeps Confirm disabled until six digits are entered', () => {
+    const { rerender } = render(
+      withAuth(<MfaSetup {...defaultProps} secret="SECRETKEY234567" code="123" />)
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    rerender(
+      withAuth(<MfaSetup {...defaultProps} secret="SECRETKEY234567" code="123456" />)
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+  });
+
+  it('submits the confirmation form', () => {
+    const onSubmit = vi.fn(e => e.preventDefault());
+    render(withAuth(
+      <MfaSetup {...defaultProps} secret="SECRETKEY234567" code="123456" onSubmit={onSubmit} />
+    ));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a way back to sign-in from both phases', () => {
+    const onCancel = vi.fn();
+    const { rerender } = render(withAuth(<MfaSetup {...defaultProps} onCancel={onCancel} />));
+    fireEvent.click(screen.getByText('Back to sign in'));
+    rerender(withAuth(
+      <MfaSetup {...defaultProps} secret="SECRETKEY234567" onCancel={onCancel} />
+    ));
+    fireEvent.click(screen.getByText('Back to sign in'));
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/react/admin/src/MfaSetup/index.jsx
+++ b/react/admin/src/MfaSetup/index.jsx
@@ -1,0 +1,106 @@
+import { QRCodeSVG } from 'qrcode.react';
+import AuthShell from '../Login/AuthShell';
+import './MfaSetup.css';
+
+/**
+ * Locked-out TOTP setup (identity plan Phase 1 follow-up). Shown when
+ * the require_admin_mfa gate rejects a password login because the
+ * account has no MFA factor: the normal client cannot issue a session
+ * to enroll with, so App.jsx re-authenticates through the dedicated
+ * enrollment app client and completes the enrollment here. Two phases:
+ * an offer screen (no secret yet), then the QR/confirm form once
+ * associateSoftwareToken has produced a secret.
+ */
+function MfaSetup({
+  userName,
+  secret,
+  busy,
+  code,
+  onBegin,
+  onCodeChange,
+  onSubmit,
+  onCancel,
+}) {
+  const headerRight = (
+    <span><a href="#" onClick={onCancel}>Back to sign in</a></span>
+  );
+
+  // otpauth URI per the Key Uri Format; label is issuer:account so
+  // authenticator apps group the entry under Cabalmail (matches the
+  // Security view's enrollment).
+  const otpauthUri = secret
+    ? `otpauth://totp/${encodeURIComponent(`Cabalmail:${userName || 'user'}`)}?secret=${secret}&issuer=Cabalmail`
+    : null;
+
+  if (!secret) {
+    return (
+      <AuthShell headerRight={headerRight} cardSize="narrow">
+        <p className="auth__eyebrow">Security</p>
+        <h1 className="auth__title">Two-factor is required.</h1>
+        <p className="auth__subtitle">
+          This account requires multi-factor authentication before it
+          can sign in. Set up an authenticator app now to restore
+          access &mdash; it only takes a minute.
+        </p>
+        <button
+          type="button"
+          className="auth__btn-primary"
+          onClick={onBegin}
+          disabled={busy}
+        >
+          Set up authenticator app
+        </button>
+      </AuthShell>
+    );
+  }
+
+  return (
+    <AuthShell headerRight={headerRight} cardSize="narrow">
+      <p className="auth__eyebrow">Security</p>
+      <h1 className="auth__title">Scan, then confirm.</h1>
+      <p className="auth__subtitle">
+        Scan this QR code with an authenticator app (1Password, Google
+        Authenticator, Authy, &hellip;), then enter the 6-digit code it
+        shows.
+      </p>
+      <div className="mfa-setup__qr" aria-label="TOTP enrollment QR code">
+        <QRCodeSVG value={otpauthUri} size={168} marginSize={2} />
+      </div>
+      <p className="mfa-setup__manual">
+        Can&rsquo;t scan? Enter this key manually:{' '}
+        <code className="mfa-setup__secret">{secret}</code>
+      </p>
+      <form className="auth__form" onSubmit={onSubmit} noValidate>
+        <div className="auth__field">
+          <div className="auth__field-header">
+            <label className="auth__field-label" htmlFor="verificationCode">
+              Code from your app
+            </label>
+          </div>
+          <input
+            id="verificationCode"
+            name="verificationCode"
+            type="text"
+            className="mono"
+            autoComplete="one-time-code"
+            inputMode="numeric"
+            placeholder="123456"
+            onChange={onCodeChange}
+            value={code || ''}
+            required
+            autoFocus
+          />
+        </div>
+        <button
+          type="submit"
+          className="auth__btn-primary"
+          disabled={busy || (code || '').length < 6}
+        >
+          Confirm
+        </button>
+      </form>
+    </AuthShell>
+  );
+}
+
+export default MfaSetup;

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -197,21 +197,22 @@ module "domains" {
 
 # Infrastructure and code for the administrative web site
 module "admin" {
-  source              = "./modules/app"
-  control_domain      = var.control_domain
-  user_pool_id        = module.pool.user_pool_id
-  user_pool_client_id = module.pool.user_pool_client_id
-  region              = var.aws_region
-  cert_arn            = module.cert.cert_arn
-  zone_id             = data.terraform_remote_state.zone.outputs.control_domain_zone_id
-  private_zone_id     = module.vpc.private_zone.zone_id
-  domains             = module.domains.domains
-  bucket              = module.bucket.bucket
-  bucket_arn          = module.bucket.bucket_arn
-  bucket_domain_name  = module.bucket.domain_name
-  oai_iam_arn         = module.bucket.oai_iam_arn
-  relay_ips           = module.vpc.relay_ips
-  dev_mode            = var.prod ? false : true
+  source               = "./modules/app"
+  control_domain       = var.control_domain
+  user_pool_id         = module.pool.user_pool_id
+  user_pool_client_id  = module.pool.user_pool_client_id
+  mfa_enroll_client_id = module.pool.mfa_enroll_client_id
+  region               = var.aws_region
+  cert_arn             = module.cert.cert_arn
+  zone_id              = data.terraform_remote_state.zone.outputs.control_domain_zone_id
+  private_zone_id      = module.vpc.private_zone.zone_id
+  domains              = module.domains.domains
+  bucket               = module.bucket.bucket
+  bucket_arn           = module.bucket.bucket_arn
+  bucket_domain_name   = module.bucket.domain_name
+  oai_iam_arn          = module.bucket.oai_iam_arn
+  relay_ips            = module.vpc.relay_ips
+  dev_mode             = var.prod ? false : true
 
   address_changed_topic_arn = module.ecs.sns_topic_arn
   push_queue_arn            = module.ecs.push_queue_arn

--- a/terraform/infra/modules/app/s3.tf
+++ b/terraform/infra/modules/app/s3.tf
@@ -13,6 +13,7 @@ resource "aws_s3_object" "website_config" {
   content = templatefile("${path.module}/templates/config.js.tftpl", {
     pool_id             = var.user_pool_id,
     pool_client_id      = var.user_pool_client_id,
+    enroll_client_id    = var.mfa_enroll_client_id,
     region              = var.region,
     invoke_url          = "https://${aws_api_gateway_rest_api.gateway.id}.execute-api.${var.region}.amazonaws.com/${var.stage_name}",
     domains             = var.domains,
@@ -24,6 +25,7 @@ resource "aws_s3_object" "website_config" {
   etag = md5(templatefile("${path.module}/templates/config.js.tftpl", {
     pool_id             = var.user_pool_id,
     pool_client_id      = var.user_pool_client_id,
+    enroll_client_id    = var.mfa_enroll_client_id,
     region              = var.region,
     invoke_url          = "https://${aws_api_gateway_rest_api.gateway.id}.execute-api.${var.region}.amazonaws.com/${var.stage_name}",
     domains             = var.domains,
@@ -48,6 +50,7 @@ resource "aws_s3_object" "website_config_json" {
   content = templatefile("${path.module}/templates/config.js.tftpl", {
     pool_id             = var.user_pool_id,
     pool_client_id      = var.user_pool_client_id,
+    enroll_client_id    = var.mfa_enroll_client_id,
     region              = var.region,
     invoke_url          = "https://${aws_api_gateway_rest_api.gateway.id}.execute-api.${var.region}.amazonaws.com/${var.stage_name}",
     domains             = var.domains,
@@ -59,6 +62,7 @@ resource "aws_s3_object" "website_config_json" {
   etag = md5(templatefile("${path.module}/templates/config.js.tftpl", {
     pool_id             = var.user_pool_id,
     pool_client_id      = var.user_pool_client_id,
+    enroll_client_id    = var.mfa_enroll_client_id,
     region              = var.region,
     invoke_url          = "https://${aws_api_gateway_rest_api.gateway.id}.execute-api.${var.region}.amazonaws.com/${var.stage_name}",
     domains             = var.domains,

--- a/terraform/infra/modules/app/templates/config.js.tftpl
+++ b/terraform/infra/modules/app/templates/config.js.tftpl
@@ -10,6 +10,7 @@
     "poolData": {
       "UserPoolId": "${pool_id}",
       "ClientId": "${pool_client_id}"
-    }
+    },
+    "enrollClientId": "${enroll_client_id}"
   }
 }

--- a/terraform/infra/modules/app/variables.tf
+++ b/terraform/infra/modules/app/variables.tf
@@ -12,6 +12,11 @@ variable "user_pool_client_id" {
   description = "Client ID for authenticating with the Cognito user pool."
 }
 
+variable "mfa_enroll_client_id" {
+  type        = string
+  description = "Client ID for the locked-out MFA setup flow."
+}
+
 variable "region" {
   type        = string
   description = "The AWS region."

--- a/terraform/infra/modules/user_pool/outputs.tf
+++ b/terraform/infra/modules/user_pool/outputs.tf
@@ -13,6 +13,11 @@ output "user_pool_client_id" {
   description = "ID for the client application of the Cognito user pool"
 }
 
+output "mfa_enroll_client_id" {
+  value       = aws_cognito_user_pool_client.mfa_enroll.id
+  description = "ID of the app client used by the locked-out MFA setup flow"
+}
+
 output "admin_group_name" {
   value       = aws_cognito_user_group.admin.name
   description = "Name of the Cognito admin group"

--- a/terraform/infra/modules/user_pool/require_admin_mfa.tf
+++ b/terraform/infra/modules/user_pool/require_admin_mfa.tf
@@ -17,6 +17,46 @@
 * the real code ships out-of-band).
 */
 
+locals {
+  # SSM parameter carrying the enrollment client's id. A literal shared
+  # by the parameter and the trigger's environment: the trigger cannot
+  # reference the client resource directly (pool -> trigger -> client ->
+  # pool would be a Terraform cycle), so it resolves the id at runtime.
+  mfa_enroll_client_param = "/cabal/mfa_enroll_client_id"
+}
+
+# Self-service escape hatch for the gates above: a dedicated app client
+# for the web app's locked-out TOTP setup flow. The trigger passes
+# sign-ins through this client only for users with NO MFA factor; the
+# short-lived tokens exist to carry AssociateSoftwareToken /
+# VerifySoftwareToken / SetUserMFAPreference. Enrolled users still get
+# Cognito's own TOTP challenge on this client (per-user preference, not
+# per-client), so it cannot sidestep an existing second factor.
+resource "aws_cognito_user_pool_client" "mfa_enroll" {
+  name                = "cabal_mfa_enroll_client"
+  user_pool_id        = aws_cognito_user_pool.users.id
+  explicit_auth_flows = ["USER_PASSWORD_AUTH"]
+
+  access_token_validity  = 5
+  id_token_validity      = 5
+  refresh_token_validity = 60 # Cognito's floor
+  token_validity_units {
+    access_token  = "minutes"
+    id_token      = "minutes"
+    refresh_token = "minutes"
+  }
+
+  enable_token_revocation = true
+}
+
+resource "aws_ssm_parameter" "mfa_enroll_client_id" {
+  #checkov:skip=CKV2_AWS_34: an app client id is public configuration (it ships in config.js), not a secret; plaintext String is deliberate
+  name        = local.mfa_enroll_client_param
+  description = "App client id the require_admin_mfa trigger passes for self-service TOTP enrollment"
+  type        = "String"
+  value       = aws_cognito_user_pool_client.mfa_enroll.id
+}
+
 data "archive_file" "require_admin_mfa_placeholder" {
   type        = "zip"
   output_path = "${path.module}/.terraform/require_admin_mfa_placeholder.zip"
@@ -79,6 +119,13 @@ resource "aws_iam_role_policy" "require_admin_mfa" {
         Effect   = "Allow"
         Action   = "cognito-idp:AdminGetUser"
         Resource = aws_cognito_user_pool.users.arn
+      },
+      {
+        # Runtime lookup of the enrollment client id (cycle note on the
+        # locals block above).
+        Effect   = "Allow"
+        Action   = "ssm:GetParameter"
+        Resource = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter${local.mfa_enroll_client_param}"
       },
       {
         # Bare group ARN, no ":*" suffix: the log-group resource grammar
@@ -152,6 +199,10 @@ resource "aws_lambda_function" "require_admin_mfa" {
       # A new signup gets this long to sign in and enroll via the
       # Security page before the user gate applies to them.
       GRACE_HOURS = "48"
+      # Where to find the enrollment client's id at runtime (cycle note
+      # on the locals block above). Unset or unreadable disables the
+      # escape hatch; blocked sign-ins then behave as before.
+      MFA_ENROLL_CLIENT_PARAM = local.mfa_enroll_client_param
     }
   }
 


### PR DESCRIPTION
## What was wrong

With `ENFORCE_USER_MFA=true`, the `require_admin_mfa` pre-token-generation trigger rejects every sign-in (and refresh) for an account with no MFA factor. Enrollment needs a signed-in session, so a locked-out user had no self-serve path at all — operator rescue was the only way back in (#768). On top of that, the React banner shown for the block still carried the admin-era copy "Admin accounts require multi-factor authentication" even though the gate covers all human users (#770).

## Root cause

The gate blocks at token issuance, which is *after* password verification but *before* any session exists — a by-design chicken-and-egg the Lambda's own docstring warned about. The stale banner was a canned string in `App.jsx` that predates the gate's all-users extension.

## The fix

- **New enrollment app client** (`cabal_mfa_enroll_client`, user_pool module): 5-minute access/id tokens, floor-value refresh. Its id is published to SSM (`/cabal/mfa_enroll_client_id`) and surfaced to clients as `cognitoConfig.enrollClientId` in `config.js`/`config.json`.
- **Gate pass** (`require_admin_mfa/function.py`): a sign-in through that client is passed **only for users with no MFA factor** (logged as `enroll_pass`). Enrolled users return earlier on the factor check, and Cognito still issues their TOTP challenge during the auth flow on any client (per-user preference), so the enrollment client cannot sidestep an existing second factor. The id is read from SSM at runtime because an env-var reference would cycle pool → trigger → client → pool in Terraform. SSM unset/unreadable ⇒ hatch closed, blocked sign-ins behave exactly as before (failures are not negatively cached).
- **React locked-out flow** (`MfaSetup` view): an MFA-blocked login now routes to an offer screen → re-auth through the enrollment client → QR + manual key → confirm code → `setUserMfaPreference` → back to Login, where the normal sign-in proceeds with the existing `MfaChallenge` TOTP screen. Feature-detects `enrollClientId`, so an older `config.js` falls back to a banner — now with the corrected copy (this is the #770 fix; the stale string lived in the exact code path this flow replaces, hence one PR for both).
- **Gate message** reworded to point at the web app instead of an unreachable Security page, and the trailing period dropped (Cognito appends its own — the "Security.." double period from #769).

## Rollout ordering

All three legs are fail-safe in any order: old gate + new client ⇒ enrollment sign-ins still blocked; new gate + no SSM param ⇒ hatch closed; React flow without `enrollClientId` ⇒ fallback banner.

## Test evidence

- `python3 lambda/counter/require_admin_mfa/tests/test_function.py` — 11 tests, all pass; **fails-before verified** (5 failures against the previous gate code). Covers: block on normal client, enroll-client pass (user + admin gates), enrolled-user pass on both clients, SSM failure blocks then recovers without caching the failure, id cached after success, param-unset short-circuit, audit mode, grace window, exempt users, fail-open lookup.
- `npm run test` (react/admin) — 358 tests / 37 files pass, including the new `MfaSetup` suite (offer + QR phases, no leaked Cognito internals, no admin-era copy). `npm run build` clean.
- `pylint --rcfile lambda/api/.pylintrc lambda/counter/*/function.py` — 10.00/10 (matches the CI job).
- `terraform validate` on `terraform/infra` — clean; `terraform fmt` applied. New SSM parameter carries an inline `CKV2_AWS_34` skip (an app client id is public configuration — it ships in `config.js`).
- Not live-verified end-to-end: exercising the real flow needs this stack applied to stage (client + SSM + gate env var don't exist yet). The tester's locked-out `claude` account on stage is the natural first live test once this merges and `infra.yml`/`app.yml` complete.

Addresses #768. Addresses #770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)