### PR TITLE
Cut send Lambda's SMTP submission over to the private interface

### DIFF
--- a/.github/scripts/build-api-one.sh
+++ b/.github/scripts/build-api-one.sh
@@ -75,6 +75,10 @@ if grep -qE '^[[:space:]]*(from|import)[[:space:]]+imap_session' function.py 2>/
   cp ../_shared/imap_session.py ./build/imap_session.py
   cp ../_shared/imap_pool.py ./build/imap_pool.py
 fi
+# send imports smtp_session (private-submission dial); stdlib-only module.
+if grep -qE '^[[:space:]]*(from|import)[[:space:]]+smtp_session' function.py 2>/dev/null; then
+  cp ../_shared/smtp_session.py ./build/smtp_session.py
+fi
 # fetch_bimi rasterizes BIMI SVG logos to PNG with a bundled static resvg
 # binary (fetched + sha256-verified at build time, not committed). It ships
 # at the zip root so the handler can exec /var/task/resvg. resvg only has a

--- a/changelog.d/smtp-submission-cutover.changed.md
+++ b/changelog.d/smtp-submission-cutover.changed.md
@@ -1,0 +1,7 @@
+- **The send Lambda submits mail privately.** Outbound submission from
+  /send now dials the smtp-out task directly over its new Cloud Map name
+  (TLS on 465, verified against the tier certificate) instead of
+  hairpinning through NAT to the public submission listener, with an
+  automatic fallback to the public path if the internal name does not
+  answer. Public submission (465/587) itself is unchanged and remains
+  open to standard mail clients.

--- a/lambda/api/_shared/smtp_session.py
+++ b/lambda/api/_shared/smtp_session.py
@@ -1,0 +1,62 @@
+'''SMTP connection dialing for the Lambda API (private-submission cutover).
+
+The SMTP counterpart of imap_session's dual-path dial. When
+SMTP_INTERNAL_HOST is set (the smtp-out task's Cloud Map name), the TCP
+connection goes there directly - no NLB, no NAT hairpin - while TLS
+verification keeps using the public submission hostname, because the
+container serves the wildcard *.<control-domain> certificate. The split
+lives in _get_socket: smtplib's SMTP_SSL wraps the socket with
+server_hostname=self._host (the constructor's host argument, which
+connect() never overwrites), so overriding only the TCP destination
+leaves the certificate check real and unchanged.
+
+Unlike the IMAP path, this dial FALLS BACK to the public listener when
+the internal name does not resolve or refuses the connection. Cloud Map
+registration happens at task START, so there is a window after the
+first apply (and during any Cloud Map blip - the smtp tiers pin the
+imap name in /etc/hosts for the same reason) where the name is empty;
+/send is user-facing and SMTP-first, and the public listener is open
+anyway, so failing the send to make a plumbing point would be pure
+cost. The fallback prints a line so chronic use shows up in CloudWatch.
+'''
+import os
+import smtplib
+import ssl
+
+INTERNAL_HOST = os.environ.get('SMTP_INTERNAL_HOST', '')
+
+
+class _InternalRouteSMTPSSL(smtplib.SMTP_SSL):  # pylint: disable=too-few-public-methods
+    '''SMTP_SSL whose TCP connection goes to the Cloud Map internal name
+    while self._host (used for the TLS server_hostname) stays public.'''
+
+    def _get_socket(self, host, port, timeout):
+        # host arrives as the public name the constructor was given;
+        # dial the internal name instead. The parent wraps the socket
+        # with server_hostname=self._host, so verification still runs
+        # against the public name the wildcard certificate carries.
+        return super()._get_socket(INTERNAL_HOST, port, timeout)
+
+
+def dial_smtp(host):
+    '''Returns a connected smtplib.SMTP_SSL client.
+
+    Internal path (SMTP_INTERNAL_HOST set): TCP to the Cloud Map name on
+    465, TLS verified against `host`. Public path (unset, or internal
+    dial fails): implicit TLS to host:465 via the NLB listener,
+    byte-for-byte the original behavior.'''
+    if INTERNAL_HOST:
+        try:
+            return _InternalRouteSMTPSSL(host)
+        except ssl.SSLError:
+            # SSLError subclasses OSError, so it must be re-raised before
+            # the fallback clause: a certificate failure on the internal
+            # path would fail on the public path too, and must surface,
+            # not be quietly retried against a different socket.
+            raise
+        except OSError as err:
+            # socket.gaierror (name not yet registered - Cloud Map
+            # registers at task START) and connection refusals/timeouts.
+            print(f'[smtp-session] internal dial to {INTERNAL_HOST} failed'
+                  f' ({err}); falling back to public {host}')
+    return smtplib.SMTP_SSL(host)

