### PR TITLE
CloudFront access logging via vended-log delivery (v2)

### DIFF
--- a/changelog.d/cloudfront-access-logging-v2.added.md
+++ b/changelog.d/cloudfront-access-logging-v2.added.md
@@ -1,0 +1,12 @@
+- **CloudFront access logs for both distributions.** The admin app and
+  the public front door now deliver access logs to the shared
+  `cabal-s3-access-logs-<account>` bucket, alongside the S3 server access
+  logs and under the same 180-day lifecycle. Delivery uses CloudWatch
+  vended-log delivery (CloudFront standard logging v2, new
+  `modules/cloudfront_logs`) rather than the distribution's legacy
+  `logging_config` block: the legacy path authorizes delivery with a
+  bucket ACL grant, and every bucket in the stack has ACLs disabled, so
+  it would have meant re-enabling ACLs on a log bucket. The v2 path
+  authorizes with a bucket policy instead and needs none. Delivery
+  resources live in us-east-1, which CloudFront requires, while the
+  destination bucket stays in the stack region.

--- a/terraform/infra/.checkov.baseline
+++ b/terraform/infra/.checkov.baseline
@@ -34,8 +34,7 @@
                         "CKV2_AWS_32",
                         "CKV2_AWS_47",
                         "CKV_AWS_310",
