### PR TITLE
api: answer 409 when a new folder name is already taken

### DIFF
--- a/changelog.d/new-folder-already-exists.fixed.md
+++ b/changelog.d/new-folder-already-exists.fixed.md
@@ -1,0 +1,6 @@
+- **Creating a folder that already exists.** The API turned the server's
+  rejection into an unhandled exception, so the request failed as a 502 with a
+  traceback and the web app had nothing it could show. It now answers 409 and
+  names the folder ("A folder called qa0726 already exists"), any other
+  IMAP-level create failure answers a describable 500, and the folder rail
+  surfaces whichever message the API sent instead of a generic line.

--- a/lambda/api/new_folder/function.py
+++ b/lambda/api/new_folder/function.py
@@ -1,11 +1,34 @@
 '''Creates a new folder and returns updated folder list'''
 import json
+import logging
+from imapclient.exceptions import IMAPClientError # pylint: disable=import-error
 from helper import get_imap_client # pylint: disable=import-error
 from helper import get_folder_list # pylint: disable=import-error
 from helper import parse_json_body # pylint: disable=import-error
 from helper import validate_folder_name # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
+
+
+def _create_failed(path, err):
+    '''Maps a failed CREATE onto a response the client can show. Left
+    unhandled, every IMAP-level failure escaped as an unhandled exception and
+    API Gateway turned it into a 502, which no client can describe to the
+    user. The already-exists case is the common one and is the user's to fix,
+    so it gets its own 409 and names the folder.'''
+    text = str(err)
+    if 'ALREADYEXISTS' in text.upper() or 'already exists' in text.lower():
+        return {
+            "statusCode": 409,
+            "body": json.dumps({
+                "status": f"A folder called {path.split('.')[-1]} already exists"
+            })
+        }
+    logging.warning('could not create folder %r: %s', path, text)
+    return {
+        "statusCode": 500,
+        "body": json.dumps({"status": "Unable to create folder"})
+    }
 
 
 @maintenance_guard
@@ -28,11 +51,12 @@ def handler(event, _context):
             "body": json.dumps({"status": f"Invalid input: {err}"})
         }
     client = get_imap_client(None, user, 'INBOX')
