### PR TITLE
Split address-row swipe actions across both edges

### DIFF
--- a/apple/Cabalmail/Views/AddressListView.swift
+++ b/apple/Cabalmail/Views/AddressListView.swift
@@ -266,12 +266,19 @@ extension AddressListView {
     private func addressRow(_ address: Address, model: AddressesViewModel) -> some View {
         row(for: address)
             .tag(address)
-            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            // Two edges so neither side outgrows a narrow sidebar pane, and
+            // the full-swipe default is the reversible action (suspend /
+            // reinstate), not revoke. First button listed = full-swipe action.
+            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                suspendToggleButton(address, model: model)
+                    .tint(.orange)
                 Button(role: .destructive) {
                     pendingRevoke = address
                 } label: {
                     Label("Revoke", systemImage: "xmark.bin")
                 }
+            }
+            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                 Button {
                     Task { await model.toggleFavorite(address) }
                 } label: {
@@ -281,8 +288,6 @@ extension AddressListView {
                     )
                 }
                 .tint(address.favorite ? .gray : .yellow)
-                suspendToggleButton(address, model: model)
-                    .tint(.orange)
             }
             .contextMenu {
                 Button {

--- a/changelog.d/address-swipe-two-edges.changed.md
+++ b/changelog.d/address-swipe-two-edges.changed.md
@@ -1,0 +1,6 @@
+- Apple: **Address swipe gestures reorganized.** Swiping an address row
+  left-to-right now reveals suspend/reinstate and revoke, with
+  suspend/reinstate as the full-swipe default (revoke still asks for
+  confirmation); favorite/unfavorite moved to its own right-to-left
+  swipe. Splitting the actions across the two edges also keeps them
+  from overflowing a narrow address pane.


### PR DESCRIPTION
## Summary

Fixes two usability issues with the address-list swipe gestures (reported on macOS, applies to iOS too):

1. **Destructive full-swipe default.** Revoke sat in the full-swipe slot of the single trailing swipe.
2. **Overflow in a narrow pane.** Three stacked actions on one edge exceeded the address pane's width when fully revealed.

Changes to `AddressListView`:

- **Leading swipe (left→right):** suspend/reinstate + revoke, with suspend/reinstate as the full-swipe default. Revoke keeps its confirmation dialog.
- **Trailing swipe (right→left):** favorite/unfavorite only.

Context menu is unchanged. Verified with swiftlint (clean) and a full iOS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)