### PR TITLE
Fix unreachable MFA setup screen for locked-out admins

### DIFF
--- a/changelog.d/mfa-setup-logged-out-view.fixed.md
+++ b/changelog.d/mfa-setup-logged-out-view.fixed.md
@@ -1,0 +1,7 @@
+- **Unreachable MFA setup screen for locked-out admins.** The session
+  check ran on every render and bounced any logged-out view that was not
+  on its allowlist back to the login form, and `MfaSetup` was missing
+  from it — so an admin blocked by the MFA gate never saw the
+  self-service enrollment screen the gate routes them to. Reloading that
+  screen still returns to login, since the password it re-authenticates
+  with is deliberately never persisted.

--- a/react/admin/src/App.jsx
+++ b/react/admin/src/App.jsx
@@ -56,6 +56,7 @@ import useResendThrottle from './hooks/useResendThrottle';
 import './AppLight.css';
 import './AppDark.css';
 import { ADDRESS_LIST, FOLDER_LIST, DATE, DESC } from './constants';
+import { viewWhenLoggedOut } from './authViews';
 import './App.css';
 
 // Module-level token storage (never persisted to localStorage)
@@ -211,15 +212,9 @@ function App() {
     }
     setAppState(prev => {
       const updates = {};
-      // About is reachable when logged out via the auth-shell footer link,
-      // so it must not be bounced back to Login here. MfaChallenge sits
-      // mid-login (no token yet), so it must survive this check too.
-      const allowedWhenLoggedOut = [
-        "Login", "SignUp", "Verify", "MfaChallenge", "ForgotPassword",
-        "ResetPassword", "About"
-      ];
-      if (!allowedWhenLoggedOut.includes(prev.view)) {
-        updates.view = "Login";
+      const view = viewWhenLoggedOut(prev.view, !!prev.password);
+      if (view !== prev.view) {
+        updates.view = view;
       }
       if (prev.loggedIn !== false) {
         updates.loggedIn = false;

--- a/react/admin/src/authViews.js
+++ b/react/admin/src/authViews.js
@@ -1,0 +1,30 @@
+/**
+ * Which views survive a logged-out session check.
+ *
+ * App's session check runs on every render, so any view App routes to
+ * *before* a token exists has to be listed here or it is bounced back to
+ * Login before it ever paints. About is reachable when logged out via the
+ * auth-shell footer link; MfaChallenge and MfaSetup both sit mid-login,
+ * after the password but before (or instead of) token issuance.
+ */
+export const LOGGED_OUT_VIEWS = [
+  "Login", "SignUp", "Verify", "MfaChallenge", "MfaSetup", "ForgotPassword",
+  "ResetPassword", "About"
+];
+
+/**
+ * Resolve the view a logged-out app should show.
+ *
+ * @param {string} view - the view the app currently wants to render.
+ * @param {boolean} hasPassword - whether the in-memory password is still
+ *   available. Only MfaSetup needs it: that flow re-authenticates against
+ *   the enrollment app client, and persistState deliberately strips the
+ *   password, so a reload lands on the setup screen with nothing to
+ *   re-authenticate with. Restart from Login instead.
+ * @returns {string} the view to render.
+ */
+export function viewWhenLoggedOut(view, hasPassword) {
+  if (!LOGGED_OUT_VIEWS.includes(view)) return "Login";
+  if (view === "MfaSetup" && !hasPassword) return "Login";
+  return view;
+}

--- a/react/admin/src/authViews.test.js
+++ b/react/admin/src/authViews.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { viewWhenLoggedOut } from './authViews';
+
+describe('viewWhenLoggedOut', () => {
+  it('keeps the pre-login views', () => {
+    ["Login", "SignUp", "Verify", "MfaChallenge", "ForgotPassword",
+      "ResetPassword", "About"].forEach((view) => {
+      expect(viewWhenLoggedOut(view, false)).toBe(view);
+    });
+  });
+
+  it('bounces post-login views to Login', () => {
+    ["Email", "Addresses", "Folders", "Security", "EnrollMfa"].forEach((view) => {
+      expect(viewWhenLoggedOut(view, true)).toBe("Login");
+    });
+  });
+
+  it('keeps MfaSetup while the password is still in memory', () => {
+    expect(viewWhenLoggedOut("MfaSetup", true)).toBe("MfaSetup");
+  });
+
+  it('bounces MfaSetup once the password is gone (a reload)', () => {
+    expect(viewWhenLoggedOut("MfaSetup", false)).toBe("Login");
+  });
+});


### PR DESCRIPTION
Fixes #781.

## What was wrong

`checkSession()` runs from a `useEffect` with no dependency array — i.e. on every render — and rewrites `view` to `Login` for any logged-out view not on its allowlist. The allowlist had `MfaChallenge` but not `MfaSetup`, so when `doLogin`'s failure handler routed a gate-blocked admin to `MfaSetup` (they are, by definition, logged out — the PreTokenGeneration trigger refused the token), the very next render bounced them straight back to the login form with no banner and no route to enrollment.

## The fix

The allowlist moves to `react/admin/src/authViews.js` as `viewWhenLoggedOut(view, hasPassword)` so the rule is unit-testable — the regression class here is "view added to the router, not to the allowlist", which nothing covered.

`MfaSetup` joins the list, with one extra condition: it also requires the in-memory password. `beginMfaSetup` re-authenticates against the enrollment app client with `state.password`, and `persistState` deliberately strips the password, so a *reload* of that screen has nothing to re-authenticate with. Bouncing to `Login` on reload is correct — that behavior was previously coming from the bug, so it is now explicit.

Checked the other pre-login views for the same reload interaction: `ResetPassword` only needs `userName` (persisted) plus a code the user types on that screen, and `MfaChallenge` already handles its lost-session case in `doSubmitMfaCode`. No change needed there.

## Testing

- New `src/authViews.test.js` (4 cases: pre-login views kept, post-login views bounced, `MfaSetup` kept with a password, bounced without).
- Full React suite: 362 tests / 38 files pass.
- `npm run build` clean.

Not verified against a live locked-out account — the QA account was enrolled out-of-band per the issue, so re-testing needs a fresh factorless admin user on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)