-    if parent == "":
-        client.create_folder(name)
-    else:
-        parent = parent.replace("/",".")
-        client.create_folder(f"{parent}.{name}")
+    path = name if parent == "" else f"{parent.replace('/', '.')}.{name}"
+    try:
+        client.create_folder(path)
+    except IMAPClientError as err:
+        client.logout()
+        return _create_failed(path, err)
     response = get_folder_list(client)
     client.logout()
     return {

--- a/lambda/api/new_folder/tests/test_function.py
+++ b/lambda/api/new_folder/tests/test_function.py
@@ -1,0 +1,145 @@
+'''Unit tests for the new_folder handler.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/new_folder/tests/test_function.py
+
+function.py's helper and imapclient imports are faked in sys.modules before
+import, so the suite needs no boto3 / AWS and never dials an IMAP server.'''
+import json
+import os
+import sys
+import types
+import unittest
+
+# function.py lives one directory up.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# --- fake imapclient ---------------------------------------------------------
+
+
+class IMAPClientError(Exception):
+    '''Stand-in for imapclient's own error type.'''
+
+
+_exceptions = types.ModuleType('imapclient.exceptions')
+_exceptions.IMAPClientError = IMAPClientError
+_imapclient = types.ModuleType('imapclient')
+_imapclient.exceptions = _exceptions
+sys.modules['imapclient'] = _imapclient
+sys.modules['imapclient.exceptions'] = _exceptions
+
+# --- fake helper -------------------------------------------------------------
+
+
+class _FakeImapClient:
+    def __init__(self):
+        self.ops = []
+        self.create_error = None
+        self.logged_out = False
+
+    def create_folder(self, name):
+        if self.create_error is not None:
+            raise self.create_error
+        self.ops.append(f'create:{name}')
+
+    def logout(self):
+        self.logged_out = True
+
+
+CLIENT = _FakeImapClient()
+FOLDER_LIST = {'folders': ['INBOX'], 'sub_folders': ['INBOX']}
+
+
+def _parse_json_body(event):
+    return json.loads(event['body']), None
+
+
+def _validate_folder_name(name):
+    if not name:
+        raise ValueError('missing folder name')
+    return name
+
+
+_helper = types.ModuleType("helper")
+_helper.get_imap_client = lambda _host, _user, _folder: CLIENT
+_helper.get_folder_list = lambda _client: FOLDER_LIST
+_helper.parse_json_body = _parse_json_body
+_helper.validate_folder_name = _validate_folder_name
+_helper.maintenance_guard = lambda handler: handler
+sys.modules['helper'] = _helper
+
+import function  # noqa: E402  pylint: disable=wrong-import-position
+
+# The real server's rejection, verbatim from CloudWatch (#790).
+ALREADY_EXISTS = IMAPClientError(
+    'create failed: [ALREADYEXISTS] Mailbox already exists '
+    '(0.058 + 0.000 + 0.057 secs).'
+)
+
+
+def _event(name, parent=''):
+    return {
+        'body': json.dumps({'name': name, 'parent': parent}),
+        'requestContext': {
+            'authorizer': {'claims': {'cognito:username': 'testuser'}}
+        },
+    }
+
+
+class NewFolderTest(unittest.TestCase):
+
+    def setUp(self):
+        CLIENT.ops.clear()
+        CLIENT.create_error = None
+        CLIENT.logged_out = False
+
+    def test_creates_a_top_level_folder(self):
+        response = function.handler(_event('qa0726'), None)
+        self.assertEqual(response['statusCode'], 201)
+        self.assertEqual(CLIENT.ops, ['create:qa0726'])
+        self.assertTrue(CLIENT.logged_out)
+
+    def test_creates_a_child_folder_under_its_parent(self):
+        response = function.handler(_event('qa0726', parent='Archive/2026'), None)
+        self.assertEqual(response['statusCode'], 201)
+        self.assertEqual(CLIENT.ops, ['create:Archive.2026.qa0726'])
+
+    def test_existing_folder_returns_409_naming_the_folder(self):
+        CLIENT.create_error = ALREADY_EXISTS
+        response = function.handler(_event('qa0726'), None)
+        self.assertEqual(response['statusCode'], 409)
+        self.assertEqual(
+            json.loads(response['body'])['status'],
+            'A folder called qa0726 already exists'
+        )
+        self.assertTrue(CLIENT.logged_out)
+
+    def test_existing_child_folder_names_the_leaf_not_the_path(self):
+        CLIENT.create_error = ALREADY_EXISTS
+        response = function.handler(_event('qa0726', parent='Archive'), None)
+        self.assertEqual(response['statusCode'], 409)
+        self.assertEqual(
+            json.loads(response['body'])['status'],
+            'A folder called qa0726 already exists'
+        )
+
+    def test_other_imap_failures_return_a_describable_500(self):
+        # Anything unhandled here escapes the handler and API Gateway turns it
+        # into a 502 the client can't describe.
+        CLIENT.create_error = IMAPClientError('create failed: [SERVERBUG] oops')
+        response = function.handler(_event('qa0726'), None)
+        self.assertEqual(response['statusCode'], 500)
+        self.assertEqual(
+            json.loads(response['body'])['status'], 'Unable to create folder'
+        )
+        self.assertTrue(CLIENT.logged_out)
+
+    def test_invalid_name_still_returns_400(self):
+        response = function.handler(_event(''), None)
+        self.assertEqual(response['statusCode'], 400)
+        self.assertEqual(CLIENT.ops, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/react/admin/src/Folders/Folders.test.jsx
+++ b/react/admin/src/Folders/Folders.test.jsx
@@ -294,6 +294,46 @@ describe('Folders rail', () => {
         true,
       );
     });
+
+    it('surfaces the API message when the name is already taken', async () => {
+      // 409 from new_folder — the name collision is the user's to fix, so
+      // the toast has to say which folder rather than "Unable to create".
+      mockNewFolder.mockRejectedValue({
+        response: { status: 409, data: { status: 'A folder called qa0726 already exists' } },
+      });
+      const setMessage = vi.fn();
+      renderFolders({ setMessage });
+      await waitFor(() => expect(screen.getByText('Inbox')).toBeInTheDocument());
+      const addBtns = screen.getAllByRole('button', { name: /^new folder$/i });
+      await act(async () => { fireEvent.click(addBtns[0]); });
+      const input = screen.getByPlaceholderText('New folder name');
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'qa0726' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+      await waitFor(() => expect(setMessage).toHaveBeenCalledWith(
+        'A folder called qa0726 already exists',
+        true,
+      ));
+    });
+
+    it('falls back to the generic message when the failure carries no body', async () => {
+      mockNewFolder.mockRejectedValue(new Error('Network Error'));
+      const setMessage = vi.fn();
+      renderFolders({ setMessage });
+      await waitFor(() => expect(screen.getByText('Inbox')).toBeInTheDocument());
+      const addBtns = screen.getAllByRole('button', { name: /^new folder$/i });
+      await act(async () => { fireEvent.click(addBtns[0]); });
+      const input = screen.getByPlaceholderText('New folder name');
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'qa0726' } });
+        fireEvent.keyDown(input, { key: 'Enter' });
+      });
+      await waitFor(() => expect(setMessage).toHaveBeenCalledWith(
+        'Unable to create folder.',
+        true,
+      ));
+    });
   });
 
   it('toggles subscription from a folder row', async () => {

--- a/react/admin/src/Folders/index.jsx
+++ b/react/admin/src/Folders/index.jsx
@@ -340,8 +340,12 @@ function Folders({ setMessage, folder, setFolder, onNewMessage, asDrawer = false
       setNewName('');
       localStorage.removeItem(FOLDER_LIST);
       refresh();
-    }).catch(() => {
-      setMessage && setMessage('Unable to create folder.', true);
+    }).catch((err) => {
+      // The API describes what went wrong when it can — a name collision
+      // comes back as a 409 naming the folder. Fall back to the generic
+      // line for transport failures, which carry no response body.
+      const detail = err?.response?.data?.status;
+      setMessage && setMessage(detail || 'Unable to create folder.', true);
     });
   }, [addingParent, api, newName, refresh, setMessage]);
 


