### PR TITLE
iOS: inject the viewport meta in Original mode too

### DIFF
--- a/apple/Cabalmail/Views/HTMLRewrite.swift
+++ b/apple/Cabalmail/Views/HTMLRewrite.swift
@@ -4,7 +4,7 @@ import Foundation
 /// `data:` URIs pulled from the inline-image map. Purely string-level so
 /// we never need to run a JS context. In `readerMode`, prepends a reset +
 /// typography stylesheet that overrides author CSS for a Safari Reader-
-/// style presentation.
+/// style presentation. Both modes get a default viewport meta.
 func rewrite(
     html: String,
     inlineImages: [String: URL],
@@ -24,7 +24,39 @@ func rewrite(
     if readerMode {
         result = readerStylesheet + result
     }
-    return result
+    return insertingViewportMeta(into: result)
+}
+
+/// Injected on both render paths. Without it WebKit lays the document out
+/// at its 980pt desktop viewport and scales the result down to the pane
+/// width — about 40% on a phone — so any message that ships no viewport of
+/// its own (including the HTML alternative our own `/send` generates) is
+/// unreadable without pinch-zoom. Unlike the reader stylesheet this is
+/// presentation-neutral: it sets the layout viewport, it doesn't override
+/// author CSS.
+private let viewportMeta =
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+
+/// Places `viewportMeta` at the *start* of the document head, so a sender
+/// that declares its own viewport still wins (WebKit takes the last
+/// declaration in document order). The insertion point matters: prepending
+/// ahead of a `<!DOCTYPE>` would push the author's page into quirks mode
+/// and change how their CSS renders, which is exactly what "Original" mode
+/// must not do.
+private func insertingViewportMeta(into html: String) -> String {
+    // `<head>` first, then `<html>`, then the doctype; a bare fragment has
+    // none of them and can simply be prefixed (the parser synthesizes the
+    // head around it).
+    for tag in ["<head", "<html", "<!doctype"] {
+        guard let open = html.range(of: tag, options: .caseInsensitive),
+              let close = html.range(of: ">", range: open.upperBound..<html.endIndex)
+        else { continue }
+        return html.replacingCharacters(
+            in: close,
+            with: ">" + viewportMeta
+        )
+    }
+    return viewportMeta + html
 }
 
 /// Prepended in reader mode. Every rule uses `!important` because most
@@ -37,7 +69,6 @@ func rewrite(
 /// system appearance (which is why `readerMode` also drops the `.light`
 /// WebKit override in the host view).
 private let readerStylesheet = """
-<meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   html, body {
     margin: 0 !important;

--- a/apple/CabalmailTests/HTMLRewriteTests.swift
+++ b/apple/CabalmailTests/HTMLRewriteTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Cabalmail
+
+/// Covers the viewport meta both render paths depend on (without it WebKit
+/// lays messages out at 980pt and scales them down) and the `cid:` rewriting
+/// that predates it.
+final class HTMLRewriteTests: XCTestCase {
+    private let viewport = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+
+    // MARK: - Viewport injection
+
+    func testOriginalModeInjectsViewport() {
+        let html = "<html><head><title>hi</title></head><body>two words</body></html>"
+        let result = rewrite(html: html, inlineImages: [:], readerMode: false)
+        XCTAssertTrue(result.contains(viewport))
+    }
+
+    func testReaderModeStillInjectsViewport() {
+        let result = rewrite(html: "<body>hi</body>", inlineImages: [:], readerMode: true)
+        XCTAssertTrue(result.contains(viewport))
+    }
+
+    func testViewportLandsInsideHead() {
+        let html = "<html><head><title>hi</title></head><body>hi</body></html>"
+        let result = rewrite(html: html, inlineImages: [:], readerMode: false)
+        XCTAssertEqual(result, "<html><head>\(viewport)<title>hi</title></head><body>hi</body></html>")
+    }
+
+    /// A doctype has to stay first or the author's page renders in quirks
+    /// mode — the one thing "Original" mode must not change.
+    func testDoctypeStaysFirstWhenThereIsNoHead() {
+        let html = "<!DOCTYPE html>\n<body>hi</body>"
+        let result = rewrite(html: html, inlineImages: [:], readerMode: false)
+        XCTAssertTrue(result.hasPrefix("<!DOCTYPE html>\(viewport)"), result)
+    }
+
+    func testViewportGoesAfterHtmlTagWhenThereIsNoHead() {
+        let html = "<html><body>hi</body></html>"
+        let result = rewrite(html: html, inlineImages: [:], readerMode: false)
+        XCTAssertEqual(result, "<html>\(viewport)<body>hi</body></html>")
+    }
+
+    /// The HTML alternative our own `/send` Lambda generates is a bare
+    /// fragment — the shape the tester hit in #787.
+    func testBareFragmentIsPrefixed() {
+        let result = rewrite(html: "<p>two words</p>", inlineImages: [:], readerMode: false)
+        XCTAssertEqual(result, "\(viewport)<p>two words</p>")
+    }
+
+    /// Ours is a default, not an override: a sender's own viewport must come
+    /// later in document order so WebKit honors theirs.
+    func testSenderViewportSurvivesAndWins() throws {
+        let sender = "<meta name=\"viewport\" content=\"width=600\">"
+        let html = "<html><head>\(sender)</head><body>hi</body></html>"
+        let result = rewrite(html: html, inlineImages: [:], readerMode: false)
+        let ours = try XCTUnwrap(result.range(of: viewport))
+        let theirs = try XCTUnwrap(result.range(of: sender))
+        XCTAssertTrue(ours.lowerBound < theirs.lowerBound, result)
+    }
+
+    // MARK: - cid: rewriting
+
+    func testRewritesInlineImageReferencesCaseInsensitively() {
+        let url = URL(string: "data:image/png;base64,AAA")!
+        let html = "<img src=\"cid:LogoPart\"><img src=\"CID:LogoPart\">"
+        let result = rewrite(html: html, inlineImages: ["LogoPart": url], readerMode: false)
+        XCTAssertFalse(result.lowercased().contains("cid:"))
+        XCTAssertEqual(result.components(separatedBy: url.absoluteString).count - 1, 2)
+    }
+}

--- a/changelog.d/reader-viewport-meta.fixed.md
+++ b/changelog.d/reader-viewport-meta.fixed.md
@@ -1,0 +1,7 @@
+- Apple: **Readable HTML bodies in "Original" mode.** The reader now injects a
+  `width=device-width` viewport meta on both render paths, not just in Reader
+  mode. Without it WebKit laid messages out at its 980pt desktop viewport and
+  scaled the result down to the pane — about 40% on a phone — so any message
+  that ships no viewport of its own was legible only by pinch-zoom. A sender's
+  own viewport still wins, and the injection never displaces a `<!DOCTYPE>`, so
+  author CSS renders exactly as before.


### PR DESCRIPTION
## What was wrong

In the default `Original` body render mode, HTML message bodies rendered at
roughly 40% scale on iPhone — a two-word sentence occupying a ~7pt line.
Toggling to Reader mode fixed it instantly. Reported in #787 (2/2 on the
iPhone 17 sim); the iPad two-pane layout was unaffected, which matches the
root cause below.

## Root cause

`<meta name="viewport" content="width=device-width, initial-scale=1">` was
part of `readerStylesheet` in `HTMLRewrite.swift`, so it was injected **only**
when `readerMode` was true. With no viewport declared, WKWebView lays the
document out at its 980pt desktop viewport and scales the result to the pane
width — ~0.41 on a 402pt phone, ~1.0 in the iPad's ~1070pt reader pane, which
is why the iPad looked fine. Any message that ships no viewport of its own is
hit, including the `text/html` alternative our own `/send` Lambda generates.

## The fix

Move the meta out of the reader stylesheet and inject it on both render paths.
Two details:

- It goes at the **start of the document head**, so a sender that declares its
  own viewport still wins (WebKit takes the last declaration in document
  order). Ours is a default, not an override.
- The insertion point is chosen so a `<!DOCTYPE>` stays first (`<head>`, else
  `<html>`, else after the doctype, else prefix the fragment). Prepending ahead
  of the doctype would push the author's page into quirks mode and change how
  their CSS renders — exactly what `Original` mode must not do.

A viewport meta is presentation-neutral: unlike the reader stylesheet it sets
the layout viewport and overrides no author CSS.

## Test evidence

New `apple/CabalmailTests/HTMLRewriteTests.swift` (8 cases: injection on both
paths, head/html/doctype/fragment insertion points, sender-viewport ordering,
plus the pre-existing `cid:` rewriting). 6 of the 8 fail with the fix stashed
and all pass with it; full `CabalmailMac` suite green at 43 tests. `swiftlint
--strict` from `apple/` clean.

Live repro on the iPhone 17 sim (iOS 26.5) against a build of this branch: the
same "smtp cutover probe 0726" message that reproduced the bug now renders its
body at full reading size in `Original` mode, still in the author's own face
(no reader typography applied).

Addresses #787