### PR TITLE
Bundle imapclient deps in suspend_address and reinstate_address zips

### DIFF
--- a/changelog.d/suspend-reinstate-requirements.fixed.md
+++ b/changelog.d/suspend-reinstate-requirements.fixed.md
@@ -1,0 +1,6 @@
+- **`suspend_address` / `reinstate_address` import failure.** Both new
+  Lambdas shipped with an empty `requirements.txt`, so the build bundled
+  `helper.py` (whose `imap_session` dependency imports `imapclient`) without
+  the pinned third-party packages, and every invocation died with
+  `Runtime.ImportModuleError: No module named 'imapclient'`. They now pin
+  the same hashed dependency set as the other helper-importing endpoints.

--- a/lambda/api/reinstate_address/requirements.txt
+++ b/lambda/api/reinstate_address/requirements.txt
@@ -1,0 +1,11 @@
+imapclient==2.3.1 \
+    --hash=sha256:057f28025d2987c63e065afb0e4370b0b850b539b0e1494cea0427e88130108c \
+    --hash=sha256:26ea995664fae3a88b878ebce2aff7402931697b86658b7882043ddb01b0e6ba
+# six is imapclient's only runtime dependency; pinned and hashed so
+# pip --require-hashes can resolve the full tree.
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+dnspython==2.3.0 \
+    --hash=sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46 \
+    --hash=sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9

--- a/lambda/api/suspend_address/requirements.txt
+++ b/lambda/api/suspend_address/requirements.txt
@@ -1,0 +1,11 @@
+imapclient==2.3.1 \
+    --hash=sha256:057f28025d2987c63e065afb0e4370b0b850b539b0e1494cea0427e88130108c \
+    --hash=sha256:26ea995664fae3a88b878ebce2aff7402931697b86658b7882043ddb01b0e6ba
+# six is imapclient's only runtime dependency; pinned and hashed so
+# pip --require-hashes can resolve the full tree.
+six==1.17.0 \
+    --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
+    --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
+dnspython==2.3.0 \
+    --hash=sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46 \
+    --hash=sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9


### PR DESCRIPTION
## Problem

`suspend_address` fails on every invocation:

```
Runtime.ImportModuleError: Unable to import module 'function': No module named 'imapclient'
```

## Root cause

Both `lambda/api/suspend_address/requirements.txt` and `lambda/api/reinstate_address/requirements.txt` were committed **empty**. `build-api-one.sh` skips `pip install` when requirements.txt has no real lines, but still bundles `helper.py` + `imap_session.py` + `imap_pool.py` because `function.py` imports `helper` — and `imap_session.py` imports `imapclient` at module load. So the zip carries the shared modules without their third-party dependency, and the handler dies at import time.

`reinstate_address` has not been reported yet only because it hasn't been invoked; it carries the identical defect, so this PR fixes both.

## Fix

Copy `revoke`'s hash-pinned `requirements.txt` (imapclient 2.3.1, six 1.17.0, dnspython 2.3.0 — the same set every other helper-importing endpoint pins) into both function directories. The `app.yml` lambda-api path filter picks up the change and rebuilds/redeploys both zips.

Includes a `changelog.d` fixed fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)