### PR TITLE
Fix the draft reader's overflowing bottom toolbar on iPhone

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageDetailViewModel+Drafts.swift
+++ b/apple/Cabalmail/ViewModels/MessageDetailViewModel+Drafts.swift
@@ -30,6 +30,16 @@ extension MessageDetailViewModel {
     /// `Drafts` mailbox.
     var isDraftsFolder: Bool { folder.path == "Drafts" }
 
+    /// Leading reader-toolbar action. In Drafts, "Edit Draft" takes the
+    /// Reply slot rather than claiming an eighth one: the iPhone bottom
+    /// bar sizes itself to its content and doesn't scroll or compact, so
+    /// an eighth item spilled ~23pt off each end and clipped the outermost
+    /// buttons to ~5pt slivers. Replacing Reply also reads correctly —
+    /// replying to your own unsent draft isn't a meaningful action.
+    var leadingToolbarAction: LeadingReaderAction {
+        isDraftsFolder ? .editDraft : .reply
+    }
+
     /// Resume needs the fetched, parsed body in hand; until then the Edit
     /// Draft button stays disabled rather than seeding an empty compose.
     var canResumeDraft: Bool {
@@ -53,4 +63,11 @@ extension MessageDetailViewModel {
             serverRef: ref
         )
     }
+}
+
+/// Which action occupies the reader toolbar's first slot; see
+/// `MessageDetailViewModel.leadingToolbarAction`.
+enum LeadingReaderAction {
+    case reply
+    case editDraft
 }

--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -265,19 +265,22 @@ struct MessageDetailView: View {
         }
     }
 
-    // The detail view exposes six action buttons. On macOS they live in the
+    // The detail view exposes seven action buttons. On macOS they live in the
     // top toolbar; on iOS/visionOS they would crowd the inline title and hide
     // the subject, so we route them to a bottom bar where they're also easier