--- a/lambda/api/_shared/tests/test_smtp_session_dial.py
+++ b/lambda/api/_shared/tests/test_smtp_session_dial.py
@@ -1,0 +1,137 @@
+'''Unit tests for smtp_session's connection dialing (private-submission
+cutover).
+
+There is no pytest harness in this repo, so this runs under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_smtp_session_dial.py
+
+smtp_session is stdlib-only, so the module imports for real; the tests
+patch smtplib internals at the class level so nothing dials a network.
+The assertions pin the contract the cutover depends on:
+
+  - with SMTP_INTERNAL_HOST set, the TCP dial goes to the internal name
+    while self._host keeps the public name (which SMTP_SSL passes as
+    server_hostname, so the wildcard-certificate check is unchanged);
+  - a failed internal dial (gaierror et al.) falls back to the public
+    listener, but an ssl.SSLError - despite subclassing OSError - does
+    NOT fall back;
+  - with the env var unset, a plain smtplib.SMTP_SSL(host) is built.
+'''
+import importlib
+import os
+import smtplib
+import socket
+import ssl
+import sys
+import unittest
+
+_SHARED_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SHARED_DIR)
+
+PUBLIC_HOST = 'smtp-out.control.example'
+INTERNAL = 'smtp-out.cabal.internal'
+
+
+def _import_smtp_session(internal_host):
+    '''(Re)imports smtp_session with SMTP_INTERNAL_HOST set as given -
+    the module reads the env var at import time.'''
+    if internal_host is None:
+        os.environ.pop('SMTP_INTERNAL_HOST', None)
+    else:
+        os.environ['SMTP_INTERNAL_HOST'] = internal_host
+    sys.modules.pop('smtp_session', None)
+    return importlib.import_module('smtp_session')
+
+
+class _RecordingConnects(unittest.TestCase):
+    '''Base: patches smtplib.SMTP.connect to record its host argument and
+    skip the network. connect() is what __init__ calls, and it is also the
+    only caller of _get_socket, so recording here captures the TCP target
+    each dial variant would use.'''
+
+    def setUp(self):
+        self.connects = []
+        tests = self
+
+        def fake_connect(client, host='localhost', port=0, source_address=None):
+            del source_address
+            tests.connects.append((client, host, port))
+            return (220, b'ok')
+
+        self._orig_connect = smtplib.SMTP.connect
+        smtplib.SMTP.connect = fake_connect
+        self.addCleanup(setattr, smtplib.SMTP, 'connect', self._orig_connect)
+
+
+class PublicPathTest(_RecordingConnects):
+
+    def setUp(self):
+        super().setUp()
+        self.session = _import_smtp_session(None)
+
+    def test_plain_smtp_ssl_to_public_host(self):
+        client = self.session.dial_smtp(PUBLIC_HOST)
+        self.assertIs(type(client), smtplib.SMTP_SSL)
+        self.assertEqual(self.connects[-1][1], PUBLIC_HOST)
+
+
+class InternalPathTest(_RecordingConnects):
+
+    def setUp(self):
+        super().setUp()
+        self.session = _import_smtp_session(INTERNAL)
+
+    def test_host_stays_public_for_tls_verification(self):
+        client = self.session.dial_smtp(PUBLIC_HOST)
+        # smtplib.SMTP.__init__ stores the constructor host in _host and
+        # SMTP_SSL wraps sockets with server_hostname=self._host; the
+        # public name there is what keeps certificate verification real.
+        self.assertEqual(client._host, PUBLIC_HOST)  # pylint: disable=protected-access
+
+    def test_socket_override_dials_internal_name(self):
+        client = self.session.dial_smtp(PUBLIC_HOST)
+        wrapped = []
+
+        def fake_parent_get_socket(instance, host, port, timeout):
+            del instance, timeout
+            wrapped.append((host, port))
+            return 'sentinel-socket'
+
+        orig = smtplib.SMTP_SSL._get_socket
+        smtplib.SMTP_SSL._get_socket = fake_parent_get_socket
+        try:
+            result = client._get_socket(PUBLIC_HOST, 465, None)  # pylint: disable=protected-access
+        finally:
+            smtplib.SMTP_SSL._get_socket = orig
+        # The override swaps the public name for the internal one before
+        # delegating to the parent (which does the TLS wrap).
+        self.assertEqual(result, 'sentinel-socket')
+        self.assertEqual(wrapped, [(INTERNAL, 465)])
+
+    def test_gaierror_falls_back_to_public(self):
+        def failing_connect(client, host='localhost', port=0,
+                            source_address=None):
+            del source_address
+            if isinstance(client, self.session._InternalRouteSMTPSSL):  # pylint: disable=protected-access
+                raise socket.gaierror(8, 'name not yet registered')
+            self.connects.append((client, host, port))
+            return (220, b'ok')
+
+        smtplib.SMTP.connect = failing_connect
+        client = self.session.dial_smtp(PUBLIC_HOST)
+        self.assertIs(type(client), smtplib.SMTP_SSL)
+        self.assertEqual(self.connects[-1][1], PUBLIC_HOST)
+
+    def test_ssl_error_does_not_fall_back(self):
+        def failing_connect(client, host='localhost', port=0,
+                            source_address=None):
+            del client, host, port, source_address
+            raise ssl.SSLError('certificate verify failed')
+
+        smtplib.SMTP.connect = failing_connect
+        with self.assertRaises(ssl.SSLError):
+            self.session.dial_smtp(PUBLIC_HOST)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/send/function.py
+++ b/lambda/api/send/function.py
@@ -21,6 +21,7 @@ from helper import parse_json_body # pylint: disable=import-error
 from helper import upload_object # pylint: disable=import-error
 from helper import validate_uid # pylint: disable=import-error
 from helper import CACHE_BUCKET, SMTP_HOST # pylint: disable=import-error
