### PR TITLE
Correct the gate status and decay state in BASELINE.md

### DIFF
--- a/changelog.d/baseline-gate-status-accuracy.fixed.md
+++ b/changelog.d/baseline-gate-status-accuracy.fixed.md
@@ -1,0 +1,8 @@
+- **Stale gate status in the scanner baseline record.**
+  `terraform/infra/BASELINE.md` still said the IaC gate was "soft-fail
+  until Phase 3" long after Phase 3 shipped - the workflow jobs it
+  describes are commented `GATING (Phase 3)` and genuinely block the
+  apply. It now states the real posture, names the mechanism (scanner
+  jobs in `approval`'s `needs:` and `if:`, `apply` behind `approval`,
+  plus the baseline-drift step), and records that the decay backlog is
+  complete, so the header matches the now-empty decay table.

--- a/terraform/infra/BASELINE.md
+++ b/terraform/infra/BASELINE.md
@@ -1,8 +1,12 @@
 # terraform/infra - scanner baseline
 
-Phase 2 of [`docs/0.10.x/iac-quality-gates-plan.md`](../../docs/0.10.x/iac-quality-gates-plan.md). This file is the reviewed record behind the machine-readable suppression and baseline files in this directory. Every accepted finding is here with a rationale; decay candidates carry a target version.
+Phase 2 of [`docs/0.10.x/iac-quality-gates-plan.md`](../../docs/0.10.x/iac-quality-gates-plan.md). This file is the reviewed record behind the machine-readable suppression and baseline files in this directory. Every accepted finding is here with a rationale.
 
-Measured against commit `371dc6a1` (see [`docs/0.10.x/iac-baseline-snapshot.md`](../../docs/0.10.x/iac-baseline-snapshot.md) for the Phase 0 inventory). Gate posture: **fail on all Trivy severities** (Checkov is severity-blind, so it fails on any finding). The gate is still soft-fail until Phase 3.
+Measured against commit `371dc6a1` (see [`docs/0.10.x/iac-baseline-snapshot.md`](../../docs/0.10.x/iac-baseline-snapshot.md) for the Phase 0 inventory). Gate posture: **fail on all Trivy severities** (Checkov is severity-blind, so it fails on any finding).
+
+**The gate is live and blocking (Phase 3).** In [`infra.yml`](../../.github/workflows/infra.yml) the `chekov` / `tflint` / `trivy` jobs are both listed in `approval`'s `needs:` and asserted `result == 'success'` in its `if:`, and `apply` runs only behind `approval` - so a scanner failure blocks the apply rather than annotating it. The bootstrap stage mirrors this with `checkov_dns` / `tflint_dns` / `trivy_dns`. Each scanner job also runs [`baseline-diff.py`](../../.github/scripts/baseline-diff.py) as a second gating step, failing on a *stale* entry so a fixed finding cannot keep its grandfather. The only `continue-on-error` in those jobs is on the SARIF upload steps, deliberately: a code-scanning upload hiccup must not decide a gate whose verdict is the scan step itself.
+
+**Decay is complete.** Section 4 is empty - every finding the weekly decay process tracked has been fixed or reclassified (see "Decay clears (Phase 4)"). What remains baselined is design-driven (section 3): won't-fix by intent, not deferred work. A finding that is worth fixing but not now goes in section 4 *with a target version*; without one it rots, which is how several rows here outlived their own accuracy.
 
 ## Files in this directory
 


### PR DESCRIPTION
Docs only. No Terraform, no scanner config, no baseline or ignorefile changes.

## The stale claim

`terraform/infra/BASELINE.md` opened with:

> The gate is still soft-fail until Phase 3.

Phase 3 shipped. The jobs that sentence describes are commented `# GATING (Phase 3)` in `infra.yml` and genuinely block the apply:

- `chekov` / `tflint` / `trivy` appear in `approval`'s `needs:` **and** are asserted `result == 'success'` in its `if:`
- `apply` runs only behind `approval`
- the bootstrap stage mirrors it with `checkov_dns` / `tflint_dns` / `trivy_dns`
- each scanner job runs `baseline-diff.py` as a second gating step, failing on a *stale* baseline entry so a fixed finding cannot keep its grandfather
- the only `continue-on-error` in those jobs is on the SARIF upload steps, deliberately - an upload hiccup must not decide a gate whose verdict is the scan step itself

The header now says that, with the mechanism spelled out, so the next reader does not have to re-derive it from the workflow.

## Decay state

Also records that the decay backlog is complete, so the header agrees with the section 4 table that #800 emptied. Kept the rule that earns a row there: **a target version, or it rots** - which is precisely how several of those rows outlived their own accuracy before this week's audit.

## Note

`terraform/dns/BASELINE.md` was checked and never carried the claim; the only other "soft-fail" match in the repo is an unrelated SPF reference in a sendmail runbook. This was the sole offender.

Because `BASELINE.md` sits under `terraform/infra/**`, merging this triggers `infra.yml`. Expect a no-op: plan finds nothing to change, and `apply` is gated on `plan.outputs.exit_code == '2'`, so it will not run.