-    // to reach with a thumb.
+    // to reach with a thumb. Seven is the ceiling that fits an iPhone bottom
+    // bar, which sizes to its content and neither scrolls nor compacts — so
+    // the Drafts affordance swaps into the leading slot instead of adding an
+    // eighth item. Anything new belongs in the overflow menu.
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         #if os(iOS) || os(visionOS)
         ToolbarItemGroup(placement: .bottomBar) {
-            if model?.isDraftsFolder == true {
+            if model?.leadingToolbarAction == .editDraft {
                 editDraftButton
-                Spacer()
+            } else {
+                replyButton
             }
-            replyButton
             Spacer()
             seenButton
             Spacer()
@@ -292,10 +295,11 @@ struct MessageDetailView: View {
             overflowMenuButton
         }
         #else
-        if model?.isDraftsFolder == true {
+        if model?.leadingToolbarAction == .editDraft {
             ToolbarItem { editDraftButton }
+        } else {
+            ToolbarItem { replyButton }
         }
-        ToolbarItem { replyButton }
         ToolbarItem { seenButton }
         ToolbarItem { flagButton }
         ToolbarItem { remoteContentButton }

--- a/apple/CabalmailTests/ReaderToolbarActionTests.swift
+++ b/apple/CabalmailTests/ReaderToolbarActionTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Regression coverage for issue #836: opening a message in Drafts used to
+// ADD "Edit Draft" to the reader toolbar, taking the iPhone bottom bar to
+// eight items. That row sizes to its content and neither scrolls nor
+// compacts, so the extra item spilled ~23pt off each end and clipped
+// "Edit Draft" and "More actions" to ~5pt slivers at the screen edges.
+// The fix swaps Edit Draft into the Reply slot, which keeps the count at
+// seven in every folder.
+@MainActor
+final class ReaderToolbarActionTests: XCTestCase {
+
+    private func makeModel(folderPath: String) throws -> MessageDetailViewModel {
+        let client = try TestFixtures.makeClient(imap: FakeImapClient())
+        let folder = Folder(path: folderPath, attributes: [], isSubscribed: true)
+        return MessageDetailViewModel(
+            folder: folder,
+            envelope: TestFixtures.makeEnvelope(uid: 7),
+            client: client,
+            preferences: Preferences(store: InMemoryPreferenceStore())
+        )
+    }
+
+    func testDraftsFolderSwapsReplyForEditDraft() throws {
+        let model = try makeModel(folderPath: "Drafts")
+
+        XCTAssertTrue(model.isDraftsFolder)
+        XCTAssertEqual(
+            model.leadingToolbarAction,
+            .editDraft,
+            "Drafts must show Edit Draft in the leading slot, not alongside Reply"
+        )
+    }
+
+    func testNonDraftFoldersKeepReply() throws {
+        for path in ["INBOX", "Sent", "Trash", "Drafts.Old"] {
+            let model = try makeModel(folderPath: path)
+
+            XCTAssertFalse(model.isDraftsFolder, "\(path) is not the Drafts mailbox")
+            XCTAssertEqual(
+                model.leadingToolbarAction,
+                .reply,
+                "\(path) must keep Reply in the leading toolbar slot"
+            )
+        }
+    }
+}

--- a/changelog.d/draft-reader-toolbar-overflow.fixed.md
+++ b/changelog.d/draft-reader-toolbar-overflow.fixed.md
@@ -1,0 +1,6 @@
+- Apple: **Draft reader toolbar no longer overflows the iPhone screen.** Opening a
+  message in Drafts added "Edit Draft" as an eighth bottom-bar item, which pushed the
+  row wider than the screen and clipped both "Edit Draft" and "More actions" to ~5pt
+  slivers at the edges. Drafts now show "Edit Draft" in place of "Reply" — replying to
+  your own unsent draft was never a meaningful action — keeping the toolbar at seven
+  items in every folder.


### PR DESCRIPTION
## What was wrong

Opening a message in **Drafts** gave the reader an eighth bottom-bar item, `Edit Draft`.
On a 402pt iPhone screen the row overflowed at both ends: `Edit Draft` sat at x=-23.3
(5.3pt visible) and `More actions` at x=397 (5.0pt visible) — the primary action for a
draft was a 5pt target flush against the screen edge.

## Root cause

`ToolbarItemGroup(placement: .bottomBar)` sizes to its content and neither scrolls nor
compacts overflow into a menu, so the seven-item row that fits comfortably (x=6.7…395)
has no room for an eighth. `MessageDetailView.toolbarContent` *added* `editDraftButton`
ahead of `replyButton` when the folder was Drafts instead of substituting it.

## The fix

Drafts now show `Edit Draft` **in place of** `Reply`, keeping the count at seven in
every folder. That is the tester's own suggestion, and it beats the alternatives:

- **Push something into the overflow menu** — hides the one action a draft exists for
  behind an extra tap, or demotes an action that is equally useful on drafts.
- **Make the row scroll / compact** — the bottom bar doesn't offer that, so it would
  mean hand-rolling the toolbar; disproportionate to the defect.
- **Shrink the glass buttons** — pushes below the 44pt HIG target.

Replying to your own unsent draft isn't a meaningful action, so nothing useful is lost.
The swap is applied on macOS too, where the toolbar has room but the semantics are the
same; the macOS menu bar (`CabalmailCommands.Message`) still carries Reply/Reply All/
Forward.

The decision moved onto the view model as `leadingToolbarAction`, so both platforms'
toolbars read it from one place and it can be unit-tested.

## Test evidence

New `apple/CabalmailTests/ReaderToolbarActionTests.swift`:

- Fails before (shimming the property back to the old always-`.reply` behavior):
  `XCTAssertEqual failed: ("reply") is not equal to ("editDraft")`.
- Passes after; full app-target suite green — `Executed 54 tests, with 0 failures`
  (`xcodebuild test -scheme CabalmailMac`). `swiftlint --strict` from `apple/`:
  `0 violations, 0 serious in 246 files`.

Live repro on the iPhone 17 sim (iOS 26.5), draft open in the reader, `idb ui
describe-all` frames — all seven items fully on screen, none clipped:

| item | x | width |
|---|---|---|
| Edit Draft | 6.7 | 28.7 |
| Mark as unread | 64.3 | 33.3 |
| Flag | 127.7 | 26.7 |
| Show remote content | 183.0 | 36.0 |
| Show reader view | 248.3 | 25.7 |
| Archive | 306.3 | 29.3 |
| More actions | 367.0 | 28.0 |

(Right edge lands at 395 of 402pt, matching a non-draft reader.) Note: `Edit Draft`
rendered *disabled* in that run because both stage drafts failed their body fetch with a
502 — an unrelated server-side defect I hit while verifying and filed separately; the
geometry this PR is about is unaffected by the button's enabled state.

Addresses #836