### PR TITLE
Replumb IMAP-consuming Lambdas onto the private interface

### DIFF
--- a/.github/scripts/build-api-one.sh
+++ b/.github/scripts/build-api-one.sh
@@ -69,6 +69,12 @@ fi
 if grep -qE '^[[:space:]]*(from|import)[[:space:]]+admin_limits' function.py 2>/dev/null; then
   cp ../_shared/admin_limits.py ./build/admin_limits.py
 fi
+# process_dmarc imports imap_session directly (login-only dmarc-user dial,
+# no helper.py); ship it plus its imap_pool dependency for any such handler.
+if grep -qE '^[[:space:]]*(from|import)[[:space:]]+imap_session' function.py 2>/dev/null; then
+  cp ../_shared/imap_session.py ./build/imap_session.py
+  cp ../_shared/imap_pool.py ./build/imap_pool.py
+fi
 # fetch_bimi rasterizes BIMI SVG logos to PNG with a bundled static resvg
 # binary (fetched + sha256-verified at build time, not committed). It ships
 # at the zip root so the handler can exec /var/task/resvg. resvg only has a

--- a/changelog.d/private-imap-replumb.changed.md
+++ b/changelog.d/private-imap-replumb.changed.md
@@ -1,0 +1,7 @@
+- **API Lambdas reach IMAP privately.** The IMAP-consuming Lambdas (every
+  API endpoint plus append_sent and process_dmarc) now run inside the VPC
+  and dial the imap container directly over its Cloud Map name - STARTTLS
+  on 143, verifying the tier certificate end-to-end - instead of the
+  public IMAPS listener. New S3 and DynamoDB gateway endpoints keep the
+  message cache and address-table traffic off the NAT path. First step
+  toward closing public IMAP access entirely.

--- a/lambda/api/_shared/imap_session.py
+++ b/lambda/api/_shared/imap_session.py
@@ -20,8 +20,18 @@ only the on/off flag has to be wired through Terraform.'''
 import os
 import time
 from imapclient import IMAPClient, SocketTimeout  # pylint: disable=import-error
+from imapclient import imap4  # pylint: disable=import-error
 from imapclient.exceptions import IMAPClientError  # pylint: disable=import-error
 from imap_pool import ImapConnectionPool  # pylint: disable=import-error
+
+# Private-IMAP replumb: Cloud Map name of the imap task (imap.cabal.internal),
+# set by Terraform on every IMAP-consuming function now that they run inside
+# the VPC. When present, connections dial it on 143 and upgrade with STARTTLS
+# instead of using the public NLB's IMAPS listener (993), which is slated for
+# removal. Unset (e.g. local `python -m function` runs), the public path is
+# byte-for-byte what it always was.
+INTERNAL_HOST = os.environ.get('IMAP_INTERNAL_HOST', '')
+INTERNAL_PORT = 143
 
 POOL_ENABLED = os.environ.get('IMAP_POOL_ENABLED', 'false').lower() == 'true'
 POOL_MAX_SIZE = int(os.environ.get('IMAP_POOL_MAX_SIZE', '8'))
@@ -33,9 +43,52 @@ POOL_SOCKET_TIMEOUT = SocketTimeout(connect=10, read=27)
 _imap_pool = ImapConnectionPool(POOL_MAX_SIZE, POOL_IDLE_SECONDS, time.monotonic)
 
 
+class _InternalRouteImapClient(IMAPClient):  # pylint: disable=too-few-public-methods
+    '''IMAPClient whose TCP connection goes to the Cloud Map internal name
+    while TLS verification keeps using the public IMAP hostname.
+
+    The imap container serves the wildcard *.<control-domain> Let's Encrypt
+    certificate, so the STARTTLS handshake must be verified against
+    imap.<control-domain> - but that name resolves to the NLB, which is the
+    path this class exists to avoid. Overriding _create_IMAP4 splits the two
+    concerns: the socket dials INTERNAL_HOST (the task's private IP via Cloud
+    Map, no NLB), while self.host stays the public name, which starttls()
+    passes as server_hostname, so certificate verification is the real thing.
+    Dovecot's disable_plaintext_auth is satisfied because LOGIN only happens
+    after the TLS upgrade - no login_trusted_networks widening needed. Note
+    this is end-to-end TLS into Dovecot, strictly better than the public
+    path, where the NLB terminates TLS and forwards cleartext to 143.
+
+    _create_IMAP4 is internal imapclient API; imapclient is pinned (2.3.1)
+    in every consumer's requirements.txt, so it cannot drift underneath us.'''
+
+    def _create_IMAP4(self):  # pylint: disable=invalid-name
+        # Name is fixed by the parent class - this is the override point.
+        connect_timeout = getattr(self._timeout, 'connect', None)
+        return imap4.IMAP4WithTimeout(INTERNAL_HOST, self.port, connect_timeout)
+
+
+def dial_imap(host, timeout=None):
+    '''Returns a connected (not yet authenticated) IMAPClient.
+
+    Internal path (IMAP_INTERNAL_HOST set): plain TCP to the Cloud Map name
+    on 143, upgraded with STARTTLS before any credentials are sent.
+    Public path (unset): implicit TLS to host:993 via the NLB listener.
+
+    Public because process_dmarc dials its own (login-only, dmarc-user)
+    session rather than going through open_imap_client's login+select.'''
+    if INTERNAL_HOST:
+        client = _InternalRouteImapClient(
+            host=host, port=INTERNAL_PORT, use_uid=True, ssl=False,
+            timeout=timeout)
+        client.starttls()
+        return client
+    return IMAPClient(host=host, use_uid=True, ssl=True, timeout=timeout)
+
+
 def _new_imap_client(host, user, mpw, timeout=None):
     '''Connects and authenticates a fresh master-user IMAP session.'''