-                        "CKV_AWS_68",
-                        "CKV_AWS_86"
+                        "CKV_AWS_68"
                     ]
                 },
                 {
@@ -223,8 +222,7 @@
                         "CKV2_AWS_47",
                         "CKV_AWS_310",
                         "CKV_AWS_374",
-                        "CKV_AWS_68",
-                        "CKV_AWS_86"
+                        "CKV_AWS_68"
                     ]
                 },
                 {

--- a/terraform/infra/BASELINE.md
+++ b/terraform/infra/BASELINE.md
@@ -9,7 +9,7 @@ Measured against commit `371dc6a1` (see [`docs/0.10.x/iac-baseline-snapshot.md`]
 | File | Purpose |
 | ---- | ------- |
 | [`.checkov.yaml`](.checkov.yaml) | Global, design-driven `skip-check` of the CMK class (11 ids). Policy only. |
-| [`.checkov.baseline`](.checkov.baseline) | Per-resource grandfather of the 110 residual Checkov findings (38 ids). New findings fail. |
+| [`.checkov.baseline`](.checkov.baseline) | Per-resource grandfather of the 108 residual Checkov findings (37 ids). New findings fail. |
 | [`.trivyignore`](.trivyignore) | Rule-id ignore list: the CMK class + design-driven (11 ids). The must-fix and decay sections are both empty. |
 
 ## Counts
@@ -18,7 +18,7 @@ Counts reflect **pip checkov** (what CI runs). See the [graph-check note](#graph
 
 | Tool | Total | CMK global-suppress | Baselined | Fixed / inline-suppressed (2.5) | Residual |
 | ---- | ----- | ------------------- | --------- | ------------------------------- | -------- |
-| Checkov | 243 | 76 (12 ids) | 110 (38 ids) | 14 (276, 51, 8, 341, 26, 27x3, 103, 74, 12 fixed; 111, 356, 2_18, 21 inline) | 0 |
+| Checkov | 243 | 76 (12 ids) | 108 (37 ids) | 14 (276, 51, 8, 341, 26, 27x3, 103, 74, 12 fixed; 111, 356, 2_18, 21 inline) | 0 |
 | Trivy   | 41  | 29 (4 ids)  | 12 (7 ids) | 4 (AWS-0031, 0095, 0096, 0131 fixed) | 0 |
 | tflint  | 6   | 0           | 0 (never baselined) | 6 fixed (`tls` version + 5 unused decls) | 0 |
 
@@ -56,6 +56,7 @@ The weekly decay task walks the grandfathered findings down one at a time:
 - **CKV_AWS_135** (EC2 EBS-optimized) - **reclassified to design-driven** via inline skip, no behavior change. The flagged instance is a `t3.micro` NAT instance; t3 is Nitro-based, so EBS optimization is already on and cannot be turned off. The check describes a gap that does not exist in AWS, and the one-line "fix" would be a no-op that only quiets the scanner. Moved to section 3 with a co-located `#checkov:skip`; baseline entry removed.
 - **CKV_AWS_91** (ALB access logging) and **CKV_AWS_237** (API Gateway create-before-destroy) - **reclassified to design-driven**, no code change, baseline entries kept (per resource, so a new load balancer or REST API is still caught). CKV_AWS_91's only remaining instance is the monitoring ALB, which is count-gated off in every environment; CKV_AWS_237's lifecycle block does not address the actual replacement risk (a new `execute-api` id). Full rationales in section 3.
 - **X-Ray ids realigned** (`AWS-0066`, `AWS-0003`) - documentation only. Both sat under the `# --- Decay:` heading in `.trivyignore` while section 3 of this file classified them (with `CKV_AWS_50` / `CKV_AWS_73`) as design-driven, won't-fix on cost grounds. The two files disagreed; `.trivyignore` now matches this one. With `AWS-0124` cleared, its decay section is empty.
+- **CKV_AWS_86** (CloudFront access logging, x2) - **fixed in substance, suppressed inline**, and the last row of the decay table. Both distributions now deliver access logs, but through CloudWatch vended-log delivery (CloudFront "standard logging (v2)", new `modules/cloudfront_logs`) rather than the distribution's `logging_config` block. The check only recognizes the latter - it inspects `logging_config/[0]/bucket` and nothing else - so both distributions carry a co-located `#checkov:skip=CKV_AWS_86` explaining that logging is on by a mechanism the rule predates. Baseline entries removed. The legacy block was rejected deliberately: it delivers through a bucket ACL grant to the log-delivery group, and every bucket in this stack is `BucketOwnerEnforced` (ACLs disabled), so satisfying the check literally would have meant re-enabling ACLs on a log bucket - trading a real posture for a green rule, and tripping `CKV2_AWS_65` in the process. The v2 path authorizes delivery with a bucket *policy* grant to `delivery.logs.amazonaws.com` and needs no ACLs, so the logs land in the existing shared `modules/s3_access_logs` bucket alongside the S3 server access logs, inheriting its 180-day lifecycle. The delivery resources live in us-east-1 (CloudFront is global and its delivery configuration is only accepted there; the root passes the module the `use1` provider as its default `aws`), while the destination bucket stays in the stack region - cross-Region delivery is explicitly supported. **Watch item:** delivery is authorized only for the `AWSLogs/<account-id>/CloudFront/*` subtree, so a future change to the module's `suffix_path` that escapes that prefix will stop delivery silently; the bucket policy and the suffix path have to move together.
 
 ### NAT-mode refactor re-key (0.10.x)
 
@@ -135,9 +136,7 @@ Accepted as intentional architecture. Baselined **per resource** (not globally s
 
 Low-value hygiene. Each release should clear or re-justify entries whose target version has arrived (Phase 4).
 
-| Checkov | Trivy | Item | Target |
-| ------- | ----- | ---- | ------ |
-| CKV_AWS_86 (x2) | - | CloudFront access logging on both distributions (`module.admin.aws_cloudfront_distribution.cdn`, `module.front_door.aws_cloudfront_distribution.this`). **Not hygiene** - admin-app access logs have real audit value, and this is the only decay row left with a genuine open decision. The obvious target, the shared `modules/s3_access_logs` bucket, does not work as-is: legacy CloudFront standard logging delivers via bucket ACL, and that bucket sets no `aws_s3_bucket_ownership_controls`, so it defaults to BucketOwnerEnforced (ACLs disabled). The three options are a separate ACL-enabled bucket, relaxing ownership on the shared one, or CloudFront v2 logging (delivery sources) - and v2 would *not* clear this check, which looks specifically for a `logging_config` block. Decide the target before scheduling the work. | 1.0.0 |
+**This table is empty.** Every finding the decay process was tracking has been fixed or reclassified; see "Decay clears (Phase 4)" above for the walk-down. What remains in the baseline is design-driven (section 3), which is won't-fix by intent rather than deferred work. Add a row here only if a new finding arrives that is worth fixing but not worth fixing now - and give it a target version, or it will rot.
 
 ## Notes / known limitations
 

--- a/terraform/infra/main.tf
+++ b/terraform/infra/main.tf
@@ -178,6 +178,24 @@ module "front_door" {
   access_logs_bucket = module.s3_access_logs.bucket
 }
 
+# CloudFront access logs for both distributions, delivered to the shared
+# access-log bucket by CloudWatch vended-log delivery. The module's
+# resources must be created in us-east-1 (CloudFront is global and only
+# accepts its delivery configuration there), so it gets the use1 provider
+# as its default aws; the destination bucket stays in the stack region.
+module "cloudfront_logs" {
+  source                 = "./modules/cloudfront_logs"
+  destination_bucket_arn = module.s3_access_logs.bucket_arn
+  distributions = {
+    admin      = module.admin.cloudfront_distribution_arn
+    front-door = module.front_door.cloudfront_distribution_arn
+  }
+
+  providers = {
+    aws = aws.use1
+  }
+}
+
 # Sets up Route 53 hosted zones for mail domains. When the control domain is
 # also a mail domain, its bootstrap zone is reused rather than duplicated.
 # DNSSEC signing is opt-in per environment (var.dnssec_enabled); the

--- a/terraform/infra/modules/app/cloudfront.tf
+++ b/terraform/infra/modules/app/cloudfront.tf
@@ -56,6 +56,7 @@ resource "aws_s3_bucket_policy" "admin_bucket" {
 #tfsec:ignore:aws-cloudfront-enable-logging
 #tfsec:ignore:aws-cloudfront-enable-waf
 resource "aws_cloudfront_distribution" "cdn" {
+  #checkov:skip=CKV_AWS_86:Access logging is enabled, via CloudWatch vended-log delivery (standard logging v2, modules/cloudfront_logs). The check only recognizes the legacy `logging_config` block, whose ACL-based delivery is incompatible with this stack's ACLs-disabled buckets.
   origin {
     domain_name              = var.bucket_domain_name
     origin_id                = "cabal_admin_s3"

--- a/terraform/infra/modules/app/outputs.tf
+++ b/terraform/infra/modules/app/outputs.tf
@@ -2,3 +2,8 @@ output "master_password" {
   value = random_password.password.result
 }
 
+
+output "cloudfront_distribution_arn" {
+  value       = aws_cloudfront_distribution.cdn.arn
+  description = "ARN of the admin app CloudFront distribution. Used as the access-log delivery source (modules/cloudfront_logs)."
+}

--- a/terraform/infra/modules/cloudfront_logs/main.tf
+++ b/terraform/infra/modules/cloudfront_logs/main.tf
@@ -1,0 +1,78 @@
+/**
+* CloudFront access logging via CloudWatch vended-log delivery (standard
+* logging v2).
+*
+* CloudFront offers two logging mechanisms. The legacy one ("standard
+* logging (legacy)") is the `logging_config` block on the distribution
+* itself, and it delivers through a bucket ACL grant to the log-delivery
+* group. That path is incompatible with this stack: every bucket here is
+* created with Object Ownership BucketOwnerEnforced (ACLs disabled), and
+* re-enabling ACLs on a log bucket to satisfy it would be a step
+* backwards. This module uses the modern path instead - CloudWatch vended
+* log delivery - which authorizes delivery with a bucket *policy* grant to
+* the delivery.logs.amazonaws.com service principal and needs no ACLs at
+* all. The grant lives with the bucket, in modules/s3_access_logs.
+*
+* Three resources per delivery, following the AWS docs ("Configure
+* standard logging (v2)"):
+*   delivery source      - one per distribution, names the log type
+*   delivery destination - one shared, names the S3 bucket and format
+*   delivery             - joins a source to the destination
+*
+* Everything here must live in us-east-1. CloudFront is a global service
+* and its delivery configuration is only accepted there, so the root
+* passes this module the us-east-1 provider as its default `aws`. The
+* destination bucket does *not* have to be in us-east-1: cross-Region
+* delivery is explicitly supported ("you must specify the US East (N.
+* Virginia) Region, even if you want to enable cross Region delivery to
+* another destination"), so logs land in the same shared bucket in the
+* stack region as every other access log.
+*
+* Retention is inherited: the shared bucket's lifecycle rule is unfiltered
+* and expires everything after 180 days, CloudFront logs included.
+*/
+
+# One delivery source per distribution. AWS permits only one delivery
+# source per distribution, so the map key - not the distribution id -
+# keeps the names stable and readable.
+resource "aws_cloudwatch_log_delivery_source" "cloudfront" {
+  for_each = var.distributions
+
+  name         = "cabal-${each.key}-access-logs"
+  log_type     = "ACCESS_LOGS"
+  resource_arn = each.value
+}
+
+# One shared destination for both distributions. Note that output_format
+# is immutable: AWS only accepts it at creation, so changing it later
+# means destroying and recreating the destination (and the deliveries
+# that reference it). w3c matches the legacy CloudFront log layout, which
+# is what most off-the-shelf log tooling expects.
+resource "aws_cloudwatch_log_delivery_destination" "s3" {
+  name          = "cabal-cloudfront-access-logs-s3"
+  output_format = "w3c"
+
+  delivery_destination_configuration {
+    destination_resource_arn = var.destination_bucket_arn
+  }
+}
+
+# Joining source to destination is what actually starts delivery.
+#
+# suffix_path is appended to the default prefix CloudFront applies when
+# the destination ARN carries no prefix of its own
+# (AWSLogs/<account-id>/CloudFront/), so the delivered objects land at
+# AWSLogs/<account-id>/CloudFront/<key>/<distribution-id>/<yyyy>/<MM>/<dd>/.
+# The bucket policy grants that whole subtree; keep the two in step, since
+# a suffix_path that escapes the granted prefix fails delivery silently.
+resource "aws_cloudwatch_log_delivery" "cloudfront" {
+  for_each = var.distributions
+
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.cloudfront[each.key].name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.s3.arn
+
+  s3_delivery_configuration {
+    suffix_path                 = "${each.key}/{DistributionId}/{yyyy}/{MM}/{dd}"
+    enable_hive_compatible_path = false
+  }
+}

--- a/terraform/infra/modules/cloudfront_logs/variables.tf
+++ b/terraform/infra/modules/cloudfront_logs/variables.tf
@@ -1,0 +1,9 @@
+variable "distributions" {
+  type        = map(string)
+  description = "CloudFront distributions to deliver access logs for, keyed by a short stable name used in both the delivery-source name and the S3 key prefix. Values are distribution ARNs."
+}
+
+variable "destination_bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket receiving the access logs. Need not be in us-east-1; cross-Region delivery is supported. The bucket policy must grant delivery.logs.amazonaws.com s3:PutObject on the delivered prefix (see modules/s3_access_logs)."
+}

--- a/terraform/infra/modules/cloudfront_logs/versions.tf
+++ b/terraform/infra/modules/cloudfront_logs/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # aws_cloudwatch_log_delivery* (CloudWatch vended-log delivery)
+      # landed in provider 5.36.
+      version = ">= 5.36"
+    }
+  }
+
+  required_version = ">= 1.1.2"
+}

--- a/terraform/infra/modules/front_door/main.tf
+++ b/terraform/infra/modules/front_door/main.tf
@@ -122,6 +122,7 @@ resource "aws_s3_bucket_policy" "this" {
 #tfsec:ignore:aws-cloudfront-enable-logging
 #tfsec:ignore:aws-cloudfront-enable-waf
 resource "aws_cloudfront_distribution" "this" {
+  #checkov:skip=CKV_AWS_86:Access logging is enabled, via CloudWatch vended-log delivery (standard logging v2, modules/cloudfront_logs). The check only recognizes the legacy `logging_config` block, whose ACL-based delivery is incompatible with this stack's ACLs-disabled buckets.
   origin {
     domain_name              = aws_s3_bucket.this.bucket_regional_domain_name
     origin_id                = "front_door_s3"

--- a/terraform/infra/modules/front_door/outputs.tf
+++ b/terraform/infra/modules/front_door/outputs.tf
@@ -22,3 +22,8 @@ output "terms_url" {
   value       = "https://${local.site_host}/terms.html"
   description = "Public URL of the terms of service page."
 }
+
+output "cloudfront_distribution_arn" {
+  value       = aws_cloudfront_distribution.this.arn
+  description = "ARN of the front door CloudFront distribution. Used as the access-log delivery source (modules/cloudfront_logs)."
+}

--- a/terraform/infra/modules/s3_access_logs/main.tf
+++ b/terraform/infra/modules/s3_access_logs/main.tf
@@ -117,6 +117,40 @@ data "aws_iam_policy_document" "access_logs" {
       values   = local.source_bucket_arns
     }
   }
+
+  # CloudFront access logs arrive by a different route: CloudWatch vended
+  # log delivery (standard logging v2, see modules/cloudfront_logs), which
+  # writes as delivery.logs.amazonaws.com rather than the S3 logging
+  # principal. Shape and conditions come from the AWS docs ("Configure
+  # standard logging (v2)" - the destination bucket policy). Scoped to the
+  # default CloudFront prefix, so a delivery whose suffix_path escapes it
+  # is denied rather than scattering objects outside the granted subtree.
+  # The delivery-source ARNs are us-east-1 regardless of the stack region:
+  # CloudFront's delivery configuration is only accepted there.
+  statement {
+    sid     = "AWSLogsDeliveryWrite"
+    actions = ["s3:PutObject"]
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    resources = ["${aws_s3_bucket.access_logs.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/CloudFront/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:us-east-1:${data.aws_caller_identity.current.account_id}:delivery-source:*"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "access_logs" {

--- a/terraform/infra/modules/s3_access_logs/outputs.tf
+++ b/terraform/infra/modules/s3_access_logs/outputs.tf
@@ -7,3 +7,13 @@ output "bucket" {
   value       = aws_s3_bucket.access_logs.id
   depends_on  = [aws_s3_bucket_policy.access_logs]
 }
+
+# ARN form, for the CloudWatch vended-log delivery destination
+# (modules/cloudfront_logs), which addresses the bucket by ARN rather
+# than by name. Same depends_on rationale as `bucket`: the delivery
+# policy must exist before a consumer points delivery at the bucket.
+output "bucket_arn" {
+  description = "ARN of the shared S3 server-access-log target bucket."
+  value       = aws_s3_bucket.access_logs.arn
+  depends_on  = [aws_s3_bucket_policy.access_logs]
+}


### PR DESCRIPTION
Closes the last decay row, `CKV_AWS_86`. **Stacked on #799** - base is `claude/iac-decay-20260726-2`, so this diff shows only the new commit. Merge #799 first and GitHub retargets this to `stage` automatically.

## What it does

Both CloudFront distributions now deliver access logs to the existing shared `cabal-s3-access-logs-<account>` bucket, under the same 180-day lifecycle as the S3 server access logs. A new `modules/cloudfront_logs` owns the three CloudWatch vended-log delivery resources: a delivery source per distribution, one shared destination, and a delivery joining them.

## Why not the block the check asks for

`CKV_AWS_86` inspects `logging_config/[0]/bucket` and nothing else - the legacy mechanism, which authorizes delivery through a **bucket ACL grant** to the log-delivery group. Every bucket in this stack is `BucketOwnerEnforced` with ACLs disabled. Satisfying the check literally meant re-enabling ACLs on a log bucket: giving up a real posture for a green rule, and tripping `CKV2_AWS_65` on the way in.

Standard logging v2 authorizes with a bucket **policy** grant to `delivery.logs.amazonaws.com` and needs no ACLs at all, so the existing shared bucket works unmodified apart from the new policy statement. Both distributions carry an inline `#checkov:skip=CKV_AWS_86` saying logging is on by a mechanism the rule predates. Baseline entries removed: **110 -> 108 findings, 38 -> 37 ids**, which empties the decay table.

## Design notes

- **Region split.** Delivery resources must be created in us-east-1 - CloudFront is global and only accepts its delivery configuration there - so the root passes the module the `use1` provider as its default `aws`. The destination bucket stays in the stack region. Cross-Region delivery is explicitly supported: *"you must specify the US East (N. Virginia) Region (`us-east-1`), even if you want to enable cross Region delivery to another destination."*
- **Prefix coupling.** The bucket policy grants only `AWSLogs/<account-id>/CloudFront/*`. The module's `suffix_path` appends beneath that default prefix, so the two must move together - a suffix path that escapes the grant fails delivery **silently**. Called out in the module comment, the bucket policy comment, and BASELINE.md.
- **Immutable output format.** `output_format = "w3c"` can only be set at destination creation; changing it later requires destroying the destination and its deliveries. Noted in the module.
- One delivery source per distribution is an AWS limit, which the per-distribution map respects.

## STAGE-VALIDATE before promoting

This creates real delivery infrastructure and cannot be verified by planning alone. After it applies to stage, check:

1. **Logs actually arrive.** Objects appear under `s3://cabal-s3-access-logs-<account>/AWSLogs/<account-id>/CloudFront/{admin,front-door}/<distribution-id>/<yyyy>/<MM>/<dd>/`. Allow time - CloudFront says logging changes take effect **within 12 hours**, and delivery is not immediate.
2. **The policy grant is sufficient.** If nothing lands, the first suspect is the bucket policy path not matching the delivered prefix (the documented silent-failure mode), not the delivery config itself.
3. **No duplicate-source error.** `This ResourceId has already been used in another Delivery Source in this account` means a distribution already had a delivery source from an earlier manual attempt; it must be deleted before Terraform can create its own.
4. **Both distributions**, not just the admin one - the front door is easy to forget.

No data plane, message flow, or user-facing surface is touched. Nothing about mail delivery depends on this.

## Verification

```
make scan                                      exit 0
make drift                                     exit 0
terraform fmt -check -recursive terraform/infra exit 0
terraform validate                             exit 0 (Success! - pre-existing
                                               redundant-ignore_changes warnings only;
                                               the new module's provider warning was
                                               fixed with a required_providers block)
checkov: Passed 1232, Failed 108, Skipped 36   (all 108 baselined; skips 34 -> 36 is
                                               the two new CKV_AWS_86 inline skips)
```

No new findings were introduced by the module or the policy statement.