### PR DESCRIPTION
## What was wrong

`PUT /new_folder` with a name that already exists returned **502** with a
traceback in the logs, and the web app surfaced nothing (#790).

## Root cause

`new_folder`'s handler calls `client.create_folder(...)` directly, so Dovecot's
`[ALREADYEXISTS] Mailbox already exists` came back as an `imapclient`
`IMAPClientError`, escaped the handler, and API Gateway rendered its
unhandled-exception 502. A 502 has no body a client can read, so an ordinary
user-fixable mistake was indistinguishable from a broken backend. As the issue
notes, that applied to *every* IMAP-level failure in this handler, not just
this one.

## The fix

Two layers, one bug:

- **`lambda/api/new_folder`** — catch `IMAPClientError` around the create. A
  name collision answers **409** naming the folder ("A folder called qa0726
  already exists"); anything else answers a describable **500** plus a log
  line. Nothing IMAP-level leaves the handler as an exception now. The
  parent/child path is built once instead of twice so the error message can
  name the leaf.
- **`react/admin` folder rail** — the create path already had a `.catch`, but
  it always showed the same generic "Unable to create folder."; it now prefers
  the API's own message when the response carries one.

## Test evidence

- New `lambda/api/new_folder/tests/test_function.py` (6 cases: top-level and
  child create, the 409 with the real CloudWatch error string from the issue,
  the child-folder message naming the leaf not the path, the fallback 500, and
  the existing 400 on an invalid name). Follows the `delete_folder` harness —
  stdlib `unittest`, `helper` and `imapclient` faked in `sys.modules`, run with
  `python3 lambda/api/new_folder/tests/test_function.py`. 3 of the 6 error out
  with the fix stashed; all 6 pass with it. `pylint` 10.00/10.
- `Folders.test.jsx` gains the 409-message case and a no-body fallback case;
  the first fails without the client change. Full React suite green at 364.

Not verified end-to-end on stage: the fix isn't deployed there yet, and both
halves are covered by the tests above. The tester's retest is the live check.

## Two notes from the same flow

- **The tester saw no toast at all.** The rail's create path *does* catch and
  call `setMessage`, and `Email/index.jsx` passes `setMessage` in both the
  sidebar and drawer renders, so I couldn't account for a completely silent
  failure from reading the code — and I can't reproduce the client half without
  a deployed 502. Worth watching on retest: if the 409 message still doesn't
  appear, the toast plumbing is a separate bug from this one.
- **`delete_folder` has the same unguarded shape** (`client.delete_folder(name)`
  with no `IMAPClientError` catch), so deleting a folder that's already gone
  will 502 the same way. Left alone here to keep this scoped; filed separately
  as #796.

Addresses #790
