### PR TITLE
iPad multi-select: drive selection mode from the view model

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Bulk.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Bulk.swift
@@ -28,6 +28,15 @@ extension MessageListViewModel {
         selectedUIDs.removeAll()
     }
 
+    /// Leave selection mode without touching the selection. The bulk move /
+    /// dispose paths hand their UIDs to an async `Task` and clear the set
+    /// themselves once it has read them, so the view dropping the mode
+    /// straight after must not clear it here — that would race the read and
+    /// move nothing.
+    func leaveBulkMode() {
+        bulkMode = false
+    }
+
     /// Flip an envelope's membership in the selection set.
     func toggleSelection(_ envelope: Envelope) {
         if selectedUIDs.contains(envelope.uid) {

--- a/apple/Cabalmail/Views/MessageListView+Bulk.swift
+++ b/apple/Cabalmail/Views/MessageListView+Bulk.swift
@@ -6,73 +6,46 @@ import CabalmailKit
 // destination sheet. Lives in a sibling extension so MessageListView's
 // primary body stays under SwiftLint's `type_body_length` cap.
 extension MessageListView {
-    /// Toolbar item that flips edit mode. Reads "Select" when off and
-    /// "Done" while on, matching every other iOS list-edit affordance.
+    /// Toolbar item that flips the multi-select mode. Reads "Select" when off
+    /// and "Done" while on, matching every other iOS list-edit affordance.
     ///
     /// macOS multi-selects via pointer modifier-clicks (shift / command)
-    /// directly in the list, so it shows no button. iPad / visionOS toggle the
-    /// native list EditMode so touch users can multi-select without a keyboard;
-    /// compact iPhone keeps the legacy `bulkMode` checkbox flow.
+    /// directly in the list, so it shows no button. Every touch layout —
+    /// compact iPhone and wide iPad / visionOS alike — drives the view model's
+    /// `bulkMode`: the rows are a hand-rolled `LazyVStack`, so there is no
+    /// native list EditMode to enter, and view-local `@State` would not
+    /// survive the split view rebuilding its content column.
     @ViewBuilder
     var selectButton: some View {
         #if os(macOS)
         EmptyView()
         #else
         if let model {
-            if isWideLayout {
-                Button {
-                    toggleSelectionEditMode(model: model)
-                } label: {
-                    if editMode == .active {
-                        Text("Done")
-                    } else {
-                        Image(systemName: "checkmark.circle")
-                            .accessibilityLabel("Select")
-                    }
-                }
-            } else {
-                Button {
-                    model.toggleBulkMode()
-                } label: {
-                    if model.bulkMode {
-                        Text("Done")
-                    } else {
-                        Image(systemName: "checkmark.circle")
-                            .accessibilityLabel("Select")
-                    }
+            Button {
+                model.toggleBulkMode()
+            } label: {
+                if model.bulkMode {
+                    Text("Done")
+                } else {
+                    Image(systemName: "checkmark.circle")
+                        .accessibilityLabel("Select")
                 }
             }
         }
         #endif
     }
 
-    #if !os(macOS)
-    /// Enter / leave the native multi-select EditMode on wide touch layouts.
-    /// Leaving clears the selection so re-entering starts fresh, mirroring
-    /// `toggleBulkMode()`'s contract on compact.
-    private func toggleSelectionEditMode(model: MessageListViewModel) {
-        if editMode == .active {
-            editMode = .inactive
-            model.selectedUIDs.removeAll()
-        } else {
-            editMode = .active
-        }
-    }
-    #endif
-
     /// Called when a bulk move / dispose commits — the actions that remove
-    /// the selected rows. The action itself clears `selectedUIDs` (via
-    /// `exitBulkMode()`); this additionally drops any touch EditMode so the
-    /// action bar dismisses on iPad / visionOS. No-op on macOS, which has no
-    /// EditMode. The read/unread and flag buttons deliberately skip it:
-    /// their rows stay on screen, and keeping the selection lets the user
-    /// chain another action onto the same messages. Internal (not private)
-    /// so `commitDispose` in `+Actions.swift` can drop the mode after a
-    /// confirmed large dispose.
+    /// the selected rows. Drops the mode so the action bar dismisses; the
+    /// action itself clears `selectedUIDs` once its async body has read them
+    /// (`leaveBulkMode` deliberately leaves the set alone, since this runs
+    /// before the `Task` that does the moving). The read/unread and flag
+    /// buttons deliberately skip it: their rows stay on screen, and keeping
+    /// the selection lets the user chain another action onto the same
+    /// messages. Internal (not private) so `commitDispose` in
+    /// `+Actions.swift` can drop the mode after a confirmed large dispose.
     func endSelectionMode() {
-        #if !os(macOS)
-        editMode = .inactive
-        #endif
+        model?.leaveBulkMode()
     }
 
     /// Bottom action bar rendered in `safeAreaInset` while bulkMode is

--- a/apple/Cabalmail/Views/MessageListView+Rows.swift
+++ b/apple/Cabalmail/Views/MessageListView+Rows.swift
@@ -37,14 +37,11 @@ extension MessageListView {
         let isChecked = model.selectedUIDs.contains(envelope.uid)
         withRowContextMenu(for: envelope, model: model) {
             Group {
-                if isWideLayout {
-                    wideRow(
-                        for: envelope,
-                        isSelected: isSelected,
-                        model: model,
-                        orderedVisible: orderedVisible
-                    )
-                } else if bulkMode {
+                // Selection mode first, on every touch layout: the checkbox
+                // row is what makes multi-select visible, and the wide row
+                // can't draw it (it leans on a native list's selection
+                // circles, which the virtualized `LazyVStack` doesn't have).
+                if bulkMode {
                     // No .tag() while in bulk mode — the list's selection
                     // binding drives the detail pane, and we don't want a
                     // checkbox tap to also pop the reader.
@@ -54,6 +51,13 @@ extension MessageListView {
                         MessageRow(envelope: envelope, isSelected: isChecked, isChecked: isChecked, bulkMode: true)
                     }
                     .buttonStyle(.plain)
+                } else if isWideLayout {
+                    wideRow(
+                        for: envelope,
+                        isSelected: isSelected,
+                        model: model,
+                        orderedVisible: orderedVisible
+                    )
                 } else {
                     MessageRow(envelope: envelope, isSelected: isSelected, isChecked: false, bulkMode: false)
                         .tag(envelope)
@@ -91,9 +95,9 @@ extension MessageListView {
         }
     }
 
-    /// The wide-layout (native multi-select) row: a UID-tagged `MessageRow` so
-    /// the list's `Set<UInt32>` binding owns selection and the system draws the
-    /// highlight (and selection circles in iPad edit mode). `isSelected` is set
+    /// The wide-layout single-selection row: a UID-tagged `MessageRow` whose
+    /// highlight follows `selectedUIDs`. Multi-select does NOT come through
+    /// here — `bulkMode` takes the checkbox branch above. `isSelected` is set
     /// membership, used only to keep the unread dot legible. On iOS it also
     /// carries the hardware-keyboard shift / command-click handling SwiftUI
     /// doesn't wire into the native list there; plain taps fall through to the

--- a/apple/Cabalmail/Views/MessageListView+Selection.swift
+++ b/apple/Cabalmail/Views/MessageListView+Selection.swift
@@ -475,28 +475,19 @@ extension MessageListView {
 
     /// The bottom bulk-action bar shows whenever a real multi-selection exists
     /// (two or more) - a single selection uses the reading pane and its own
-    /// toolbar. On iPad / visionOS it also shows while the Select edit mode is
-    /// active so the bar is reachable before any row is picked. Compact iPhone
-    /// keeps the explicit `bulkMode` gate.
+    /// toolbar. Touch layouts also show it while the Select mode is active so
+    /// the bar is reachable before any row is picked.
     func showsBulkActionBar(model: MessageListViewModel) -> Bool {
-        guard isWideLayout else { return model.bulkMode }
-        #if os(macOS)
-        return model.selectedUIDs.count >= 2
-        #else
-        return model.selectedUIDs.count >= 2 || editMode == .active
-        #endif
+        if model.bulkMode { return true }
+        return isWideLayout && model.selectedUIDs.count >= 2
     }
 
     /// Esc clears the selection and exits any touch edit mode. Returns
     /// `.ignored` when there's nothing to clear so the key can do other things.
     func escapePressed(model: MessageListViewModel) -> KeyPress.Result {
         let hadSelection = !model.selectedUIDs.isEmpty
-        #if !os(macOS)
-        let wasEditing = editMode == .active
-        editMode = .inactive
-        #else
-        let wasEditing = false
-        #endif
+        let wasEditing = model.bulkMode
+        model.leaveBulkMode()
         guard hadSelection || wasEditing else { return .ignored }
         model.selectedUIDs.removeAll()
         model.selectionAnchor = nil

--- a/apple/Cabalmail/Views/MessageListView.swift
+++ b/apple/Cabalmail/Views/MessageListView.swift
@@ -126,15 +126,6 @@ struct MessageListView: View {
     /// keys from the search field. Set true when a row is clicked. Non-private
     /// so the `+Selection` extension can drive it.
     @FocusState var listFocused: Bool
-    #if !os(macOS)
-    /// Drives the native multi-select edit mode on wide touch layouts (iPad,
-    /// visionOS): the Select button toggles it, and while active the system
-    /// draws selection circles and taps toggle membership in `selectedUIDs`.
-    /// Non-private so the `+Bulk` extension's `selectButton` can flip it.
-    /// macOS has no `EditMode` (pointer shift/command-clicks cover multi-
-    /// select), so this is compiled out there.
-    @State var editMode: EditMode = .inactive
-    #endif
 
     // `body` was a single ~200-line modifier chain; once the sheets, the
     // purge confirmation, and the signal observers were all attached,

--- a/apple/CabalmailTests/BulkSelectionTests.swift
+++ b/apple/CabalmailTests/BulkSelectionTests.swift
@@ -54,6 +54,22 @@ final class BulkSelectionTests: XCTestCase {
         XCTAssertTrue(model.selectedUIDs.isEmpty)
     }
 
+    func testLeaveBulkModeKeepsTheSelection() throws {
+        let model = try TestFixtures.makeModel(
+            imap: FakeImapClient(),
+            envelopes: [TestFixtures.makeEnvelope(uid: 1)]
+        )
+        model.bulkMode = true
+        model.selectedUIDs = [1]
+        // `endSelectionMode()` runs synchronously right after the view kicks
+        // off `Task { await model.bulkMove(...) }`, and that task reads
+        // `selectedUIDs` when it starts — so dropping the mode must not clear
+        // the set, or the move would run against an empty selection.
+        model.leaveBulkMode()
+        XCTAssertFalse(model.bulkMode)
+        XCTAssertEqual(model.selectedUIDs, [1])
+    }
+
     // MARK: - Optimistic flag state
 
     func testSetSeenAppliesAndStaysOnSuccess() async throws {

--- a/changelog.d/ipad-select-multi-select.fixed.md
+++ b/changelog.d/ipad-select-multi-select.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Multi-select on iPad and Vision Pro.** The message list's Select
+  button did nothing on wide layouts, leaving bulk Archive / Move / Mark
+  read-unread / Flag unreachable there — it drove a view-local `EditMode`
+  that the virtualized list has no way to render. Every touch layout now
+  shares the checkbox selection mode iPhone already used.


### PR DESCRIPTION
Addresses #817.

## What was wrong

On iPad the message list's **Select** button does nothing: no Done, no
checkboxes, no bulk action bar. Every bulk operation the iPhone offers is
unreachable there, and (per the issue) leading-edge swipe is already dead in
the split view, so there is no alternative route.

## Root cause

`selectButton` had a wide-layout branch that flipped `MessageListView`'s
local `@State editMode`. Two independent things are wrong with that:

1. **Nothing renders it.** The wide row hard-codes
   `MessageRow(..., isChecked: false, bulkMode: false)` and leans on a native
   `List` selection binding to draw the circles — but the list is no longer a
   `List`. The virtualization rewrite made it a `ScrollView` + `LazyVStack`
   (its own doc comment still says "native multi-select … is Stage B"), and
   `EditMode` has nothing to drive in a hand-rolled stack.
2. **The flip doesn't even land.** If it did, the label would read "Done"
   and `showsBulkActionBar` (`editMode == .active`) would raise the bar. On a
   fresh iPad sim it stays "Select" through three taps — while the two
   controls beside it, hit-tested from the same AX frames, both respond.

So the mechanism was inert twice over. macOS was unaffected: it shows no
button and multi-selects with modifier-clicks.

## The fix

Route every touch layout through the view model's `bulkMode` — the state
iPhone already used, which the checkbox row and the action bar already read,
and which lives in the model rather than in view-local `@State`:

- `selectButton` drops the wide/compact split and toggles `model.bulkMode`.
- `row(for:)` checks `bulkMode` **before** `isWideLayout`, so the checkbox
  row (the thing that makes selection visible) wins on iPad too.
- `showsBulkActionBar` and `escapePressed` key off `bulkMode`.
- `editMode` is deleted — nothing referenced it any more.

One subtlety: `endSelectionMode()` now calls a new `leaveBulkMode()` instead
of `exitBulkMode()`. It runs synchronously right after the view starts
`Task { await model.bulkMove(...) }`, and that task reads `selectedUIDs` when
it begins — clearing the set there would have moved nothing. The new method
drops the mode and leaves the selection to the action, which clears it when
it completes.

## Test evidence

Device-level before/after on the iPad Pro 11" M5 sim (iPadOS 26.5), same
build settings both runs, resume toast dismissed first so it can't eat a tap:

| | Select ×3 (stage) | Select (this branch) |
|---|---|---|
| Button label | `Select`, `Select`, `Select` | `Done` |
| Checkbox rows | 0 | 3 (`Not selected, …`) |
| Action bar | absent | `0 selected` |

Selecting two rows then reports `2 selected` with `Archive 2 messages`,
`Move 2 messages`, `Mark 2 messages read`, `Flag 2 messages` — the bulk
operations the issue calls unreachable. iPhone 17 sim re-checked for
regression: still `Done` + 3 checkbox rows + `0 selected`, unchanged.

`swiftlint` clean. `CabalmailMacTests` green apart from three **pre-existing**
`HTMLRewriteTests` failures on stage (the rewriter now injects a link-colour
`<style>` the assertions don't expect) — unrelated to this diff, filed
separately as #822.

**On the regression test:** the defect is view composition — a view-local
`@State` and a row branch that cannot draw a checkbox — and the app-target
XCTest suite covers view models, not SwiftUI bodies, so there is no unit test
that fails before and passes after. The before/after sim runs above are the
evidence. The one new invariant this introduces *is* covered:
`testLeaveBulkModeKeepsTheSelection` pins the race described above.

visionOS takes the same wide path and should be fixed by the same change, but
I have no way to run it here — untested.

