### PR TITLE
Send: commit pending recipient text before validating

### DIFF
--- a/changelog.d/compose-pending-recipient.fixed.md
+++ b/changelog.d/compose-pending-recipient.fixed.md
@@ -1,0 +1,7 @@
+- **First Send click with an uncommitted recipient in the React composer.**
+  Typing an address and clicking Send without first pressing Enter was
+  rejected with "Please specify at least one recipient." even though the
+  address was visibly in the field, and an uncommitted second address was
+  dropped from the message entirely. Send now folds the pending input text
+  into the recipient lists before validating and sending, and commits it to
+  the row it was typed in rather than always to To.

--- a/react/admin/src/Email/ComposeOverlay/ComposeOverlay.test.jsx
+++ b/react/admin/src/Email/ComposeOverlay/ComposeOverlay.test.jsx
@@ -224,6 +224,90 @@ describe('ComposeOverlay', () => {
     }
   });
 
+  // Regression: the recipient input is committed to a chip by the same click
+  // that fires Send, so validating (and sending) the To/CC/BCC state read
+  // pre-flush — the first click was rejected as recipient-less while the
+  // address was on screen, and a second uncommitted address was dropped.
+  describe('uncommitted recipient text', () => {
+    async function fillAndPickFrom() {
+      await waitFor(() => {
+        expect(mockGetAddresses).toHaveBeenCalled();
+      });
+      fireEvent.click(screen.getByLabelText('From'));
+      fireEvent.click(await screen.findByRole('option', { name: /user@test\.com/ }));
+      fireEvent.change(screen.getByLabelText('Subject'), { target: { value: 'hi' } });
+    }
+
+    it('sends on the first click when the address was never committed with Enter', async () => {
+      const { unmount } = renderCompose();
+      try {
+        await fillAndPickFrom();
+        // Typed, then left alone — no Enter, no comma.
+        fireEvent.change(screen.getByLabelText('Recipients'), {
+          target: { value: 'dest@test.com' }
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+        await waitFor(() => {
+          expect(mockSendMessage).toHaveBeenCalled();
+        });
+        expect(mockSendMessage.mock.calls[0][2]).toEqual(['dest@test.com']);
+        expect(setMessage).not.toHaveBeenCalledWith(
+          'Please specify at least one recipient.', true
+        );
+      } finally {
+        unmount();
+      }
+    });
+
+    it('keeps an uncommitted second recipient in the sent message', async () => {
+      const { unmount } = renderCompose();
+      try {
+        await fillAndPickFrom();
+        const toInput = screen.getByLabelText('Recipients');
+        fireEvent.change(toInput, { target: { value: 'first@test.com' } });
+        fireEvent.keyDown(toInput, { key: 'Enter' });
+        fireEvent.change(toInput, { target: { value: 'second@test.com' } });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+        await waitFor(() => {
+          expect(mockSendMessage).toHaveBeenCalled();
+        });
+        expect(mockSendMessage.mock.calls[0][2]).toEqual(['first@test.com', 'second@test.com']);
+      } finally {
+        unmount();
+      }
+    });
+
+    it('commits uncommitted Bcc text to Bcc, not To', async () => {
+      const { unmount } = renderCompose();
+      try {
+        await fillAndPickFrom();
+        const toInput = screen.getByLabelText('Recipients');
+        fireEvent.change(toInput, { target: { value: 'dest@test.com' } });
+        fireEvent.keyDown(toInput, { key: 'Enter' });
+
+        fireEvent.click(screen.getByRole('button', { name: /Cc Bcc/ }));
+        fireEvent.change(screen.getByLabelText('Bcc'), {
+          target: { value: 'blind@test.com' }
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+        await waitFor(() => {
+          expect(mockSendMessage).toHaveBeenCalled();
+        });
+        const args = mockSendMessage.mock.calls[0];
+        expect(args[2]).toEqual(['dest@test.com']);
+        expect(args[4]).toEqual(['blind@test.com']);
+      } finally {
+        unmount();
+      }
+    });
+  });
+
   it('offsets the second compose window by stackIndex', async () => {
     const { container, unmount } = renderCompose({ stackIndex: 1 });
     try {

--- a/react/admin/src/Email/ComposeOverlay/index.jsx
+++ b/react/admin/src/Email/ComposeOverlay/index.jsx
@@ -50,6 +50,32 @@ const MESSAGE = {
   }
 };
 
+const ADDRESS_RE = /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
+
+function isValidAddress(addr) {
+  return addr.match(ADDRESS_RE);
+}
+
+// Fold text still sitting in the recipient input into the recipient lists.
+// The To/Cc/Bcc rows share one input state, so uncommitted text belongs to
+// whichever row it was typed in — `fieldId` names that row. Returns the
+// lists as they read once the text is committed, which is what Send has to
+// validate and ship: the click that fires Send also flushes the pending
+// text, but that setState has not landed yet, so the To/CC/BCC it closes
+// over still read pre-flush.
+function withPendingRecipient(lists, pending, fieldId) {
+  if (!pending || !isValidAddress(pending)) return lists;
+  if ([...lists.to, ...lists.cc, ...lists.bcc].indexOf(pending) > -1) return lists;
+  switch (fieldId) {
+    case "recipient-cc":
+      return { ...lists, cc: [...lists.cc, pending] };
+    case "recipient-bcc":
+      return { ...lists, bcc: [...lists.bcc, pending] };
+    default:
+      return { ...lists, to: [...lists.to, pending] };
+  }
+}
+
 function MenuBar({ editor, onImportMarkdown }) {
   if (!editor) return null;
 
@@ -172,6 +198,9 @@ function ComposeOverlay({
   const [addressItems, setAddressItems] = useState([]);
   const [address, setAddress] = useState(composeFromAddress || "");
   const [recipient, setRecipient] = useState("");
+  // Which row the shared recipient input is currently being typed into, so
+  // Send commits pending text back to that row rather than assuming To.
+  const [recipientField, setRecipientField] = useState("recipient-to");
   const [validationFail, setValidationFail] = useState(false);
   const [To, setTo] = useState([]);
   const [CC, setCC] = useState([]);
@@ -583,33 +612,18 @@ function ComposeOverlay({
     return str;
   }, []);
 
-  const validateAddress = useCallback((addr) => {
-    const re = /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
-    return addr.match(re);
-  }, []);
-
   const addRecipient = useCallback((e) => {
-    if (validateAddress(recipient)) {
-      const unionList = [...To, ...CC, ...BCC];
-      if (unionList.indexOf(recipient) > -1) return;
-      switch (e.target.id) {
-        case "recipient-to":
-          setTo(prev => [...prev, recipient]);
-          break;
-        case "recipient-cc":
-          setCC(prev => [...prev, recipient]);
-          break;
-        case "recipient-bcc":
-          setBCC(prev => [...prev, recipient]);
-          break;
-        default:
-          setTo(prev => [...prev, recipient]);
-      }
-      setRecipient("");
-    } else {
+    if (!isValidAddress(recipient)) {
       setValidationFail(true);
+      return;
     }
-  }, [recipient, To, CC, BCC, validateAddress]);
+    if ([...To, ...CC, ...BCC].indexOf(recipient) > -1) return;
+    const next = withPendingRecipient({ to: To, cc: CC, bcc: BCC }, recipient, e.target.id);
+    setTo(next.to);
+    setCC(next.cc);
+    setBCC(next.bcc);
+    setRecipient("");
+  }, [recipient, To, CC, BCC]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -644,10 +658,15 @@ function ComposeOverlay({
       message_id: msgid.map(s => s.trim()),
       references: ref.map(s => s.trim())
     };
+    // Validate and send the lists as they read with the pending input text
+    // folded in — committing it through addRecipient below only updates the
+    // chips on the next render, one step too late for this click.
+    const { to: sendTo, cc: sendCc, bcc: sendBcc } =
+      withPendingRecipient({ to: To, cc: CC, bcc: BCC }, recipient, recipientField);
     if (recipient) {
-      addRecipient(MESSAGE);
+      addRecipient({ target: { id: recipientField } });
     }
-    if (To.length + CC.length + BCC.length === 0) {
+    if (sendTo.length + sendCc.length + sendBcc.length === 0) {
       setMessage("Please specify at least one recipient.", true);
       return;
     }
@@ -703,7 +722,7 @@ function ComposeOverlay({
         }));
       }
       await api.sendMessage(
-        effectiveSmtpHost, address, To, CC, BCC, Subject, headers,
+        effectiveSmtpHost, address, sendTo, sendCc, sendBcc, Subject, headers,
         htmlBody, textBody, false, wireAttachments,
         // If autosave wrote a Drafts copy, ask /send to expunge it after
         // successful delivery so the stale draft doesn't linger. Best
@@ -722,7 +741,7 @@ function ComposeOverlay({
       setSending(false);
       console.log(err);
     });
-  }, [other_headers, effectiveSmtpHost, recipient, To, CC, BCC, Subject, address, addresses,
+  }, [other_headers, effectiveSmtpHost, recipient, recipientField, To, CC, BCC, Subject, address, addresses,
       editor, markdownContent, attachments, api, hide, setMessage, addRecipient, randomString]);
 
   // Close-without-send: match the Apple compose flow and always attempt a
@@ -804,8 +823,9 @@ function ComposeOverlay({
     return `${(n / (1024 * 1024)).toFixed(1)} MB`;
   }, []);
 
-  const onRecipientChange = (e) => {
+  const onRecipientChange = (e, fieldId) => {
     setRecipient(e.target.value);
+    setRecipientField(fieldId);
     setValidationFail(false);
   };
 
@@ -819,10 +839,11 @@ function ComposeOverlay({
     }
   };
 
-  const removeRecipient = useCallback((list, setList, e) => {
+  const removeRecipient = useCallback((list, setList, fieldId, e) => {
     const addr = e.target.value;
     setList(prev => prev.filter(a => a !== addr));
     setRecipient(addr);
+    setRecipientField(fieldId);
   }, []);
 
   // Root-level keyboard handler: Cmd/Ctrl+Enter sends, Esc minimizes.
@@ -862,7 +883,7 @@ function ComposeOverlay({
         className="recipient-chip__remove"
         onClick={(e) => removeRecipient(
           listName === 'To' ? To : listName === 'CC' ? CC : BCC,
-          setList, e
+          setList, `recipient-${listName.toLowerCase()}`, e
         )}
         value={addr}
         aria-label={`Remove ${addr}`}
@@ -964,7 +985,7 @@ function ComposeOverlay({
               id={`compose-to-${stackIndex}`}
               type="email"
               aria-label="Recipients"
-              onChange={onRecipientChange}
+              onChange={(e) => onRecipientChange(e, 'recipient-to')}
               onKeyDown={handleKeyDown}
               value={recipient}
               className={`recipient-input${validationFail ? " recipient-input--invalid" : ""}`}
@@ -990,7 +1011,7 @@ function ComposeOverlay({
                 <input
                   id={`compose-cc-${stackIndex}`}
                   type="email"
-                  onChange={onRecipientChange}
+                  onChange={(e) => onRecipientChange(e, 'recipient-cc')}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ' || e.key === ';' || e.key === ',') {
                       e.preventDefault();
@@ -1012,7 +1033,7 @@ function ComposeOverlay({
                 <input
                   id={`compose-bcc-${stackIndex}`}
                   type="email"
-                  onChange={onRecipientChange}
+                  onChange={(e) => onRecipientChange(e, 'recipient-bcc')}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ' || e.key === ';' || e.key === ',') {
                       e.preventDefault();


### PR DESCRIPTION
Addresses #816.

## What was wrong

Typing an address into **To** and clicking **Send** without first pressing
Enter is rejected with *"Please specify at least one recipient."* while the
address is sitting in the field. The same click renders the chip, so the
error and the recipient are on screen together, and a second click sends.

A silent variant of the same defect: with a recipient already committed, a
second address left uncommitted in the input is **dropped from the sent
message** — no error, the mail just goes to one recipient.

## Root cause

The three recipient rows share one `recipient` input state, and `handleSend`
flushes it with `addRecipient(MESSAGE)` and then reads `To`/`CC`/`BCC` from
the *same* render. React has not re-rendered yet, so validation (and the
`/send` payload) see the pre-flush lists — the chip appears one render later,
which is exactly the "chip and error together" the report describes.

## The fix

`withPendingRecipient()` derives the lists as they read with the pending text
folded in; `handleSend` validates and ships those, and `addRecipient` uses the
same helper so there is one commit rule. This also covers the dropped-second-
recipient variant, which no amount of re-clicking Send would have fixed.

The pending text now commits to the row it was typed in (`recipientField`,
set by the input's `onChange` and by chip removal) instead of the hard-coded
To. That is not a drive-by: once Send actually *ships* pending text, routing
it to To unconditionally would put a half-typed **Bcc** address into the
visible To header. Today that address is merely lost, so the routing had to
land with the flush fix, not after it.

Not changed: **commit-on-blur**, the other half of the issue's "two separate
places worth deciding on". Send now consumes what is visibly in the field,
which is the reported failure; committing on blur is a UX behaviour change
that also fires when the user tabs away mid-address (chipping a partial
address, or tripping the invalid-input state on the way to the Cc toggle).
Happy to do it as a follow-up if you want the chip to appear on blur.

## Test evidence

Three Vitest regressions in `ComposeOverlay.test.jsx`, all failing before the
change and passing after:

```
× sends on the first click when the address was never committed with Enter
    → expected "vi.fn()" [sendMessage] to be called at least once
× keeps an uncommitted second recipient in the sent message
    → expected [ 'first@test.com' ] to deeply equal [ 'first@test.com', 'second@test.com' ]
× commits uncommitted Bcc text to Bcc, not To
    → expected [] to deeply equal [ 'blind@test.com' ]
```

Full suite after the fix: **375 passed (38 files)**; `eslint` clean on the
changed directory.

Live repro against a local dev build of this branch, driven with Playwright
through the issue's exact steps (type `daily@qa0722.cabal-mail.com` in To
with no Enter, subject, body, one Send click):

```
to-input before send: daily@qa0722.cabal-mail.com
FIRST CLICK RESULT: sent
```

"Email sent", composer closed, no error toast. (The dev server is a different
origin from the stage API, so that run needed `--disable-web-security` in the
browser — a harness detail, no app code is conditional on it.)