### PR TITLE
Keep the unread dot brand-colored on selected rows

### DIFF
--- a/apple/Cabalmail/Views/MessageListView+Rows.swift
+++ b/apple/Cabalmail/Views/MessageListView+Rows.swift
@@ -4,7 +4,7 @@ import CabalmailKit
 // Row rendering and per-row affordances for `MessageListView`. Lives in
 // a same-module extension so the primary view body stays under
 // SwiftLint's `type_body_length` cap. Holds:
-//   - `row(for:model:isSelected:)` — list-row content (drag + tag)
+//   - `row(for:model:orderedVisible:)` — list-row content (drag + tag)
 //   - `rowContextMenu` — the per-row long-press / right-click menu
 //   - `disposeSwipe` / `toggleReadSwipe` — `SwipeActionSpec`s the
 //     `SwipeActionRow` wrapper reveals on a trailing / leading swipe
@@ -30,7 +30,6 @@ extension MessageListView {
     func row(
         for envelope: Envelope,
         model: MessageListViewModel,
-        isSelected: Bool,
         orderedVisible: [Envelope]
     ) -> some View {
         let bulkMode = model.bulkMode
@@ -48,18 +47,17 @@ extension MessageListView {
                     Button {
                         model.toggleSelection(envelope)
                     } label: {
-                        MessageRow(envelope: envelope, isSelected: isChecked, isChecked: isChecked, bulkMode: true)
+                        MessageRow(envelope: envelope, isChecked: isChecked, bulkMode: true)
                     }
                     .buttonStyle(.plain)
                 } else if isWideLayout {
                     wideRow(
                         for: envelope,
-                        isSelected: isSelected,
                         model: model,
                         orderedVisible: orderedVisible
                     )
                 } else {
-                    MessageRow(envelope: envelope, isSelected: isSelected, isChecked: false, bulkMode: false)
+                    MessageRow(envelope: envelope, isChecked: false, bulkMode: false)
                         .tag(envelope)
                 }
             }
@@ -97,8 +95,7 @@ extension MessageListView {
 
     /// The wide-layout single-selection row: a UID-tagged `MessageRow` whose
     /// highlight follows `selectedUIDs`. Multi-select does NOT come through
-    /// here — `bulkMode` takes the checkbox branch above. `isSelected` is set
-    /// membership, used only to keep the unread dot legible. On iOS it also
+    /// here — `bulkMode` takes the checkbox branch above. On iOS it also
     /// carries the hardware-keyboard shift / command-click handling SwiftUI
     /// doesn't wire into the native list there; plain taps fall through to the
     /// list. Kept beside `MessageRow` (which is file-private) and out of
@@ -106,11 +103,10 @@ extension MessageListView {
     @ViewBuilder
     func wideRow(
         for envelope: Envelope,
-        isSelected: Bool,
         model: MessageListViewModel,
         orderedVisible: [Envelope]
     ) -> some View {
-        MessageRow(envelope: envelope, isSelected: isSelected, isChecked: false, bulkMode: false)
+        MessageRow(envelope: envelope, isChecked: false, bulkMode: false)
             .tag(envelope.uid)
             #if os(iOS)
             .gesture(ModifierClickGesture { kind in
@@ -333,7 +329,6 @@ extension MessageListView {
 
 private struct MessageRow: View {
     let envelope: Envelope
-    let isSelected: Bool
     let isChecked: Bool
     let bulkMode: Bool
 
@@ -420,13 +415,9 @@ private struct MessageRow: View {
     // the platform blue. The asset-catalog color is pinned explicitly rather
     // than taken from `Color.accentColor`, which macOS repaints with the
     // user's system accent whenever that isn't "multicolor" (same reasoning
-    // as `iconForeground` in FolderListView+Helpers.swift). The dot would
-    // disappear into the row-selection highlight, which is drawn in that
-    // same accent, so it switches to `.white` when the row is selected --
-    // legible against the highlight on every platform.
+    // as `iconForeground` in FolderListView+Helpers.swift).
     private var unreadDotColor: Color {
-        guard !envelope.flags.contains(.seen) else { return .clear }
-        return isSelected ? .white : Color("AccentColor")
+        envelope.flags.contains(.seen) ? .clear : Color("AccentColor")
     }
 
     /// The row's first line: `source -> destination`. The destination is the

--- a/apple/Cabalmail/Views/MessageListView+Selection.swift
+++ b/apple/Cabalmail/Views/MessageListView+Selection.swift
@@ -239,7 +239,7 @@ extension MessageListView {
         let background = selected ? Color.accentColor.opacity(0.15) : Color.clear
         Group {
             if model.bulkMode {
-                row(for: envelope, model: model, isSelected: selected, orderedVisible: visible)
+                row(for: envelope, model: model, orderedVisible: visible)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .frame(height: rowHeight, alignment: .center)
                     .background(background)
@@ -256,7 +256,7 @@ extension MessageListView {
                         trailing: disposeSwipe(for: envelope, model: model),
                         onSelect: { selectRow(envelope, model: model, ordered: visible) },
                         content: {
-                            row(for: envelope, model: model, isSelected: selected, orderedVisible: visible)
+                            row(for: envelope, model: model, orderedVisible: visible)
                         }
                     )
                 }

--- a/changelog.d/unread-dot-selected-color.fixed.md
+++ b/changelog.d/unread-dot-selected-color.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Unread dot color on selected rows.** The unread indicator no
+  longer switches to white when its row is selected — white was nearly
+  invisible against the light-mode selection highlight. It now stays the
+  brand color everywhere, which reads fine against the highlight since the
+  dot itself stopped using the selection accent.


### PR DESCRIPTION
## Summary

The unread indicator used to switch to white on selected rows so it wouldn't blend into the selection highlight, back when the dot was drawn in the same accent as the highlight. Since the dot moved to the pinned brand forest green that override stopped helping — and in system light mode the white dot is hard to see against the light selection highlight.

- Drop the white-when-selected override in `MessageRow.unreadDotColor`; the dot is now always `Color("AccentColor")` (clear when seen).
- Remove the now-dead `isSelected` plumbing through `row()`, `wideRow()`, and `MessageRow` — it existed only to feed that override. Row-highlight rendering in `MessageListView+Selection.swift` is untouched (`selected` still drives the background there).

## Testing

- `swiftlint --strict` clean on both edited files.
- `xcodebuild build` (CabalmailMac scheme, macOS) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)