-    client = IMAPClient(host=host, use_uid=True, ssl=True, timeout=timeout)
+    client = dial_imap(host, timeout)
     client.login(f"{user}*admin", mpw)
     return client
 
@@ -114,8 +167,7 @@ def open_imap_client(host, user, folder, read_only, mpw):
     warm invocation. Callers reach this through helper.get_imap_client, which
     applies the maintenance gate first.'''
     if not POOL_ENABLED:
-        client = IMAPClient(host=host, use_uid=True, ssl=True)
-        client.login(f"{user}*admin", mpw)
+        client = _new_imap_client(host, user, mpw)
         client.select_folder(folder, read_only)
         return client
     return _get_pooled_imap_client(host, user, folder, read_only, mpw)

--- a/lambda/api/_shared/tests/test_imap_session_dial.py
+++ b/lambda/api/_shared/tests/test_imap_session_dial.py
@@ -1,0 +1,155 @@
+'''Unit tests for imap_session's connection dialing (private-IMAP replumb).
+
+There is no pytest harness in this repo, so this runs under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_imap_session_dial.py
+
+imapclient is faked in sys.modules so the module under test imports without
+third-party deps or a live IMAP server. The fakes record constructor
+arguments and method calls; the assertions pin the contract the replumb
+depends on:
+
+  - with IMAP_INTERNAL_HOST set, the TCP dial goes to the internal name on
+    143 while self.host keeps the public name (starttls() verifies the
+    server certificate against self.host, so this split is what makes the
+    wildcard *.<control-domain> cert check work on a connection to
+    imap.cabal.internal), and STARTTLS runs before any LOGIN;
+  - without it, the original implicit-TLS client is built, byte-for-byte:
+    ssl=True, no port override, no STARTTLS.
+'''
+import collections
+import importlib
+import os
+import sys
+import types
+import unittest
+
+_SHARED_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SHARED_DIR)
+
+SocketTimeout = collections.namedtuple('SocketTimeout', ['connect', 'read'])
+
+
+class FakeIMAP4WithTimeout:
+    '''Records the (address, port, timeout) the override dials.'''
+
+    def __init__(self, address, port, timeout):
+        self.address = address
+        self.port = port
+        self.timeout = timeout
+
+
+class FakeIMAPClient:
+    '''Mirrors the slice of imapclient.IMAPClient that imap_session touches:
+    the constructor stores connection parameters and immediately "connects"
+    via _create_IMAP4 (the real client does this too, which is what makes
+    the subclass override effective).'''
+
+    def __init__(self, host=None, port=None, use_uid=None, ssl=True,
+                 timeout=None):
+        self.host = host
+        self.port = port
+        self.use_uid = use_uid
+        self.ssl = ssl
+        self._timeout = timeout
+        self.calls = []
+        self._imap = self._create_IMAP4()  # pylint: disable=invalid-name
+
+    def _create_IMAP4(self):  # pylint: disable=invalid-name
+        return FakeIMAP4WithTimeout(self.host, self.port, None)
+
+    def starttls(self, ssl_context=None):
+        self.calls.append('starttls')
+
+    def login(self, user, password):
+        self.calls.append(('login', user))
+
+    def select_folder(self, folder, read_only):
+        self.calls.append(('select_folder', folder, read_only))
+
+
+def _install_fake_imapclient():
+    imapclient_mod = types.ModuleType('imapclient')
+    imapclient_mod.IMAPClient = FakeIMAPClient
+    imapclient_mod.SocketTimeout = SocketTimeout
+
+    imap4_mod = types.ModuleType('imapclient.imap4')
+    imap4_mod.IMAP4WithTimeout = FakeIMAP4WithTimeout
+    imapclient_mod.imap4 = imap4_mod
+
+    exceptions_mod = types.ModuleType('imapclient.exceptions')
+    exceptions_mod.IMAPClientError = type('IMAPClientError', (Exception,), {})
+    imapclient_mod.exceptions = exceptions_mod
+
+    sys.modules['imapclient'] = imapclient_mod
+    sys.modules['imapclient.imap4'] = imap4_mod
+    sys.modules['imapclient.exceptions'] = exceptions_mod
+
+
+def _import_imap_session(internal_host):
+    '''(Re)imports imap_session with IMAP_INTERNAL_HOST set as given -
+    the module reads the env var at import time.'''
+    if internal_host is None:
+        os.environ.pop('IMAP_INTERNAL_HOST', None)
+    else:
+        os.environ['IMAP_INTERNAL_HOST'] = internal_host
+    sys.modules.pop('imap_session', None)
+    return importlib.import_module('imap_session')
+
+
+PUBLIC_HOST = 'imap.control.example'
+INTERNAL = 'imap.cabal.internal'
+
+
+class PublicPathTest(unittest.TestCase):
+    '''IMAP_INTERNAL_HOST unset: the pre-replumb client, unchanged.'''
+
+    def setUp(self):
+        _install_fake_imapclient()
+        self.session = _import_imap_session(None)
+
+    def test_dial_is_implicit_tls_to_public_host(self):
+        client = self.session.dial_imap(PUBLIC_HOST)
+        self.assertEqual(client.host, PUBLIC_HOST)
+        self.assertTrue(client.ssl)
+        self.assertIsNone(client.port)  # imapclient's default (993 for ssl)
+        self.assertEqual(client.calls, [])  # no STARTTLS on the 993 path
+
+    def test_open_imap_client_logs_in_then_selects(self):
+        client = self.session.open_imap_client(
+            PUBLIC_HOST, 'alice', 'INBOX', False, 'mpw')
+        self.assertEqual(client.calls, [
+            ('login', 'alice*admin'),
+            ('select_folder', 'INBOX', False),
+        ])
+
+
+class InternalPathTest(unittest.TestCase):
+    '''IMAP_INTERNAL_HOST set: dial the Cloud Map name, STARTTLS first.'''
+
+    def setUp(self):
+        _install_fake_imapclient()
+        self.session = _import_imap_session(INTERNAL)
+
+    def test_tcp_goes_internal_but_host_stays_public(self):
+        client = self.session.dial_imap(PUBLIC_HOST)
+        # The socket dials the Cloud Map name on 143...
+        self.assertEqual(client._imap.address, INTERNAL)  # pylint: disable=protected-access
+        self.assertEqual(client._imap.port, 143)  # pylint: disable=protected-access
+        # ...while self.host keeps the public name starttls() verifies the
+        # certificate against.
+        self.assertEqual(client.host, PUBLIC_HOST)
+        self.assertFalse(client.ssl)
+
+    def test_starttls_runs_before_login(self):
+        client = self.session.open_imap_client(
+            PUBLIC_HOST, 'alice', 'INBOX', True, 'mpw')
+        self.assertEqual(client.calls, [
+            'starttls',
+            ('login', 'alice*admin'),
+            ('select_folder', 'INBOX', True),
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/process_dmarc/function.py
+++ b/lambda/api/process_dmarc/function.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.request
 import zipfile
 import boto3  # pylint: disable=import-error
-import imapclient  # pylint: disable=import-error
+import imap_session  # pylint: disable=import-error
 import defusedxml.ElementTree as ET  # pylint: disable=import-error
 from defusedxml.common import DefusedXmlException  # pylint: disable=import-error
 
@@ -97,10 +97,14 @@ def get_master_password():
 
 
 def get_imap_client():
-    '''Connects to IMAP as the dmarc user via master-user authentication'''
+    '''Connects to IMAP as the dmarc user via master-user authentication.
+
+    imap_session.dial_imap routes over the Cloud Map internal name when
+    IMAP_INTERNAL_HOST is set (private-IMAP replumb), falling back to the
+    public IMAPS listener when it is not.'''
     host = f'imap.{control_domain}'
     mpw = get_master_password()
-    client = imapclient.IMAPClient(host, ssl=True)
+    client = imap_session.dial_imap(host)
     client.login(f'{dmarc_user}*admin', mpw)
     return client
 

--- a/terraform/infra/.checkov.baseline
+++ b/terraform/infra/.checkov.baseline
@@ -19,7 +19,6 @@
                     "check_ids": [
                         "CKV_AWS_115",
                         "CKV_AWS_116",
-                        "CKV_AWS_117",
                         "CKV_AWS_272",
                         "CKV_AWS_50"
                     ]
@@ -55,7 +54,6 @@
                     "check_ids": [
                         "CKV_AWS_115",
                         "CKV_AWS_116",
-                        "CKV_AWS_117",
                         "CKV_AWS_272",
                         "CKV_AWS_50"
                     ]
@@ -104,7 +102,6 @@
                     "check_ids": [
                         "CKV_AWS_115",
                         "CKV_AWS_116",
-                        "CKV_AWS_117",
                         "CKV_AWS_272",
                         "CKV_AWS_50"
                     ]

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -224,6 +224,12 @@ module "admin" {
   monitoring          = var.monitoring
   imap_pool_enabled   = var.imap_pool_enabled
   access_logs_bucket  = module.s3_access_logs.bucket
+
+  # Private-IMAP replumb: the API Lambdas attach to the VPC and dial the imap
+  # task over its Cloud Map name instead of the public IMAPS listener.
+  vpc_id             = module.vpc.vpc.id
+  private_subnet_ids = module.vpc.private_subnets[*].id
+  imap_internal_host = module.ecs.imap_internal_host
 }
 
 # Creates a DynamoDB table for storing address data

--- a/terraform/infra/modules/app/append_sent.tf
+++ b/terraform/infra/modules/app/append_sent.tf
@@ -50,6 +50,8 @@ resource "aws_iam_role" "append_sent" {
 }
 
 resource "aws_iam_role_policy" "append_sent" {
+  #checkov:skip=CKV_AWS_290:the only unconstrained write actions are the EC2 ENI trio for VPC-attached Lambda networking - Lambda-managed interface ARNs only exist at runtime (mirrors AWSLambdaVPCAccessExecutionRole)
+  #checkov:skip=CKV_AWS_355:same statement - ec2:Describe* has no resource-level scoping and the ENI create/delete targets are runtime values
   name = "append_sent_policy"
   role = aws_iam_role.append_sent.id
 
@@ -88,6 +90,22 @@ resource "aws_iam_role_policy" "append_sent" {
           "logs:PutLogEvents",
         ]
         Resource = "${aws_cloudwatch_log_group.append_sent.arn}:*"
+      },
+      {
+        # iam-wildcard-ok: EC2 ENI actions for VPC-attached Lambda networking
+        # (private-IMAP replumb). Lambda-created interface ARNs only exist at
+        # runtime and Describe* has no resource-level scoping; mirrors the
+        # AWSLambdaVPCAccessExecutionRole managed policy.
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:UnassignPrivateIpAddresses",
+        ]
+        # iam-wildcard-ok: Lambda-managed ENI ARNs only exist at runtime; Describe* has no resource-level scoping
+        Resource = "*"
       }
     ]
   })
@@ -123,13 +141,20 @@ resource "aws_lambda_function" "append_sent" {
     log_group  = aws_cloudwatch_log_group.append_sent.name
   }
 
+  # Private-IMAP replumb: same VPC posture as the call-module endpoints.
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
   # helper.py derives IMAP_HOST as imap.<CONTROL_DOMAIN>; without this the
   # consumer dials the garbage name "imap." and every append fails. The
   # endpoint lambdas get this from the call module's shared environment block;
   # this function is defined outside that factory, so it must carry its own.
   environment {
     variables = {
-      CONTROL_DOMAIN = var.control_domain
+      CONTROL_DOMAIN     = var.control_domain
+      IMAP_INTERNAL_HOST = var.imap_internal_host
     }
   }
 

--- a/terraform/infra/modules/app/dmarc.tf
+++ b/terraform/infra/modules/app/dmarc.tf
@@ -127,6 +127,22 @@ resource "aws_iam_role_policy" "process_dmarc" {
           "logs:PutLogEvents"
         ]
         Resource = "${aws_cloudwatch_log_group.process_dmarc.arn}:*"
+      },
+      {
+        # iam-wildcard-ok: EC2 ENI actions for VPC-attached Lambda networking
+        # (private-IMAP replumb). Lambda-created interface ARNs only exist at
+        # runtime and Describe* has no resource-level scoping; mirrors the
+        # AWSLambdaVPCAccessExecutionRole managed policy.
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:UnassignPrivateIpAddresses",
+        ]
+        # iam-wildcard-ok: Lambda-managed ENI ARNs only exist at runtime; Describe* has no resource-level scoping
+        Resource = "*"
       }
     ]
   })
@@ -162,9 +178,16 @@ resource "aws_lambda_function" "process_dmarc" {
     log_group  = aws_cloudwatch_log_group.process_dmarc.name
   }
 
+  # Private-IMAP replumb: same VPC posture as the call-module endpoints.
+  vpc_config {
+    subnet_ids         = var.private_subnet_ids
+    security_group_ids = [aws_security_group.lambda.id]
+  }
+
   environment {
     variables = {
       CONTROL_DOMAIN         = var.control_domain
+      IMAP_INTERNAL_HOST     = var.imap_internal_host
       DMARC_TABLE_NAME       = aws_dynamodb_table.dmarc_reports.name
       CAA_TABLE_NAME         = aws_dynamodb_table.caa_reports.name
       DMARC_USER             = "dmarc"

--- a/terraform/infra/modules/app/main.tf
+++ b/terraform/infra/modules/app/main.tf
@@ -56,6 +56,13 @@ module "cabal_method" {
   # cardinality (large-mailbox hardening plan, Layer 4.3).
   alarm_on_latency  = contains(["list_messages", "list_envelopes"], each.key)
   imap_pool_enabled = var.imap_pool_enabled
+
+  # Private-IMAP replumb: every endpoint runs inside the VPC (uniform posture;
+  # the DynamoDB-only functions ride along) and IMAP consumers dial the imap
+  # task via Cloud Map instead of the public IMAPS listener.
+  subnet_ids         = var.private_subnet_ids
+  security_group_ids = [aws_security_group.lambda.id]
+  imap_internal_host = var.imap_internal_host
   # fetch_bimi bundles a static resvg binary that ships only for linux-x86_64,
   # so it runs x86_64 while the rest of the API fleet stays arm64.
   architecture = each.key == "fetch_bimi" ? "x86_64" : "arm64"

--- a/terraform/infra/modules/app/modules/call/lambda.tf
+++ b/terraform/infra/modules/app/modules/call/lambda.tf
@@ -44,10 +44,15 @@ ROLEPOLICY
 resource "aws_iam_role_policy" "lambda" {
   name = "${var.name}_policy"
   role = aws_iam_role.lambda.id
-  # iam-wildcard-ok: heredoc JSON cannot carry inline comments, so this
-  # directive covers both wildcards in the document below - S3 object keys
-  # under the per-user cache prefix and log-stream names are runtime values
-  # with no enumerable ARN. Every other statement names specific resources.
+  # Heredoc JSON cannot carry inline comments, so one directive covers every
+  # wildcard in the document below: S3 object keys under the per-user cache
+  # prefix and log-stream names are runtime values with no enumerable ARN,
+  # and the EC2 ENI actions (VPC-attached Lambda networking) manage
+  # Lambda-created interfaces whose ARNs likewise only exist at runtime,
+  # with no resource-level scoping on Describe* at all (the statement
+  # mirrors the AWSLambdaVPCAccessExecutionRole managed policy). Every
+  # other statement names specific resources.
+  # iam-wildcard-ok: runtime-only ARNs (cache object keys, log streams, Lambda-managed ENIs) - see above
   policy = <<RUNPOLICY
 {
     "Version": "2012-10-17",
@@ -159,6 +164,17 @@ resource "aws_iam_role_policy" "lambda" {
         {
             "Effect": "Allow",
             "Action": [
+                "ec2:CreateNetworkInterface",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DeleteNetworkInterface",
+                "ec2:AssignPrivateIpAddresses",
+                "ec2:UnassignPrivateIpAddresses"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
                 "cognito-idp:ListUsers",
                 "cognito-idp:AdminGetUser",
                 "cognito-idp:AdminConfirmSignUp",
@@ -198,6 +214,15 @@ resource "aws_lambda_function" "api_call" {
   # on invisibly past it (and a real timeout becomes an alarmable signal).
   timeout     = 29
   memory_size = var.memory
+
+  # Private-IMAP replumb: run inside the VPC so IMAP consumers can reach the
+  # imap task over its Cloud Map name. AWS-API and internet egress rides the
+  # NAT path plus the S3/DynamoDB gateway endpoints (modules/vpc/endpoints.tf).
+  vpc_config {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
+  }
+
   logging_config {
     log_format = "Text"
     log_group  = aws_cloudwatch_log_group.lambda_log.name
@@ -213,6 +238,7 @@ resource "aws_lambda_function" "api_call" {
       USER_PREFERENCES_TABLE_NAME = "cabal-user-preferences"
       PUSH_TOKENS_TABLE_NAME      = "cabal-push-tokens"
       IMAP_POOL_ENABLED           = var.imap_pool_enabled ? "true" : "false"
+      IMAP_INTERNAL_HOST          = var.imap_internal_host
     }
   }
   depends_on = [

--- a/terraform/infra/modules/app/modules/call/variables.tf
+++ b/terraform/infra/modules/app/modules/call/variables.tf
@@ -79,3 +79,17 @@ variable "architecture" {
     error_message = "architecture must be arm64 or x86_64."
   }
 }
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the function's vpc_config (private-IMAP replumb)."
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "Security group IDs for the function's vpc_config (the app module's shared Lambda group)."
+}
+
+variable "imap_internal_host" {
+  type        = string
+  description = "Cloud Map DNS name of the imap task. When set, imap_session dials it on 143 + STARTTLS instead of the public IMAPS listener."
+}

--- a/terraform/infra/modules/app/network.tf
+++ b/terraform/infra/modules/app/network.tf
@@ -1,0 +1,35 @@
+/**
+* Shared security group for the VPC-attached API Lambdas.
+*
+* The Lambdas moved inside the VPC so they can reach the imap container
+* over the Cloud Map internal name (143 + STARTTLS) instead of the
+* public IMAPS listener - the prerequisite for closing public IMAP
+* access entirely. One group serves every function the call module
+* stamps out plus append_sent and process_dmarc: they share an identical
+* network posture (originate-only), so per-function groups would add
+* drift surface without adding isolation.
+*
+* No ingress: nothing dials a Lambda. Egress stays open because the
+* functions collectively need SSM, Cognito, SNS, SQS, Route 53, S3,
+* DynamoDB, external DNS/HTTPS (fetch_bimi), SMTP submission (send),
+* and IMAP - an allowlist here would just restate "most of the
+* internet" and break quietly on the next endpoint.
+*/
+
+resource "aws_security_group" "lambda" {
+  name        = "cabal-lambda-api-sg"
+  description = "API Lambda functions (VPC-attached for private IMAP access)"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "lambda_egress" {
+  #checkov:skip=CKV_AWS_382:originate-only functions collectively need SSM, Cognito, SNS, SQS, Route 53, external DNS/HTTPS, SMTP, and IMAP; a port allowlist would restate most of the internet (matches the mail-tier egress posture)
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sgr
+  ipv6_cidr_blocks  = ["::/0"]      #tfsec:ignore:aws-vpc-no-public-egress-sgr
+  description       = "Allow all outgoing"
+  security_group_id = aws_security_group.lambda.id
+}

--- a/terraform/infra/modules/app/variables.tf
+++ b/terraform/infra/modules/app/variables.tf
@@ -145,3 +145,18 @@ variable "push_queue_arn" {
   type        = string
   description = "ARN of the push wake-signal SQS queue (modules/ecs). Event source for the push_dispatch Lambda."
 }
+
+variable "vpc_id" {
+  type        = string
+  description = "ID of the VPC the API Lambdas attach to (private-IMAP replumb). Owns the Lambda security group."
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs the API Lambdas attach to. Egress to AWS APIs and the internet rides the NAT path plus the S3/DynamoDB gateway endpoints."
+}
+
+variable "imap_internal_host" {
+  type        = string
+  description = "Cloud Map DNS name of the imap task (modules/ecs service discovery). IMAP-consuming Lambdas dial this on 143 + STARTTLS instead of the public IMAPS listener."
+}

--- a/terraform/infra/modules/ecs/outputs.tf
+++ b/terraform/infra/modules/ecs/outputs.tf
@@ -64,3 +64,10 @@ output "tier_log_group_names" {
   value       = { for k, v in aws_cloudwatch_log_group.tier : k => v.name }
   description = "Map of mail-tier CloudWatch log group names keyed by tier (imap | smtp-in | smtp-out). Phase 4 section 2 metric filters target these."
 }
+
+output "imap_internal_host" {
+  # Composed from the service_discovery.tf locals rather than the resource
+  # attributes - see the comment there (checkov graph workaround).
+  value       = "${local.sd_imap_service_name}.${local.sd_namespace_name}"
+  description = "Cloud Map DNS name that resolves to the imap task's private IP directly (no NLB). VPC-attached Lambdas dial this on 143 + STARTTLS instead of the public IMAPS listener."
+}

--- a/terraform/infra/modules/ecs/service_discovery.tf
+++ b/terraform/infra/modules/ecs/service_discovery.tf
@@ -11,14 +11,24 @@
 * through the NLB.
 */
 
+# Name literals live in locals so outputs.tf can compose the imap
+# internal hostname without referencing these resources: checkov's graph
+# renderer chokes on an output edge into this file's lifecycle wiring
+# (replace_triggered_by below) and then stops evaluating count
+# expressions module-wide, resurrecting count=0 resources as findings.
+locals {
+  sd_namespace_name    = "cabal.internal"
+  sd_imap_service_name = "imap"
+}
+
 resource "aws_service_discovery_private_dns_namespace" "mail" {
-  name        = "cabal.internal"
+  name        = local.sd_namespace_name
   description = "Internal service discovery for ECS mail tiers"
   vpc         = var.vpc_id
 }
 
 resource "aws_service_discovery_service" "imap" {
-  name = "imap"
+  name = local.sd_imap_service_name
 
   dns_config {
     namespace_id = aws_service_discovery_private_dns_namespace.mail.id

--- a/terraform/infra/modules/vpc/endpoints.tf
+++ b/terraform/infra/modules/vpc/endpoints.tf
@@ -1,0 +1,43 @@
+/**
+* Gateway VPC endpoints for S3 and DynamoDB.
+*
+* Gateway endpoints are free and add a route-table entry that keeps
+* traffic to these services on the AWS network instead of the NAT
+* path. The API Lambdas run inside the VPC (private-IMAP replumb), so
+* without these their fattest flows - the S3 message cache and the
+* DynamoDB address tables - would all transit the NAT instance. The
+* endpoints also serve the mail-tier containers (generate-config.sh
+* scans DynamoDB; message delivery reads S3), which previously egressed
+* through NAT for the same calls.
+*
+* Attached to every route table: private (Lambdas, ECS tasks) and
+* public. Interface endpoints for the remaining services (SSM, SNS,
+* SQS, Cognito) are deliberately NOT provisioned - they carry an hourly
+* charge per AZ, and those calls are thin enough to ride the NAT path.
+*/
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.network.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = concat(
+    aws_route_table.private[*].id,
+    [aws_route_table.public.id],
+  )
+  tags = {
+    Name = "cabal-s3-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id            = aws_vpc.network.id
+  service_name      = "com.amazonaws.${var.region}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids = concat(
+    aws_route_table.private[*].id,
+    [aws_route_table.public.id],
+  )
+  tags = {
+    Name = "cabal-dynamodb-endpoint"
+  }
+}


### PR DESCRIPTION
## Summary

First phase of deprecating public IMAP access (announced in cb1bcdfa): before the public 993 listener can be removed, the Lambdas that consume IMAP must stop using it. This PR moves them onto a private path; removing the listener is a deliberate later phase.

**Lambda code (`_shared/imap_session.py`)**
- New env var `IMAP_INTERNAL_HOST` (the ecs module's Cloud Map name, `imap.cabal.internal`). When set, connections dial it directly on 143 and upgrade with STARTTLS before any credentials are sent; when unset, the public implicit-TLS 993 path is byte-for-byte unchanged (so local `python -m function` runs and any deploy-ordering race keep working).
- `_InternalRouteImapClient` splits TCP dialing from TLS verification: the socket goes to the Cloud Map name (task private IP, no NLB), while `self.host` keeps the public hostname that `starttls()` passes as `server_hostname` - so the wildcard `*.<control_domain>` certificate check is the real thing. This satisfies Dovecot's `disable_plaintext_auth` without widening `login_trusted_networks`, and makes the Lambda→Dovecot leg encrypted end-to-end (the public path terminates TLS at the NLB and forwards cleartext).
- `process_dmarc` had its own hand-rolled `IMAPClient`; it now uses the shared dial (`imap_session.dial_imap`), and `build-api-one.sh` learns to bundle `imap_session`/`imap_pool` for handlers that import `imap_session` directly.

**Terraform**
- `vpc_config` (private subnets + a shared originate-only security group) on the call-module fleet, `append_sent`, and `process_dmarc`; ENI permissions on their roles (mirroring `AWSLambdaVPCAccessExecutionRole`).
- Free S3 + DynamoDB **gateway endpoints** on all route tables, keeping the message cache and address-table traffic off the NAT instance (which the mail-tier containers also benefit from).
- `imap_internal_host` output from the ecs module, wired root → app → call.
- No new imap-side SG rule needed: the tier SG already allows 143 from anywhere.

## Notes / trade-offs

- **NAT is now an availability dependency of the API**: SSM (master password on cold start), Cognito, SNS/SQS, Route 53, and fetch_bimi's outbound DNS/HTTPS ride the NAT path. Discussed and accepted; the gateway endpoints take the fat flows off it, and NAT Gateway mode remains the managed upgrade path.
- `send`'s SMTP leg now egresses via NAT to the public submission listener - unchanged semantics, and SMTP stays public regardless.
- **Checkov quirk**: an ecs-module *output* referencing the service-discovery resources makes checkov's graph renderer resurrect count=0 resources (sinkhole) as new findings. The service/namespace names moved into locals and the output composes from those; comment in `service_discovery.tf` explains it.
- Baseline: `CKV_AWS_117` (Lambda-in-VPC) entries for the three affected functions are now fixed and removed from `.checkov.baseline`.

## Verification

- `terraform validate` + `fmt -check`: clean
- checkov 3.2.530 (CI pin) with repo config + baseline: no new findings; `baseline-diff.py`: no stale entries
- tflint v0.63.1 (CI pin) recursive: clean; trivy with `.trivyignore`: clean
- `check-iam-resource-scope.py` + `check-suppression-justifications.sh`: clean
- pylint sweep (CLAUDE.md invocation): 10.00/10
- New stdlib tests `lambda/api/_shared/tests/test_imap_session_dial.py` (4 passing) pin the dial contract: internal TCP target + public verification host + STARTTLS-before-LOGIN, and the unchanged public path.

## Post-merge validation on stage

1. Exercise the API (list folders/messages, fetch, move, send, save draft) from a client.
2. `process_dmarc` scheduled run and an `append_sent` job complete (check `/cabal/lambda/*` log groups).
3. Confirm IMAP connections now arrive from Lambda ENIs (Dovecot logs show private-subnet IPs on 143 with TLS).
4. Watch cold-start latency for regressions (SSM via NAT).

Once stage soaks clean, the follow-up phase removes the public 993 listener and the `_imaps` SRV record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)