### PR TITLE
Invert logo treatment on the auth screens

### DIFF
--- a/changelog.d/auth-logo-inversion.changed.md
+++ b/changelog.d/auth-logo-inversion.changed.md
@@ -1,0 +1,4 @@
+- **Inverted logo on the web app's auth screens.** The sign-in, sign-up,
+  and other pre-login gates now render the logo mark in the accent color
+  directly on the page background, matching the inverted treatment the
+  top bar already uses.

--- a/react/admin/src/Login/AuthShell.css
+++ b/react/admin/src/Login/AuthShell.css
@@ -46,17 +46,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--accent);
-  color: var(--surface);
+  background: transparent;
+  color: var(--accent);
   height: 37px;
   width: 72px;
-  border-radius: var(--radius-sm);
   overflow: hidden;
   padding: 4px;
-}
-
-@media (prefers-color-scheme: dark) {
-  .auth__brand-tile { color: #0b0b0b; }
 }
 
 .auth__brand-tile svg {


### PR DESCRIPTION
## Summary

Follow-up to #803, which inverted the top-bar logo. This applies the same treatment to the auth screens: `AuthShell.css`'s `.auth__brand-tile` now renders the C and M glyphs in the user's accent color on a transparent background, instead of surface-colored glyphs on an accent-filled tile. The now-moot dark-mode glyph override is removed. Tile dimensions and padding are unchanged, so the header doesn't shift.

This covers sign-in, sign-up, forgot-password, and the MFA/verify gates — everything that renders inside `AuthShell`. The accent resolves pre-login because `useTheme` always sets `data-accent` (defaulting to `forest`) on mount.

The About page needs no change: it has no logo of its own — the top bar renders above it in both logged-in and logged-out states, and that tile was already inverted in #803.

## Testing

- `npm run test`: 38 files, 371 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)