### PR TITLE
Announce a dead compose editor bridge instead of a dead Send button

### DIFF
--- a/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
@@ -6,6 +6,35 @@ import CabalmailKit
 /// to keep the type body under the SwiftLint length ceiling. Everything
 /// here is `@MainActor` by inheritance from the host class.
 extension ComposeViewModel {
+    // MARK: - Editor bridge health
+
+    /// Banner copy for a dead editor bridge. One phrasing for both the
+    /// compose-open announcement and the send refusal, so recovery can
+    /// recognize (and clear) the message it put up.
+    static func editorUnavailableMessage(_ reason: String) -> String {
+        "The message editor didn't load (\(reason)). Nothing can be sent from this "
+            + "window — copy anything you still need, close it, and compose again."
+    }
+
+    /// The bridge reported itself unusable. Raise the banner now, at
+    /// compose-open, rather than leaving the user to discover it by
+    /// pressing Send and watching nothing happen (#812).
+    func noteEditorUnavailable(_ reason: String) {
+        editorUnavailable = reason
+        errorMessage = Self.editorUnavailableMessage(reason)
+    }
+
+    /// The bridge came up after all. Clears the banner, but only the one
+    /// this failure raised — a send or address error reported since then is
+    /// still the more useful message to leave on screen.
+    func noteEditorRecovered() {
+        guard let reason = editorUnavailable else { return }
+        editorUnavailable = nil
+        if errorMessage == Self.editorUnavailableMessage(reason) {
+            errorMessage = nil
+        }
+    }
+
     // MARK: - Attachments
 
     /// Add an already-loaded file (raw bytes + mime type) as an attachment.

--- a/apple/Cabalmail/ViewModels/ComposeViewModel.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel.swift
@@ -66,6 +66,15 @@ final class ComposeViewModel {
     var availableAddresses: [Address] = []
     var isSending = false
     var errorMessage: String?
+    /// Non-nil while the WebKit editor bridge is known to be unusable,
+    /// mirroring `RichTextEditorController.bridgeFailure` — the controller
+    /// is a plain `NSObject`, so SwiftUI can't observe its state directly.
+    /// Every body conversion answers `""` from that point on, so nothing can
+    /// be sent: this keeps Send disabled and the banner up (#812). Mutated
+    /// only by the `noteEditorUnavailable` / `noteEditorRecovered` pair in
+    /// `ComposeViewModel+Internals.swift`, which a `private(set)` here
+    /// would put out of reach.
+    var editorUnavailable: String?
     /// Set to `.queued` when the most recent send dropped the message into
     /// the outbox instead of delivering it. `ComposeView` reads this to
     /// decide whether the dismiss toast should say "Sent" or "Queued — will
@@ -173,7 +182,13 @@ final class ComposeViewModel {
         // the rich pane (and send-time conversion) is out of commission
         // for this compose. Say so instead of failing silently (#734).
         self.editorController.onBridgeError = { [weak self] message in
-            self?.errorMessage = "Rich-text editor failed to load: \(message)"
+            self?.noteEditorUnavailable(message)
+        }
+        // A `ready` that lands after the failure means the boot was merely
+        // slow; the controller has already cleared its own failure, so drop
+        // the banner and re-enable Send rather than stranding the compose.
+        self.editorController.onReady = { [weak self] in
+            self?.noteEditorRecovered()
         }
     }
 
@@ -254,8 +269,11 @@ final class ComposeViewModel {
         composeIntent == .reply || composeIntent == .replyAll
     }
 
-    /// Is the form complete enough to enable the Send button?
+    /// Is the form complete enough to enable the Send button? A dead editor
+    /// bridge disables it too: the body can't be assembled, so the send
+    /// would only be refused (#745) — better not to offer the tap (#812).
     var canSend: Bool {
+        guard editorUnavailable == nil else { return false }
         guard fromAddress != nil, !subject.isEmpty else { return false }
         return !parseRecipients(toText).isEmpty
             || !parseRecipients(ccText).isEmpty
@@ -320,6 +338,13 @@ final class ComposeViewModel {
     }
 
     func send() async -> Bool {
+        // Checked ahead of `canSend` so a tap that races the bridge dying
+        // gets the real reason instead of the generic form complaint —
+        // silence here is what made a dead bridge look like a dead button.
+        if let reason = editorUnavailable {
+            errorMessage = Self.editorUnavailableMessage(reason)
+            return false
+        }
         guard canSend, let fromEmail = currentFromEmail() else {
             if fromAddress != nil { errorMessage = "Invalid From address." }
             return false
@@ -333,8 +358,7 @@ final class ComposeViewModel {
             // deliver an empty message the user had written text into, so
             // refuse and leave the window open (#745).
             if let failure = editorController.bridgeFailure {
-                errorMessage = "Can't prepare the message body — \(failure). "
-                    + "Copy anything you still need before closing this window."
+                noteEditorUnavailable(failure)
                 return false
             }
             // Send-from-draft cleans up the server copy after delivery

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -305,6 +305,18 @@ extension ComposeView {
     private var composeForm: some View {
         @Bindable var model = model
         return Form {
+            // First section on purpose. As the last one it sat below the
+            // body editor, off the bottom of an iPhone screen, and the
+            // WKWebView swallows the pan that would scroll down to it — so
+            // a send-blocking error was invisible and Send looked dead
+            // (#812). macOS pins the same text to the window bottom, which
+            // is always on screen there.
+            if let errorMessage = model.errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                }
+            }
             Section("From") {
                 FromPicker(
                     model: model,
@@ -348,12 +360,6 @@ extension ComposeView {
                     if model.attachmentTotalExceedsWarning {
                         attachmentSizeWarning
                     }
-                }
-            }
-            if let errorMessage = model.errorMessage {
-                Section {
-                    Label(errorMessage, systemImage: "exclamationmark.triangle")
-                        .foregroundStyle(.red)
                 }
             }
         }

--- a/apple/CabalmailTests/ComposeBridgeFailureTests.swift
+++ b/apple/CabalmailTests/ComposeBridgeFailureTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+/// Compose behaviour when the WebKit editor bridge is dead.
+///
+/// The send-side guard (#745) already refuses to ship a body that converted
+/// to `""`, but it refused *silently*: Send stayed enabled, the tap did
+/// nothing visible, and the user reasonably concluded the message had gone
+/// (#812). These cover the announcement half — the banner goes up when the
+/// bridge reports the failure, Send stops being offered, a tap that races
+/// the failure still explains itself, and a late `ready` undoes all of it.
+@MainActor
+final class ComposeBridgeFailureTests: XCTestCase {
+    /// A compose filled in far enough that only the editor's health is
+    /// left to decide whether Send is offered.
+    private func makeFilledModel() throws -> ComposeViewModel {
+        let model = try TestFixtures.makeComposeModel()
+        model.fromAddress = "sender@cabalmail.example"
+        model.subject = "Bridge health"
+        model.toText = "recipient@example.com"
+        return model
+    }
+
+    func testFilledFormOffersSend() throws {
+        let model = try makeFilledModel()
+        XCTAssertTrue(model.canSend)
+    }
+
+    func testBridgeFailureRaisesBannerAndWithdrawsSend() throws {
+        let model = try makeFilledModel()
+        model.noteEditorUnavailable("failed to load editor-bridge.js")
+
+        XCTAssertFalse(model.canSend, "Send must not stay enabled with no way to build a body")
+        let message = try XCTUnwrap(model.errorMessage)
+        XCTAssertTrue(message.contains("editor didn't load"), message)
+        XCTAssertTrue(message.contains("failed to load editor-bridge.js"), message)
+    }
+
+    func testSendRefusesAndSaysWhy() async throws {
+        let model = try makeFilledModel()
+        model.noteEditorUnavailable("the editor did not finish loading")
+
+        let sent = await model.send()
+
+        XCTAssertFalse(sent)
+        XCTAssertEqual(
+            model.errorMessage,
+            ComposeViewModel.editorUnavailableMessage("the editor did not finish loading")
+        )
+    }
+
+    func testLateReadyClearsBannerAndRestoresSend() throws {
+        let model = try makeFilledModel()
+        model.noteEditorUnavailable("the editor did not finish loading")
+
+        model.noteEditorRecovered()
+
+        XCTAssertNil(model.errorMessage)
+        XCTAssertTrue(model.canSend)
+    }
+
+    /// Recovery only retracts its own banner — an error raised since the
+    /// bridge failed is still the message worth leaving on screen.
+    func testLateReadyKeepsAnUnrelatedError() throws {
+        let model = try makeFilledModel()
+        model.noteEditorUnavailable("the editor did not finish loading")
+        model.errorMessage = "Couldn't load addresses: network error"
+
+        model.noteEditorRecovered()
+
+        XCTAssertEqual(model.errorMessage, "Couldn't load addresses: network error")
+    }
+}

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -212,6 +212,22 @@ enum TestFixtures {
         return model
     }
 
+    /// Compose model over the fake transport, with a scratch draft store.
+    /// A real `RichTextEditorController` (and its WKWebView) comes up inside
+    /// it; the bridge-health tests drive the failure hooks directly rather
+    /// than depending on whether `editor.html` loads in the test host.
+    @MainActor
+    static func makeComposeModel(imap: FakeImapClient = FakeImapClient()) throws -> ComposeViewModel {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cabalmail-compose-tests-\(UUID().uuidString)")
+        return ComposeViewModel(
+            client: try makeClient(imap: imap),
+            draftStore: try DraftStore(directory: tmp),
+            preferences: Preferences(store: InMemoryPreferenceStore()),
+            onClose: {}
+        )
+    }
+
     static func makeEnvelope(uid: UInt32, flags: Set<Flag> = []) -> Envelope {
         Envelope(
             uid: uid,

--- a/changelog.d/compose-dead-editor-bridge-feedback.fixed.md
+++ b/changelog.d/compose-dead-editor-bridge-feedback.fixed.md
@@ -1,0 +1,6 @@
+- Apple: **Silent Send when the message editor fails to load.** Compose now
+  announces a dead editor bridge the moment the window opens and stops
+  offering Send, instead of leaving an enabled button whose taps did nothing
+  — the send was already being refused, just invisibly. On iPhone the compose
+  error banner also moved to the top of the form, where it can no longer hide
+  below the body editor.


### PR DESCRIPTION
Addresses #812.

## What was wrong

With the compose editor's WebKit bridge dead (fault injection: delete
`editor-bridge.js` from the installed `.app`; a user reaches the same state
when the bridge fails to boot or the content process dies), filling in From /
To / Subject and tapping **Send** did nothing at all. No banner, no toast, no
alert, no dismissal, Send stayed enabled — and the message was neither sent nor
saved as a draft. The user reasonably concludes it went.

## Root cause

Two halves, both presentation:

1. **The banner was below the fold.** `onBridgeError` already set
   `errorMessage` at compose-open (#734), and `send()` set it again on refusal
   (#745) — but on iPhone that text renders as the **last** `Section` of the
   compose `Form`, below the body editor and off the bottom of the screen. The
   `WKWebView` in the Message section swallows the pan that would scroll down
   to it, so the section is never realized (hence its absence from
   `idb ui describe-all`, which the issue reasonably read as "no error exists").
2. **Send kept offering a tap it could only refuse.** `canSend` doesn't know
   about the editor, and `RichTextEditorController` is a plain `NSObject`, so
   SwiftUI can't observe `bridgeFailure` to react to it.

## The fix

- `ComposeViewModel.editorUnavailable` mirrors `bridgeFailure` as observable
  state, set from the existing `onBridgeError` hook and cleared from a newly
  wired `onReady` — a late `ready` means the boot was merely slow, so the
  compose recovers instead of being stranded with Send off.
- `canSend` is false while the editor is unavailable: the body can't be
  assembled, so the tap is no longer offered.
- `send()` checks it ahead of `canSend` and restates the reason, so a tap that
  races the bridge dying still gets the real explanation rather than the
  generic form complaint.
- The iPhone/iPad error banner moves to the **top** of the compose form, where
  it is on screen the moment compose opens. macOS already pins the same text to
  the window bottom, which is always visible there, so `macLayout` is unchanged.
- Copy is now actionable and shared by both paths: "The message editor didn't
  load (<reason>). Nothing can be sent from this window — copy anything you
  still need, close it, and compose again."

The underlying refusal is unchanged: nothing new is sent, and no empty body can
reach the server.

## Test evidence

New `apple/CabalmailTests/ComposeBridgeFailureTests.swift` (5 cases, app-target
XCTest via the `CabalmailMac` scheme), plus a `makeComposeModel` fixture — the
first `ComposeViewModel` harness, built on the existing `TestFixtures.makeClient`.

Fails before / passes after, with the pre-fix behaviour shimmed back in so the
old code compiles against the new tests:

```
before:  Executed 5 tests, with 4 failures     (only the "filled form offers
         Send" control passes, as it should)
after:   Executed 5 tests, with 0 failures
full:    ** TEST SUCCEEDED **  (whole CabalmailMacTests suite)
swiftlint --strict: clean
```

Live repro on the iPhone 17 sim (iOS 26.5) against this build, using the
issue's own fault injection — banner visible at the top the moment compose
opens, Send greyed out:

- before: the issue's `logs/0727-ios-17-deadbridge-send-5s.png` (nothing at all)
- after: `/tmp/fixer812-02-compose.png` on the fixer box — red
  "The message editor didn't load (failed to load editor-bridge.js) …" banner
  above the From picker, **Send** dimmed. Tester's build restored on the sim
  afterwards.

## Note

The issue also asks whether the failure should be announced at compose-open
rather than only at send — it now is, which is the half that makes the typed
body recoverable (copy before closing). Persisting the typed body through a
dead bridge is a bigger change (the markdown pane is native and already
autosaves; the rich pane's text lives only inside the dead WebView) and is not
attempted here.