### PR TITLE
Show the MFA gate's own message on Apple sign-in, not Cognito's wrapper

### DIFF
--- a/apple/Cabalmail/AppState.swift
+++ b/apple/Cabalmail/AppState.swift
@@ -515,6 +515,11 @@ final class AppState {
         // Planned IMAP redeploy: show the API's friendly copy verbatim, no
         // "Server error:" prefix.
         case .maintenance(let message): return message
+        // A Cognito trigger rejected the sign-in (e.g. the MFA-enrollment
+        // gate). The Kit has already stripped Cognito's trigger wrapper;
+        // what remains is the trigger's own user-facing copy, so show it
+        // verbatim like .maintenance above.
+        case .server(code: "UserLambdaValidationException", message: let message): return message
         default:                  return nil
         }
     }

--- a/apple/CabalmailKit/Sources/CabalmailKit/Auth/AuthService.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Auth/AuthService.swift
@@ -329,6 +329,15 @@ public actor CognitoAuthService: AuthService {
             if code == "NotAuthorizedException" {
                 throw CabalmailError.invalidCredentials
             }
+            if code == "UserLambdaValidationException" {
+                // A pool trigger (require_admin_mfa, check_invite, ...)
+                // rejected the call; the trigger's own message is the
+                // user-facing part, not Cognito's wrapper around it.
+                throw CabalmailError.server(
+                    code: code,
+                    message: Self.stripLambdaTriggerWrapper(from: message)
+                )
+            }
             throw CabalmailError.server(code: code, message: message)
         }
         return (try JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
@@ -464,5 +473,28 @@ extension CognitoAuthService {
         let refreshed = try await refresh(using: tokens)
         try persist(tokens: refreshed)
         return refreshed.accessToken
+    }
+}
+
+extension CognitoAuthService {
+    /// Cognito reports a Lambda-trigger rejection as
+    /// "<TriggerName> failed with error <trigger message>." — the wrapper
+    /// leaks the trigger's name and, when the trigger message has its own
+    /// terminal period, produces a doubled one. Return just the trigger's
+    /// message. Internal (not private) for direct unit coverage.
+    static func stripLambdaTriggerWrapper(from message: String) -> String {
+        var text = message
+        if let range = text.range(of: " failed with error ") {
+            // Only strip when the lead-in is a bare trigger name; a space
+            // means the phrase occurs mid-sentence in a real message.
+            let lead = text[..<range.lowerBound]
+            if !lead.isEmpty && !lead.contains(" ") {
+                text = String(text[range.upperBound...])
+            }
+        }
+        while text.hasSuffix("..") {
+            text.removeLast()
+        }
+        return text
     }
 }

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/AuthServiceTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/AuthServiceTests.swift
@@ -120,6 +120,49 @@ final class AuthServiceTests: XCTestCase {
         }
     }
 
