### PR TITLE
Apple: detect a dead rich-text editor bridge instead of hanging or sending an empty body

### DIFF
--- a/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
@@ -134,6 +134,10 @@ extension ComposeViewModel {
     /// plan calls for without a second persistent queue.
     func autosaveToServer() async {
         guard !isSending, !serverSaveInFlight else { return }
+        // Same reasoning as `cancel()`: with the bridge dead every body
+        // converts to "", and a debounced push of that would overwrite the
+        // server copy with an empty draft (#745).
+        guard editorController.bridgeFailure == nil else { return }
         guard let fromEmail = currentFromEmail() else { return }
         let message = await buildOutgoingMessage(from: fromEmail)
         guard hasDraftContent(message) else { return }

--- a/apple/Cabalmail/ViewModels/ComposeViewModel.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel.swift
@@ -328,6 +328,15 @@ final class ComposeViewModel {
         defer { isSending = false }
         do {
             let message = await buildOutgoingMessage(from: fromEmail)
+            // Body assembly runs through the WebKit bridge, which answers
+            // "" for every conversion once it is dead. Sending that would
+            // deliver an empty message the user had written text into, so
+            // refuse and leave the window open (#745).
+            if let failure = editorController.bridgeFailure {
+                errorMessage = "Can't prepare the message body — \(failure). "
+                    + "Copy anything you still need before closing this window."
+                return false
+            }
             // Send-from-draft cleans up the server copy after delivery
             // (best-effort, server-side). A queued send drops the ref; the
             // stale copy survives, which beats discarding a draft for a
@@ -372,6 +381,15 @@ final class ComposeViewModel {
             return true
         }
         let message = await buildOutgoingMessage(from: fromEmail)
+        // A dead bridge converts every body to "" (#745). Pushing that to
+        // the server would replace a good Drafts copy with an empty one, so
+        // keep the local draft (already flushed above) and let the window
+        // close — trapping the user in a compose they can't fix is worse.
+        if editorController.bridgeFailure != nil {
+            stop()
+            onClose()
+            return true
+        }
         guard hasDraftContent(message) else {
             if let ref = serverDraftRef {
                 _ = try? await client.discardDraft(ref)

--- a/apple/CabalmailKit/Sources/CabalmailKit/Compose/RichTextEditorController.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Compose/RichTextEditorController.swift
@@ -120,6 +120,13 @@ public final class RichTextEditorController: NSObject {
     /// True once `editor-bridge.js` has finished bootstrapping and is safe
     /// to call. Drives `waitUntilReady()` so callers don't race the load.
     public private(set) var isReady: Bool = false
+    /// Non-nil once the bridge is known to be unusable: the boot script
+    /// failed, `ready` never arrived within `readyTimeout`, or the web
+    /// content process died after boot. Every bridge call answers with its
+    /// empty / identity fallback from that point on, so a caller about to
+    /// *send* or *persist* a converted body must check this and refuse
+    /// rather than treat `""` as "the user wrote nothing" (#745).
+    public private(set) var bridgeFailure: String?
 
     /// Fires after every `input` event from the editor (typing, paste,
     /// formatting). Use it to invalidate cached HTML.
@@ -129,16 +136,24 @@ public final class RichTextEditorController: NSObject {
     public var onSelectionChanged: (@MainActor (Selection) -> Void)?
     /// Fires once after the editor finishes bootstrapping.
     public var onReady: (@MainActor () -> Void)?
-    /// Fires when the editor page reports a script error — most notably a
-    /// failure while loading or evaluating marked / turndown /
-    /// editor-bridge.js, after which the bridge never posts `ready` and
-    /// every editor await stays parked. Hosts should surface this to the
-    /// user; the controller only records and forwards it.
+    /// Fires when the bridge reports trouble: a script error from the editor
+    /// page (most notably while loading or evaluating marked / turndown /
+    /// editor-bridge.js), a `ready` handshake that never arrived, or a dead
+    /// web content process. Hosts should surface it to the user; whether the
+    /// bridge is still usable afterwards is recorded in `bridgeFailure`.
     public var onBridgeError: (@MainActor (String) -> Void)?
 
     private var pendingReadyContinuations: [CheckedContinuation<Void, Never>] = []
+    private var readyTimeoutTask: Task<Void, Never>?
+    private let readyTimeout: TimeInterval
 
-    public init(placeholder: String? = nil) {
+    /// `readyTimeout` bounds how long the first `waitUntilReady()` parks
+    /// before the bridge is declared dead. Ten seconds is far longer than a
+    /// local `file://` load needs even on a cold, loaded device, and a
+    /// late `ready` still recovers the bridge — so a slow boot costs a
+    /// transient banner, never a stuck Send.
+    public init(placeholder: String? = nil, readyTimeout: TimeInterval = 10) {
+        self.readyTimeout = readyTimeout
         let config = WKWebViewConfiguration()
         let controller = WKUserContentController()
         config.userContentController = controller
@@ -182,10 +197,15 @@ public final class RichTextEditorController: NSObject {
         }
     }
 
-    /// Suspends the caller until the bridge has posted its `ready` message.
-    /// Cheap to call repeatedly — returns immediately once ready.
+    /// Suspends the caller until the bridge posts `ready`, fails, or
+    /// `readyTimeout` elapses — whichever comes first. Cheap to call
+    /// repeatedly. It never parks forever: a bridge that dies while
+    /// bootstrapping used to leave Send spinning with no error and no
+    /// timeout (#745), so the wait is bounded and callers that care about
+    /// the result check `bridgeFailure` afterwards.
     public func waitUntilReady() async {
-        if isReady { return }
+        if isReady || bridgeFailure != nil { return }
+        startReadyTimeout()
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             pendingReadyContinuations.append(continuation)
         }
@@ -265,12 +285,20 @@ public final class RichTextEditorController: NSObject {
 
     // MARK: - Bridge plumbing
 
-    fileprivate func handleBridgeMessage(_ payload: [String: Any]) {
+    // Internal rather than fileprivate so the bridge-liveness tests can
+    // drive the handshake without an app host to run editor.html in.
+    func handleBridgeMessage(_ payload: [String: Any]) {
         guard let type = payload["type"] as? String else { return }
         switch type {
         case "ready":
             guard !isReady else { return }
             isReady = true
+            // A `ready` that arrives after the timeout fired means the boot
+            // was merely slow, not dead — clear the failure so the compose
+            // can go on using the bridge.
+            bridgeFailure = nil
+            readyTimeoutTask?.cancel()
+            readyTimeoutTask = nil
             let waiters = pendingReadyContinuations
             pendingReadyContinuations.removeAll()
             for continuation in waiters { continuation.resume() }
@@ -280,7 +308,14 @@ public final class RichTextEditorController: NSObject {
             let source = payload["source"] as? String ?? ""
             let described = source.isEmpty ? message : "\(message) (\(source))"
             NSLog("[RichTextEditor] bridge script error: %@", described)
-            onBridgeError?(described)
+            // A script error before `ready` is terminal — the handshake
+            // never comes. After `ready` the bridge is live and a stray
+            // page error is not worth disabling the composer for.
+            if isReady {
+                onBridgeError?(described)
+            } else {
+                failBridge(described)
+            }
         case "input":
             onContentChanged?()
         case "selection":
@@ -291,6 +326,35 @@ public final class RichTextEditorController: NSObject {
         default:
             break
         }
+    }
+
+    /// Arms the one-shot deadline behind `waitUntilReady()`. Started on the
+    /// first wait rather than in `init` so a controller nobody awaits never
+    /// arms a timer.
+    private func startReadyTimeout() {
+        guard readyTimeoutTask == nil else { return }
+        let timeout = readyTimeout
+        readyTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.failBridge("the editor did not finish loading")
+        }
+    }
+
+    /// Records a bridge failure, releases everyone parked in
+    /// `waitUntilReady()`, and tells the host. Idempotent — the first cause
+    /// wins, and a later `ready` clears it.
+    private func failBridge(_ reason: String) {
+        guard bridgeFailure == nil else { return }
+        bridgeFailure = reason
+        isReady = false
+        readyTimeoutTask?.cancel()
+        readyTimeoutTask = nil
+        let waiters = pendingReadyContinuations
+        pendingReadyContinuations.removeAll()
+        for continuation in waiters { continuation.resume() }
+        NSLog("[RichTextEditor] bridge unusable: %@", reason)
+        onBridgeError?(reason)
     }
 
     // The WKWebView async/await API can throw on otherwise-benign navigations
@@ -344,6 +408,15 @@ extension RichTextEditorController: WKNavigationDelegate {
             return
         }
         decisionHandler(.cancel)
+    }
+
+    /// The web content process can be jetsammed or crash *after* the bridge
+    /// reported ready, and nothing else tells us: `isReady` would stay true,
+    /// every `evaluateJavaScript` would fail, and `getHTML()`'s `?? ""`
+    /// fallback would hand the send path an empty body for a message the
+    /// user did write — which then leaves on the wire (#745).
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        failBridge("the editor's web content process stopped")
     }
 }
 

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/RichTextEditorBridgeHealthTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/RichTextEditorBridgeHealthTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+#if canImport(WebKit)
+@testable import CabalmailKit
+
+/// Bridge-liveness tests (#745).
+///
+/// The conversion suite in `RichTextEditorControllerTests` needs an app host
+/// so `editor.html` can actually boot. These don't: they drive the handshake
+/// directly through `handleBridgeMessage` / the navigation-delegate callback
+/// and assert on what happens when the bridge *doesn't* come up, or dies
+/// after it has. Every one of them ends with a `waitUntilReady()` that must
+/// return — before the fix those awaits parked forever and Send spun with no
+/// error and no timeout.
+@MainActor
+final class RichTextEditorBridgeHealthTests: XCTestCase {
+    /// The #734 shape: the boot script fails, so `ready` never arrives.
+    /// The error is posted synchronously right after `init`, before any
+    /// suspension point lets a (hosted) real load report ready.
+    func testBootScriptErrorReleasesWaiters() async {
+        let controller = RichTextEditorController(readyTimeout: 600)
+        var reported: String?
+        controller.onBridgeError = { reported = $0 }
+
+        controller.handleBridgeMessage([
+            "type": "error",
+            "message": "failed to load editor-bridge.js"
+        ])
+
+        XCTAssertEqual(controller.bridgeFailure, "failed to load editor-bridge.js")
+        XCTAssertFalse(controller.isReady)
+        XCTAssertEqual(reported, "failed to load editor-bridge.js")
+        // The deadline is 10 minutes out, so a wait that returns here was
+        // released by the failure, not by the timeout.
+        await controller.waitUntilReady()
+    }
+
+    /// The shape the tester reproduced on device: the content process is
+    /// killed *after* boot. `isReady` used to stay true forever, so nothing
+    /// was waiting — every conversion just answered "" and the send went
+    /// out empty.
+    func testContentProcessTerminationMarksBridgeUnusable() async {
+        let controller = RichTextEditorController(readyTimeout: 600)
+        var reported: String?
+        controller.handleBridgeMessage(["type": "ready"])
+        XCTAssertTrue(controller.isReady)
+        controller.onBridgeError = { reported = $0 }
+
+        controller.webViewWebContentProcessDidTerminate(controller.webView)
+
+        XCTAssertFalse(controller.isReady)
+        XCTAssertNotNil(controller.bridgeFailure)
+        XCTAssertNotNil(reported)
+        await controller.waitUntilReady()
+    }
+
+    /// A script error *after* the bridge is live is forwarded but not fatal —
+    /// the composer keeps working, so a stray page error can't strand a
+    /// message the user can otherwise send.
+    func testPostReadyScriptErrorDoesNotDisableTheBridge() {
+        let controller = RichTextEditorController(readyTimeout: 600)
+        var reported: String?
+        controller.handleBridgeMessage(["type": "ready"])
+        controller.onBridgeError = { reported = $0 }
+
+        controller.handleBridgeMessage(["type": "error", "message": "stray"])
+
+        XCTAssertEqual(reported, "stray")
+        XCTAssertNil(controller.bridgeFailure)
+        XCTAssertTrue(controller.isReady)
+    }
+
+    /// A `ready` that lands after the deadline fired means the boot was slow,
+    /// not dead: the failure clears and the composer goes on using it.
+    func testLateReadyClearsTheFailure() {
+        let controller = RichTextEditorController(readyTimeout: 600)
+        controller.webViewWebContentProcessDidTerminate(controller.webView)
+        XCTAssertNotNil(controller.bridgeFailure)
+
+        controller.handleBridgeMessage(["type": "ready"])
+
+        XCTAssertNil(controller.bridgeFailure)
+        XCTAssertTrue(controller.isReady)
+    }
+
+    /// The deadline itself. Hosted (`xcodebuild test`) the real page may well
+    /// boot first, so the assertion is the disjunction — what must hold
+    /// either way is that the wait *returns*, which is the whole bug.
+    func testWaitUntilReadyIsBounded() async {
+        let controller = RichTextEditorController(readyTimeout: 0.25)
+
+        await controller.waitUntilReady()
+
+        XCTAssertTrue(
+            controller.isReady || controller.bridgeFailure != nil,
+            "wait returned without either outcome recorded"
+        )
+    }
+}
+#endif

--- a/changelog.d/compose-bridge-death.fixed.md
+++ b/changelog.d/compose-bridge-death.fixed.md
@@ -1,0 +1,7 @@
+- Apple: **Compose no longer hangs or sends an empty body when the rich-text
+  editor dies.** The WebKit bridge that assembles the message body now reports
+  its own death — a `ready` handshake that never arrives, a failed boot script,
+  or a web content process that stops after boot — instead of leaving Send
+  spinning forever or converting the message to an empty string. Send refuses
+  with an explanatory banner, and draft pushes to the server are skipped rather
+  than replacing a good copy with an empty one.


### PR DESCRIPTION
Addresses #745.

## What was wrong

Compose builds the outgoing body through the WebKit bridge (`RichTextEditorController`). The verification on #745 found two distinct failure shapes, and neither was represented in the controller's state:

- **A — bridge never boots.** `ready` never posts, so `waitUntilReady()` parks forever. The tester watched Send spin for 5m20s with no error and nothing sent.
- **B — content process dies after boot.** `isReady` was set once and never cleared, and there was no `webViewWebContentProcessDidTerminate` handling. Nothing was waiting: `evaluateJavaScript` failed, `getHTML()` returned its `?? ""` fallback, and the send delivered a message with an empty body and empty HTML — silent data loss, on the wire.

## Root cause

`isReady` was a one-way latch with no failure state and no deadline, and every accessor treated a failed bridge call as a legitimately empty result.

## The fix

`RichTextEditorController` now tracks `bridgeFailure: String?`:

- `waitUntilReady()` is bounded by a `readyTimeout` (default 10s, injectable) and returns immediately once a failure is recorded — no more unbounded parks (shape A).
- `webViewWebContentProcessDidTerminate` clears `isReady` and records the failure (shape B).
- A boot-time script error is now terminal (the handshake is never coming); a script error *after* `ready` is still only forwarded, so a stray page error can't strand a message the user can otherwise send.
- A late `ready` clears the failure — a slow boot costs a transient banner, never a stuck Send.

`ComposeViewModel` consumes it at the three points where an empty conversion result would do damage: `send()` refuses with a banner instead of delivering an empty message; `autosaveToServer()` and `cancel()` skip the server draft push rather than replacing a good Drafts copy with an empty one (`cancel()` still dismisses — the local draft is already flushed, and trapping the user in a compose they can't fix would be worse).

## Test evidence

New `RichTextEditorBridgeHealthTests` (5 cases) in CabalmailKit — they drive the handshake directly, so unlike the conversion suite they need no app host.

Fails before / passes after, against the pre-fix controller (termination hook shimmed in as an empty method, which is what the old code effectively had, so the tests compile):

- before: `Executed 5 tests, with 5 failures` — no failure state recorded on a boot script error, on process termination, or for the late-`ready` recovery.
- after: `Executed 5 tests, with 0 failures`.

Full suites: `swift test` 369 tests / 0 failures; `xcodebuild test -scheme CabalmailMac` 46 tests / 0 failures; `swiftlint` from `apple/` clean; iOS `generic/platform=iOS` build clean.

Not verified live on a sim: reproducing either shape needs the fault injection the tester used (stripping `editor-bridge.js` from a re-signed installed bundle, or `pkill -9` of the sim's WebContent process). The state machine is covered by the unit tests above; the banner copy is the one part that has only been read, not seen.

## Out of scope

The verification also noted that the existing bridge-error banner sits below the fold on an iPhone sheet. That is placement, not this bug — left alone rather than folded into an unrelated fix.