### PR TITLE
React: parse naive envelope dates as UTC

### DIFF
--- a/changelog.d/react-naive-utc-dates.fixed.md
+++ b/changelog.d/react-naive-utc-dates.fixed.md
@@ -1,0 +1,6 @@
+- **Message timestamps in the web app.** Envelope dates arrive from the API as
+  naive UTC, and the browser was parsing them as local time, so every reader
+  header and every relative age in the message list was off by the viewer's UTC
+  offset — a message sent moments ago could read as hours in the future, and
+  yesterday evening's mail showed today's date. Naive date-times are now pinned
+  to UTC before formatting; values that carry a zone are untouched.

--- a/react/admin/src/utils/formatDate.js
+++ b/react/admin/src/utils/formatDate.js
@@ -10,14 +10,27 @@
 
 const LOCALE = 'en-US';
 
+/* Envelope dates arrive from the API as naive UTC — "2026-07-26 01:16:27",
+   no offset and no trailing Z. JS parses a bare date-time as *local* time,
+   which shifted every timestamp and relative age by the viewer's UTC
+   offset. Match that shape and pin it to UTC; anything that already carries
+   a zone (or isn't a date-time at all) goes to Date untouched. */
+const NAIVE_DATE_TIME = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?)$/;
+
+export function parseDate(value) {
+  if (!value) return null;
+  const naive = NAIVE_DATE_TIME.exec(String(value).trim());
+  const d = new Date(naive ? `${naive[1]}T${naive[2]}Z` : value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
 function startOfDay(d) {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
 }
 
 export default function formatDate(iso, now = new Date()) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseDate(iso);
+  if (!d) return '';
 
   const ms = now.getTime() - d.getTime();
   if (ms < 60000) return 'now';
@@ -66,9 +79,8 @@ export function domainFor(fromStr) {
 
 /* Reader-pane timestamp, per §4d: "Friday, Apr 17 · 1:10 PM". */
 export function formatReaderTimestamp(iso) {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = parseDate(iso);
+  if (!d) return '';
   const datePart = d.toLocaleDateString(LOCALE, {
     weekday: 'long',
     month: 'short',

--- a/react/admin/src/utils/formatDate.test.js
+++ b/react/admin/src/utils/formatDate.test.js
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import formatDate, { extractName, extractEmail, domainFor } from './formatDate';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import formatDate, {
+  extractName,
+  extractEmail,
+  domainFor,
+  parseDate,
+  formatReaderTimestamp,
+} from './formatDate';
 
 describe('formatDate', () => {
   const now = new Date('2026-04-20T14:00:00');
@@ -86,5 +92,58 @@ describe('domainFor', () => {
   it('returns empty string when there is no @', () => {
     expect(domainFor('Mailer Daemon')).toBe('');
     expect(domainFor('')).toBe('');
+  });
+});
+
+/* The API sends envelope dates as naive UTC ("2026-07-26 01:16:27"), which
+   JS otherwise parses as local time. Pin a non-UTC zone so these assertions
+   are meaningful on a UTC CI runner too. */
+describe('naive-UTC envelope dates', () => {
+  const original = process.env.TZ;
+  beforeAll(() => { process.env.TZ = 'America/New_York'; });
+  afterAll(() => { process.env.TZ = original; });
+
+  it('runs against a non-UTC zone', () => {
+    expect(new Date('2026-07-26T01:16:27Z').getHours()).toBe(21);
+  });
+
+  it('reads a naive date-time as UTC, not local', () => {
+    expect(parseDate('2026-07-26 01:16:27').getTime())
+      .toBe(Date.parse('2026-07-26T01:16:27Z'));
+  });
+
+  it('leaves a zoned date-time alone', () => {
+    expect(parseDate('2026-07-26T01:16:27Z').getTime())
+      .toBe(Date.parse('2026-07-26T01:16:27Z'));
+    expect(parseDate('2026-07-25T21:16:27-04:00').getTime())
+      .toBe(Date.parse('2026-07-26T01:16:27Z'));
+  });
+
+  it('returns null for missing or unparseable input', () => {
+    expect(parseDate('')).toBeNull();
+    expect(parseDate(null)).toBeNull();
+    expect(parseDate('not-a-date')).toBeNull();
+  });
+
+  it('renders the reader timestamp in local time', () => {
+    // Sent 2026-07-25 21:16 EDT; the naive value is its UTC equivalent.
+    expect(formatReaderTimestamp('2026-07-26 01:16:27'))
+      .toBe('Saturday, Jul 25 · 9:16 PM');
+  });
+
+  it('never dates a just-sent message into the future', () => {
+    // 06:21 EDT today, i.e. 10:21 UTC — was rendering as "10:21 AM".
+    const now = new Date('2026-07-26T10:26:00Z');
+    expect(formatDate('2026-07-26 10:21:00', now)).toBe('5m');
+    expect(formatReaderTimestamp('2026-07-26 10:21:00'))
+      .toBe('Sunday, Jul 26 · 6:21 AM');
+  });
+
+  it('ages a message by its true elapsed time', () => {
+    // Sent 2026-07-25 21:16 EDT, read 2026-07-26 06:20 EDT — the previous
+    // local day, so "Yesterday". The shifted parse put it at 01:16 *today*
+    // and the row read "5h".
+    const now = new Date('2026-07-26T10:20:00Z');
+    expect(formatDate('2026-07-26 01:16:27', now)).toBe('Yesterday');
   });
 });


### PR DESCRIPTION
## What was wrong

Every timestamp in the web app was shifted by the viewer's UTC offset (#788):
a message sent at 06:21 EDT rendered as "Sunday, Jul 26 · 10:21 AM" — four
hours in the future — and one sent 2026-07-25 21:16 EDT rendered with the
wrong time *and* the wrong date, its list row reading "5h" when it was 9h old.

## Root cause

`list_envelopes` returns a naive date-time with no offset — `"2026-07-26
01:16:27"` — and the value is UTC. `formatDate` and `formatReaderTimestamp`
both handed that string to `new Date(...)`, and per the JS spec a date-time
form without an offset is **local** time. The Apple client reads the same
field as UTC and is correct, which is what pinned this to the web app rather
than the data.

## The fix

A `parseDate()` helper in `utils/formatDate.js` matches the naive shape and
pins it to UTC (`…T…Z`) before parsing; a value that already carries `Z` or an
offset goes to `Date` untouched, as does anything unparseable (still `null` →
empty string). Both formatters route through it.

Fixed on the client side rather than by changing the API to emit ISO-8601 with
`Z`: the Apple client already interprets the field correctly, so re-cutting the
contract would mean a coordinated change across both clients for no gain.

## Test evidence

`react/admin/src/utils/formatDate.test.js` gains a `naive-UTC envelope dates`
block covering `parseDate` directly plus the two reported symptoms with the
issue's own values (`"10:21 AM"` → `"6:21 AM"`, `"5h"` → `"Yesterday"`). It
pins `process.env.TZ` to `America/New_York` — with a guard case asserting the
zone actually took effect — so the assertions stay meaningful on a UTC CI
runner, where the bug is invisible by construction. 6 of the 7 new cases fail
with the fix stashed; the full suite is green at 369 tests.

Not verified against a live browser: the deployed stage bundle doesn't carry
this change, and the TZ-pinned unit tests reproduce the exact strings from the
report. The tester's retest on stage is the live check.

## Related surface, not changed

`Email/index.jsx` interpolates the raw `envelope.date` string into the quoted
header of a reply/forward, so that line quotes UTC without labelling it. It's a
different surface from the two the issue reports (reader header, list row) and
it changes the text of outgoing mail, so I left it alone — flagging it here.

Addresses #788