+import smtp_session # pylint: disable=import-error
 from helper import MaintenanceError, maintenance_response # pylint: disable=import-error
 
 # Sending is SMTP-first: outbound delivery never blocks on IMAP. The Bcc-free
@@ -257,7 +258,10 @@ def send(msg, smtp_host, from_addr, to_addrs):
     mail or what envelope sender the relay sees. smtplib still strips Bcc from
     the transmitted DATA, so blind recipients stay blind on the wire.
     """
-    smtp_client = smtplib.SMTP_SSL(smtp_host)
+    # smtp_session routes over the Cloud Map internal name when
+    # SMTP_INTERNAL_HOST is set (private-submission cutover), falling back
+    # to the public listener when it is not set or does not answer.
+    smtp_client = smtp_session.dial_smtp(smtp_host)
     status_code = 200
     body = {
         "status": "submitted"

--- a/lambda/api/send/function.py
+++ b/lambda/api/send/function.py
@@ -21,8 +21,8 @@ from helper import parse_json_body # pylint: disable=import-error
 from helper import upload_object # pylint: disable=import-error
 from helper import validate_uid # pylint: disable=import-error
 from helper import CACHE_BUCKET, SMTP_HOST # pylint: disable=import-error
-import smtp_session # pylint: disable=import-error
 from helper import MaintenanceError, maintenance_response # pylint: disable=import-error
+import smtp_session # pylint: disable=import-error
 
 # Sending is SMTP-first: outbound delivery never blocks on IMAP. The Bcc-free
 # Sent copy is staged to S3 and queued, and the append_sent consumer Lambda

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -230,6 +230,7 @@ module "admin" {
   vpc_id             = module.vpc.vpc.id
   private_subnet_ids = module.vpc.private_subnets[*].id
   imap_internal_host = module.ecs.imap_internal_host
+  smtp_internal_host = module.ecs.smtp_internal_host
 }
 
 # Creates a DynamoDB table for storing address data

--- a/terraform/infra/modules/app/main.tf
+++ b/terraform/infra/modules/app/main.tf
@@ -63,6 +63,7 @@ module "cabal_method" {
   subnet_ids         = var.private_subnet_ids
   security_group_ids = [aws_security_group.lambda.id]
   imap_internal_host = var.imap_internal_host
+  smtp_internal_host = var.smtp_internal_host
   # fetch_bimi bundles a static resvg binary that ships only for linux-x86_64,
   # so it runs x86_64 while the rest of the API fleet stays arm64.
   architecture = each.key == "fetch_bimi" ? "x86_64" : "arm64"

--- a/terraform/infra/modules/app/modules/call/lambda.tf
+++ b/terraform/infra/modules/app/modules/call/lambda.tf
@@ -239,6 +239,7 @@ resource "aws_lambda_function" "api_call" {
       PUSH_TOKENS_TABLE_NAME      = "cabal-push-tokens"
       IMAP_POOL_ENABLED           = var.imap_pool_enabled ? "true" : "false"
       IMAP_INTERNAL_HOST          = var.imap_internal_host
+      SMTP_INTERNAL_HOST          = var.smtp_internal_host
     }
   }
   depends_on = [

--- a/terraform/infra/modules/app/modules/call/variables.tf
+++ b/terraform/infra/modules/app/modules/call/variables.tf
@@ -93,3 +93,8 @@ variable "imap_internal_host" {
   type        = string
   description = "Cloud Map DNS name of the imap task. When set, imap_session dials it on 143 + STARTTLS instead of the public IMAPS listener."
 }
+
+variable "smtp_internal_host" {
+  type        = string
+  description = "Cloud Map DNS name of the smtp-out task. When set, smtp_session dials it on 465 instead of the public submission listener."
+}

--- a/terraform/infra/modules/app/variables.tf
+++ b/terraform/infra/modules/app/variables.tf
@@ -160,3 +160,8 @@ variable "imap_internal_host" {
   type        = string
   description = "Cloud Map DNS name of the imap task (modules/ecs service discovery). IMAP-consuming Lambdas dial this on 143 + STARTTLS instead of the public IMAPS listener."
 }
+
+variable "smtp_internal_host" {
+  type        = string
+  description = "Cloud Map DNS name of the smtp-out task (modules/ecs service discovery). The send Lambda dials it on 465 instead of the public submission listener, falling back to the public path if the name does not resolve."
+}

--- a/terraform/infra/modules/ecs/outputs.tf
+++ b/terraform/infra/modules/ecs/outputs.tf
@@ -71,3 +71,10 @@ output "imap_internal_host" {
   value       = "${local.sd_imap_service_name}.${local.sd_namespace_name}"
   description = "Cloud Map DNS name that resolves to the imap task's private IP directly (no NLB). VPC-attached Lambdas dial this on 143 + STARTTLS instead of the public IMAPS listener."
 }
+
+output "smtp_internal_host" {
+  # Composed from the service_discovery.tf locals rather than the resource
+  # attributes - see the comment there (checkov graph workaround).
+  value       = "${local.sd_smtp_out_service_name}.${local.sd_namespace_name}"
+  description = "Cloud Map DNS name that resolves to the smtp-out task's private IP directly (no NLB). The send Lambda dials this on 465 instead of the public submission listener."
+}

--- a/terraform/infra/modules/ecs/service_discovery.tf
+++ b/terraform/infra/modules/ecs/service_discovery.tf
@@ -17,8 +17,9 @@
 # (replace_triggered_by below) and then stops evaluating count
 # expressions module-wide, resurrecting count=0 resources as findings.
 locals {
-  sd_namespace_name    = "cabal.internal"
-  sd_imap_service_name = "imap"
+  sd_namespace_name        = "cabal.internal"
+  sd_imap_service_name     = "imap"
+  sd_smtp_out_service_name = "smtp-out"
 }
 
 resource "aws_service_discovery_private_dns_namespace" "mail" {
@@ -129,4 +130,88 @@ resource "terraform_data" "imap_cloud_map_lifecycle" {
   }
 
   depends_on = [aws_ecs_service.imap]
+}
+
+# -- SMTP-OUT registration (private-submission cutover) ----------
+#
+# The send Lambda submits outbound mail to smtp-out. It used to dial the
+# public NLB submission listener (a NAT hairpin once the Lambdas moved
+# into the VPC); registering smtp-out in Cloud Map gives it the same
+# direct private path the imap tier already has. Everything below
+# mirrors the imap registration one-for-one - same
+# health_check_custom_config trap (see the comment on
+# aws_service_discovery_service.imap), same lifecycle bracketing.
+
+resource "aws_service_discovery_service" "smtp_out" {
+  name = local.sd_smtp_out_service_name
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.mail.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  # Same server-side FailureThreshold pinning as the imap service above;
+  # without this, every plan schedules a forced replacement.
+  lifecycle {
+    ignore_changes = [health_check_custom_config]
+  }
+}
+
+# Same bracket as terraform_data.imap_cloud_map_lifecycle (see the long
+# comment there for the destroy/create ordering rationale). The create
+# provisioner also covers FIRST registration: adding service_registries
+# to the existing smtp-out service is an in-place UpdateService, but ECS
+# only registers tasks with Cloud Map at task START - without the
+# force-new-deployment here, the Cloud Map name would resolve to nothing
+# until the next unrelated deploy. smtp-out rolls with overlap
+# (min_healthy=100), so this redeploy is not client-visible.
+resource "terraform_data" "smtp_out_cloud_map_lifecycle" {
+  triggers_replace = [
+    aws_service_discovery_service.smtp_out.id,
+    var.quiesced,
+  ]
+
+  input = {
+    cluster_name     = aws_ecs_cluster.mail.name
+    ecs_service_name = aws_ecs_service.smtp_out.name
+    region           = var.region
+    desired_count    = var.quiesced ? 0 : 1
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      set -eu
+      echo "[smtp-out-cm-lifecycle] draining ${self.input.ecs_service_name} before Cloud Map service is destroyed"
+      aws --region ${self.input.region} ecs update-service \
+        --cluster ${self.input.cluster_name} \
+        --service ${self.input.ecs_service_name} \
+        --desired-count 0 \
+        --no-cli-pager >/dev/null
+      aws --region ${self.input.region} ecs wait services-stable \
+        --cluster ${self.input.cluster_name} \
+        --services ${self.input.ecs_service_name}
+    EOT
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -eu
+      echo "[smtp-out-cm-lifecycle] restoring ${self.input.ecs_service_name} (desired=${self.input.desired_count}) and forcing redeploy"
+      aws --region ${self.input.region} ecs update-service \
+        --cluster ${self.input.cluster_name} \
+        --service ${self.input.ecs_service_name} \
+        --desired-count ${self.input.desired_count} \
+        --force-new-deployment \
+        --no-cli-pager >/dev/null
+    EOT
+  }
+
+  depends_on = [aws_ecs_service.smtp_out]
 }

--- a/terraform/infra/modules/ecs/services.tf
+++ b/terraform/infra/modules/ecs/services.tf
@@ -145,6 +145,15 @@ resource "aws_ecs_service" "smtp_out" {
     container_port   = 587
   }
 
+  # Private-submission cutover: registers the task's ENI IP at
+  # smtp-out.cabal.internal so the send Lambda can dial it directly.
+  # In-place update on this service; the terraform_data bracket in
+  # service_discovery.tf forces the redeploy that actually registers
+  # the running task.
+  service_registries {
+    registry_arn = aws_service_discovery_service.smtp_out.arn
+  }
+
   depends_on = [aws_ecs_cluster_capacity_providers.mail]
 
   # See aws_ecs_service.imap for rationale.


### PR DESCRIPTION
## Summary

Same playbook as the IMAP replumb (#774), one tier over. `/send` has been dialing the **public** NLB submission listener — a NAT hairpin ever since the Lambdas moved into the VPC. This registers smtp-out in Cloud Map and gives the send Lambda a direct private path.

**Terraform**
- `aws_service_discovery_service.smtp_out` (`smtp-out.cabal.internal`), mirroring the imap registration one-for-one: same `health_check_custom_config` pinning (the forced-replacement trap behind the 2026-05-18 outage) and the same `terraform_data` lifecycle bracket.
- `service_registries` added to the existing smtp-out ECS service. On provider v6 this is an in-place UpdateService, **but ECS only registers tasks with Cloud Map at task start** — the bracket's create-provisioner force-redeploys the service so the running task registers immediately. smtp-out rolls with overlap (min_healthy=100), so this is not client-visible. *Reviewer check: the plan should show `aws_ecs_service.smtp_out` updated in-place, not replaced.*
- `smtp_internal_host` output (composed from locals — the checkov graph workaround from #774) wired root → app → call as `SMTP_INTERNAL_HOST`.
- No SG change: the smtp-out tier already admits 465 from `0.0.0.0/0`.

**Lambda**
- New stdlib-only `_shared/smtp_session.py`: when `SMTP_INTERNAL_HOST` is set, TCP goes to the Cloud Map name on 465 while TLS verification stays pinned to the public hostname (`smtplib`'s `_get_socket` override — SMTP_SSL wraps with `server_hostname=self._host`, which `connect()` never overwrites). Same TCP/verification split as `imap_session`; auth is the master user over implicit TLS, unchanged.
- **Falls back to the public listener** when the internal name doesn't resolve or refuses (first-apply registration window, Cloud Map blips — the same failure the smtp tiers pin `/etc/hosts` against). `/send` is user-facing and the public listener stays open, so failing a send to make a plumbing point would be pure cost. `ssl.SSLError` is explicitly re-raised despite subclassing `OSError` — a certificate failure must surface, never be retried on a different socket. The fallback prints a `[smtp-session]` line so chronic use is visible in CloudWatch.
- `build-api-one.sh` bundles `smtp_session.py` for handlers that import it.

Public submission (465/587) itself is **unchanged** and remains open to standard clients — it's in the compatibility promise and the freshly-updated `mua_setup.md`. Whether it ever closes is a separate, deliberate decision; this PR just removes our own dependence on it, which is what would make that decision free.

## Verification

- New stdlib tests (`test_smtp_session_dial.py`, 5 passing): internal TCP target vs public verification host, gaierror→public fallback, SSLError does **not** fall back, and the unset-env path building a plain `SMTP_SSL(host)`.
- pylint sweep 10.00/10; terraform fmt/validate clean; checkov (CI pin) no new findings + baseline drift clean both directions; tflint (CI pin) clean; trivy clean; IAM-wildcard + suppression gates clean.

## Post-merge validation on stage

1. Watch the apply: smtp-out redeploys once (overlap) and `aws servicediscovery list-instances` shows the new task under the smtp-out service.
2. Send a test email; `/cabal/lambda/send` should show no `[smtp-session]` fallback line (a transient one during the registration window is expected and benign).
3. Confirm delivery + DKIM as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)