### PR TITLE
iOS/macOS: disable WebKit link preview in the reader

### DIFF
--- a/apple/Cabalmail/Views/HTMLBodyView.swift
+++ b/apple/Cabalmail/Views/HTMLBodyView.swift
@@ -179,14 +179,7 @@ private struct MobileHTMLView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .nonPersistent()
-        let preferences = WKWebpagePreferences()
-        preferences.allowsContentJavaScript = false
-        configuration.defaultWebpagePreferences = preferences
-        context.coordinator.installLinkBridge(on: configuration.userContentController)
-        let view = WKWebView(frame: .zero, configuration: configuration)
-        view.navigationDelegate = context.coordinator
+        let view = makeReaderWebView(coordinator: context.coordinator)
         view.isOpaque = true
         return view
     }
@@ -234,15 +227,7 @@ private struct MacHTMLView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .nonPersistent()
-        let preferences = WKWebpagePreferences()
-        preferences.allowsContentJavaScript = false
-        configuration.defaultWebpagePreferences = preferences
-        context.coordinator.installLinkBridge(on: configuration.userContentController)
-        let view = WKWebView(frame: .zero, configuration: configuration)
-        view.navigationDelegate = context.coordinator
-        return view
+        makeReaderWebView(coordinator: context.coordinator)
     }
 
     func updateNSView(_ nsView: WKWebView, context: Context) {
@@ -267,6 +252,30 @@ private struct MacHTMLView: NSViewRepresentable {
 #endif
 
 // MARK: - Shared helpers
+
+/// Builds the reader's web view with the privacy posture both platforms
+/// share: no persistent website data, no page JavaScript, the link bridge
+/// installed, and link preview off.
+///
+/// `allowsLinkPreview` defaults to true, which makes a long-press **fetch
+/// the target page** to render the preview — a silent third-party request
+/// from a reader whose whole point is that it blocks remote content, and a
+/// read receipt for anyone who sends a uniquely-keyed link. The useful
+/// actions are already covered by our own link menu on primary activation
+/// (see `HTMLBodyView+LinkBridge`), so nothing is lost by turning it off.
+@MainActor
+func makeReaderWebView(coordinator: HTMLBodyCoordinator) -> WKWebView {
+    let configuration = WKWebViewConfiguration()
+    configuration.websiteDataStore = .nonPersistent()
+    let preferences = WKWebpagePreferences()
+    preferences.allowsContentJavaScript = false
+    configuration.defaultWebpagePreferences = preferences
+    coordinator.installLinkBridge(on: configuration.userContentController)
+    let view = WKWebView(frame: .zero, configuration: configuration)
+    view.navigationDelegate = coordinator
+    view.allowsLinkPreview = false
+    return view
+}
 
 /// Navigation-level + content-blocker coordination for the embedded web
 /// view. The content rule list does the heavy lifting against subresources

--- a/apple/CabalmailTests/ReaderWebViewConfigTests.swift
+++ b/apple/CabalmailTests/ReaderWebViewConfigTests.swift
@@ -1,0 +1,28 @@
+import WebKit
+import XCTest
+@testable import Cabalmail
+
+/// The reader web view's privacy posture: everything here is a setting whose
+/// default leaks something (page JS, persistent site data, or — via link
+/// preview — a silent fetch of a link's target).
+@MainActor
+final class ReaderWebViewConfigTests: XCTestCase {
+    private func makeView() -> WKWebView {
+        makeReaderWebView(coordinator: HTMLBodyCoordinator(allowRemote: false))
+    }
+
+    /// #789: the default (true) makes a long-press load the linked page even
+    /// with remote content blocked.
+    func testLinkPreviewIsDisabled() {
+        XCTAssertFalse(makeView().allowsLinkPreview)
+    }
+
+    func testPageJavaScriptIsDisabled() {
+        let view = makeView()
+        XCTAssertFalse(view.configuration.defaultWebpagePreferences.allowsContentJavaScript)
+    }
+
+    func testWebsiteDataStoreIsNonPersistent() {
+        XCTAssertFalse(makeView().configuration.websiteDataStore.isPersistent)
+    }
+}

--- a/changelog.d/reader-link-preview-off.security.md
+++ b/changelog.d/reader-link-preview-off.security.md
@@ -1,0 +1,6 @@
+- Apple: **No silent fetch when long-pressing a link in the reader.** WebKit's
+  stock link preview is disabled, so a long-press no longer loads the target
+  page — a third-party request the remote-content gate one button away in the
+  same toolbar is meant to prevent, and a read receipt for anyone sending a
+  uniquely-keyed link. Copy Link Text / Copy Link Address / Open in Browser /
+  Share are unaffected; they hang off a primary tap.


### PR DESCRIPTION
## What was wrong

With remote content blocked (the default), long-pressing an `https://` link in
the reader made WebKit fetch and render the target page inside its preview
card — reproduced 2/2 in #789 against two different hosts.

## Root cause

`WKWebView.allowsLinkPreview` defaults to `true`. The reader never set it, so
the stock long-press preview was live: a silent third-party request from a view
whose content blocker exists precisely to stop those, and a read receipt for
anyone who sends a uniquely-keyed link.

## The fix

`allowsLinkPreview = false`. Both platform views built their web view with an
identical body (non-persistent data store, page JS off, link bridge installed),
so that setup moves into a shared `makeReaderWebView(coordinator:)` and the
setting lands in one place. The same call already appears in the compose
editor's web view, so this brings the reader in line with it.

Turned off outright rather than gated on `remoteContentAllowed`: the preview
buys nothing here — the app's own link menu (Copy Link Text / Copy Link Address
/ Open in Browser / Share) hangs off primary activation via the link bridge,
not the system menu, and it keeps working. It also takes "Add to Reading List"
out of the reader, the side observation on the issue.

Behavior change worth knowing: long-press on a link now falls through to text
selection (the WebKit default with preview off) instead of showing the system
menu.

## Test evidence

New `apple/CabalmailTests/ReaderWebViewConfigTests.swift` asserts the reader's
three privacy-relevant settings — link preview off, page JS off, non-persistent
data store — each a default that leaks if left alone. It exercises a function
this PR introduces, so it can't run against stage's code; the setting it pins
is a WebKit default of `true`. Full `CabalmailMac` suite green at 38 tests,
`swiftlint --strict` from `apple/` clean.

Live on the iPhone 17 sim (iOS 26.5) against a build of this branch, same
"Link seed 0726" message the tester used: long-pressing `https://www.wikipedia.org/`
shows no preview and no page load (text selection plus our status pill), and a
primary tap still brings up the app's four-action link menu.

Addresses #789