### PR TITLE
Skip unchanged functions in the lambda-api deploy step

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -648,10 +648,19 @@ jobs:
     # directory unconditionally.
     # Eligibility (skip healthchecks_iac and _* scaffolding, skip
     # functions whose module is gated off in this environment) is
-    # decided serially against aws lambda get-function. The actual
-    # update-function-code + wait function-updated calls are then
+    # decided against a single auto-paginated list-functions call
+    # rather than one get-function probe per directory; that call
+    # also returns each function's deployed CodeSha256, which is
+    # compared against the sidecar .zip.base64sha256 the build step
+    # just wrote. A match means the freshly built zip is byte-
+    # identical to the running code (build-api-one.sh's reproducible-
+    # zip machinery makes hashes stable across runs), so the function
+    # is skipped: update-function-code discards every warm execution
+    # environment, and redeploying identical code would cold-start
+    # the whole API surface for nothing. The remaining
+    # update-function-code + wait function-updated calls are
     # dispatched under xargs -P so the wall time is dominated by the
-    # slowest single function rather than the sum of ~30 sequential
+    # slowest single function rather than the sum of sequential
     # waits. AWS does not rate-limit update-function-code across
     # distinct functions at any level we'd hit here.
     - name: deploy
@@ -661,22 +670,37 @@ jobs:
       run: |
         set -euo pipefail
         BUCKET="admin.${TF_VAR_CONTROL_DOMAIN}"
+        aws lambda list-functions \
+          --query 'Functions[].[FunctionName,CodeSha256]' \
+          --output text > /tmp/deployed-functions.tsv
         TARGETS=()
         SKIPPED=()
+        UNCHANGED=()
         for FUNC_DIR in lambda/api/*/ ; do
           FUNC=$(basename "${FUNC_DIR}")
           case "${FUNC}" in
             healthchecks_iac|_*) continue ;;
           esac
-          if ! aws lambda get-function --function-name "${FUNC}" >/dev/null 2>&1; then
+          DEPLOYED_SHA=$(awk -v f="${FUNC}" '$1 == f {print $2}' /tmp/deployed-functions.tsv)
+          if [ -z "${DEPLOYED_SHA}" ]; then
             echo "::warning::function ${FUNC} not deployed in this environment; skipping"
             SKIPPED+=("${FUNC}")
+            continue
+          fi
+          # Sidecar written by build-api-one.sh; a missing file means the
+          # build step did not do its job, so fail loudly (set -e).
+          BUILT_SHA=$(cat "lambda/api/${FUNC}.zip.base64sha256")
+          if [ "${BUILT_SHA}" = "${DEPLOYED_SHA}" ]; then
+            UNCHANGED+=("${FUNC}")
             continue
           fi
           TARGETS+=("${FUNC}")
         done
         if [ "${#SKIPPED[@]}" -gt 0 ]; then
           echo "skipped (not deployed in this environment): ${SKIPPED[*]}"
+        fi
+        if [ "${#UNCHANGED[@]}" -gt 0 ]; then
+          echo "skipped (deployed code already matches built zip): ${UNCHANGED[*]}"
         fi
         if [ "${#TARGETS[@]}" -eq 0 ]; then
           echo "no api functions to deploy"

--- a/changelog.d/lambda-deploy-skip-unchanged.changed.md
+++ b/changelog.d/lambda-deploy-skip-unchanged.changed.md
@@ -1,0 +1,7 @@
+- **Hash-aware Lambda API deploys.** The deploy step now fetches the
+  deployed function inventory with a single `list-functions` call
+  (replacing ~57 serial per-function probes) and skips any function
+  whose freshly built zip is byte-identical to the running code, as
+  judged by CodeSha256. A push no longer cold-starts the entire API
+  surface by redeploying unchanged code, and the lambda-api job drops
+  from roughly three minutes to about half that on a typical change.


### PR DESCRIPTION
## Summary

The lambda-api job ran ~3m07s (latest stage run: pylint 11s, build 61s, deploy 110s). The deploy step's time went to two things this PR removes:

- **~43s of serial `aws lambda get-function` probes** (~57 CLI invocations at ~0.75s each) just to decide eligibility. Replaced with one auto-paginated `list-functions` call (~2s).
- **~66s updating every function on every push**, even when the zip is byte-identical to the running code. The same `list-functions` call returns each function's deployed `CodeSha256`; the deploy now compares it against the sidecar `.zip.base64sha256` the build step wrote and skips matches. Beyond wall time, `update-function-code` discards every warm execution environment — so each push was cold-starting the entire ~55-function API surface even when one function changed. Now only functions whose build inputs changed are touched.

Expected job time on a typical push: roughly half of today's, with the deploy phase dominated by the handful of genuinely changed functions.

## Reproducibility verification

Skip-if-identical is only sound if unchanged inputs rebuild to byte-identical zips. Verified empirically from CI deploy logs (which print each function's post-deploy `CodeSha256`) across three stage runs spanning Jul 13 → Jul 28:

- Runs 30386085798 (18:08) vs 30389949225 (18:59), Jul 28: all 52 comparable functions identical; the only source changes between them were the two functions not present in both.
- Runs 30375035424 (15:46) vs 30386085798 (18:08), Jul 28: `_shared/helper.py` changed; the set of changed hashes matched the set of helper/compose importers plus directly-edited functions *exactly* — every non-importer rebuilt identical.
- Run 29268299885 (Jul 13) vs 30389949225 (Jul 28): across 15 days of runner-image/pip drift, zero hash changes without a corresponding source change (including the four `admin_limits`-only importers, whose shared module was untouched).

The determinism machinery in `build-api-one.sh` (SOURCE_DATE_EPOCH, `--no-compile`, `--require-hashes`, mtime/perm normalization) is doing its job.

## Behavior notes

- Functions absent in the environment (e.g. `alert_sink`/`backup_heartbeat` with monitoring off) still skip with the same warning.
- A missing sidecar fails the step loudly (`set -e` on the `cat`), which is correct — it means the build step didn't run properly.
- Out-of-band drift self-heals: a mismatched hash simply redeploys.
- `deploy-lambda-zip.sh` is unchanged; its internal `get-function` guard stays for its other callers and now runs only for genuinely-deploying functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)