+    func testLambdaTriggerRejectionStripsWrapperAndDoubledPeriod() async throws {
+        let errorType = "com.amazonaws.cognito.identity.model#UserLambdaValidationException"
+        let wrapped = "PreTokenGeneration failed with error This account requires "
+            + "multi-factor authentication. Enroll an authenticator app under Security.."
+        let body = "{\"__type\":\"\(errorType)\",\"message\":\"\(wrapped)\"}"
+        let http = RecordingHTTPTransport(responses: [(Data(body.utf8), 400)])
+        let service = CognitoAuthService(
+            configuration: makeConfiguration(),
+            transport: http,
+            secureStore: InMemorySecureStore()
+        )
+        do {
+            _ = try await service.signIn(username: "alice", password: "hunter2")
+            XCTFail("Expected a server error")
+        } catch let error as CabalmailError {
+            XCTAssertEqual(error, .server(
+                code: "UserLambdaValidationException",
+                message: "This account requires multi-factor authentication. "
+                    + "Enroll an authenticator app under Security."
+            ))
+        }
+    }
+
+    func testStripLambdaTriggerWrapperLeavesOrdinaryMessagesAlone() {
+        // No wrapper at all.
+        XCTAssertEqual(
+            CognitoAuthService.stripLambdaTriggerWrapper(from: "Invitation code required"),
+            "Invitation code required"
+        )
+        // A mid-sentence occurrence (the lead-in contains spaces) is a
+        // real message, not Cognito's wrapper.
+        XCTAssertEqual(
+            CognitoAuthService.stripLambdaTriggerWrapper(from: "The last attempt failed with error 42"),
+            "The last attempt failed with error 42"
+        )
+        // A trigger message with a single terminal period keeps it.
+        let singlePeriod = "PreSignUp_SignUp failed with error Signups are closed."
+        XCTAssertEqual(
+            CognitoAuthService.stripLambdaTriggerWrapper(from: singlePeriod),
+            "Signups are closed."
+        )
+    }
+
     func testSignOutClearsStore() async throws {
         let authResult = """
         {"AuthenticationResult":{"IdToken":"I","AccessToken":"A","RefreshToken":"R","ExpiresIn":3600}}

--- a/changelog.d/mfa-block-error-copy-apple.fixed.md
+++ b/changelog.d/mfa-block-error-copy-apple.fixed.md
@@ -1,0 +1,7 @@
+- Apple: **Readable message when the MFA gate blocks sign-in.** A
+  sign-in rejected by the server's MFA-enrollment gate surfaced the raw
+  Cognito wrapper ("Server error: PreTokenGeneration failed with error
+  …", doubled period included). CabalmailKit now strips Cognito's
+  Lambda-trigger wrapper from such rejections and the sign-in screen
+  shows the trigger's own message verbatim, without the "Server
+  error:" prefix.


### PR DESCRIPTION
## What was wrong

When the `require_admin_mfa` gate rejects a sign-in (or token refresh), the Apple clients showed the raw Cognito wrapper on the sign-in screen: `Server error: PreTokenGeneration failed with error This account requires multi-factor authentication. …Security..` — leaking the Lambda trigger name and rendering a doubled terminal period (#769).

## Root cause

Cognito reports any Lambda-trigger rejection as a `UserLambdaValidationException` whose message is `"<TriggerName> failed with error <trigger message>."` — and Cognito appends its own period even when the trigger's message already ends with one. `CognitoAuthService` passed that message through as `.server(code:message:)`, and `AppState` renders `.server` with a generic `Server error:` prefix.

## The fix

- `CognitoAuthService` now strips the trigger wrapper from `UserLambdaValidationException` messages (`stripLambdaTriggerWrapper`): the `"<TriggerName> failed with error "` lead-in is removed only when the lead-in is a bare trigger name (no spaces), and a doubled terminal period is collapsed. Applies to all trigger rejections (require_admin_mfa, check_invite, …), whose messages are written to be user-facing.
- `AppState` shows the cleaned message verbatim for that error code — no `Server error:` prefix — mirroring the existing `.maintenance` precedent.

Scoped to the reported presentation problem: the lockout itself is #768 (PR #772 adds the self-service enrollment path and rewrites the gate's copy to point at the web app instead of the unreachable Security screen), and the lower-priority silent-signout-on-cold-launch observation in #769's body is **not** addressed here — it is a different surface (no message at all rather than a bad one).

## Test evidence

- `swift test` (apple/CabalmailKit) — 364 tests pass. New: `testLambdaTriggerRejectionStripsWrapperAndDoubledPeriod` (end-to-end through the fake transport with the exact stage message shape) and `testStripLambdaTriggerWrapperLeavesOrdinaryMessagesAlone` (no-wrapper, mid-sentence "failed with error", single-period cases). **Fails-before verified** (compile-level plus behavior: the wrapper previously passed through untouched).
- CabalmailMac XCTest suite (`xcodebuild test`, per CLAUDE.md) — 35 tests pass; compiles the `AppState` change for macOS.
- `swiftlint` from `apple/` — zero warnings/errors (the helper lives in an extension to respect the actor's `type_body_length` cap).
- **Live repro on the iPhone 17 sim against stage** (gate currently enforcing): before = the raw `Server error: PreTokenGeneration …` banner from the issue; after = "This account requires multi-factor authentication. Ask the operator to re-enable access, then enroll an authenticator app under Security." — wrapper gone, prefix gone, single period. (Copy itself becomes web-app-directed once #772's gate message deploys.) Tester's sim build restored after the check.
- The `AppState` presentation line has no direct unit test: `message(for:)`/`cannedMessage(for:)` are private presentation helpers with no existing test seam; content correctness is pinned by the Kit tests and the live repro above.

Addresses #769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)