### PR TITLE
Give the cancel-compose dialog all three outcomes

### DIFF
--- a/apple/Cabalmail/Views/ComposeCancelChoice.swift
+++ b/apple/Cabalmail/Views/ComposeCancelChoice.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The three outcomes of tapping Cancel in the composer, in the order the
+/// confirmation dialog offers them.
+///
+/// Modelled as a type rather than three inline `Button`s so the set — and,
+/// more importantly, which member carries the `.cancel` role — is unit
+/// testable. That role is load-bearing: SwiftUI drops the cancel-role button
+/// when a `confirmationDialog` renders as a popover (which is what iPhone
+/// does here) and runs its action on an outside tap instead. "Save Draft"
+/// used to hold the role, so the popover showed only the destructive button
+/// and an accidental outside tap silently closed the composer.
+enum ComposeCancelChoice: CaseIterable {
+    case discard
+    case saveDraft
+    /// Deliberately a no-op: dismissing the dialog leaves the composer up,
+    /// which is also what an outside tap now does.
+    case keepEditing
+
+    var title: String {
+        switch self {
+        case .discard:     return "Discard Draft"
+        case .saveDraft:   return "Save Draft"
+        case .keepEditing: return "Keep Editing"
+        }
+    }
+
+    var role: ButtonRole? {
+        switch self {
+        case .discard:   return .destructive
+        case .saveDraft: return nil
+        case .keepEditing:
+            // iOS/visionOS render this dialog as a popover, where SwiftUI
+            // suppresses cancel-role buttons and treats an outside tap as
+            // the cancel — so a cancel-roled "Keep Editing" would be
+            // invisible, exactly the hole this fix is closing. Leaving it
+            // roleless keeps it on screen; the outside tap still resolves
+            // to the system's implicit cancel, which is the same no-op.
+            // macOS shows every button in an alert and maps Escape to the
+            // cancel-roled one, so there the role is worth having.
+            #if os(macOS)
+            return .cancel
+            #else
+            return nil
+            #endif
+        }
+    }
+}

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -146,36 +146,51 @@ struct ComposeView: View {
                 "Discard draft?",
                 isPresented: $showDiscardConfirm
             ) {
-                Button("Discard Draft", role: .destructive) {
-                    Task {
-                        #if os(macOS)
-                        // Pre-approve the close so the dismissWindow call
-                        // inside discard() doesn't get re-intercepted by
-                        // the NSWindowDelegate.
-                        closeCoordinator.allowsClose = true
-                        #endif
-                        await model.discard()
-                    }
-                }
-                Button("Save Draft", role: .cancel) {
-                    Task {
-                        #if os(macOS)
-                        closeCoordinator.allowsClose = true
-                        #endif
-                        let didClose = await model.cancel()
-                        #if os(macOS)
-                        // IMAP save failed: keep the user in the window so
-                        // they can see the error banner and retry.
-                        if !didClose {
-                            closeCoordinator.allowsClose = false
-                        }
-                        #endif
-                    }
+                ForEach(ComposeCancelChoice.allCases, id: \.self) { choice in
+                    Button(choice.title, role: choice.role) { perform(choice) }
                 }
             } message: {
-                Text("Keep a copy of the draft for later, or discard it now.")
+                Text("Keep a copy of the draft for later, discard it now, or go back to editing.")
             }
             .toastOverlay($composeToast)
+        }
+    }
+
+    // MARK: - Cancel dialog
+
+    /// Runs the outcome the user picked in the cancel-compose dialog. Stays
+    /// in this file (rather than the `+Subviews` extension) because it
+    /// touches the `private` close coordinator.
+    private func perform(_ choice: ComposeCancelChoice) {
+        switch choice {
+        case .discard:
+            Task {
+                #if os(macOS)
+                // Pre-approve the close so the dismissWindow call inside
+                // discard() doesn't get re-intercepted by the
+                // NSWindowDelegate.
+                closeCoordinator.allowsClose = true
+                #endif
+                await model.discard()
+            }
+        case .saveDraft:
+            Task {
+                #if os(macOS)
+                closeCoordinator.allowsClose = true
+                #endif
+                let didClose = await model.cancel()
+                #if os(macOS)
+                // IMAP save failed: keep the user in the window so they can
+                // see the error banner and retry.
+                if !didClose {
+                    closeCoordinator.allowsClose = false
+                }
+                #endif
+            }
+        case .keepEditing:
+            // No-op by design — the dialog dismisses and the composer, with
+            // everything typed so far, is still there.
+            break
         }
     }
 

--- a/apple/CabalmailTests/ComposeCancelChoiceTests.swift
+++ b/apple/CabalmailTests/ComposeCancelChoiceTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import SwiftUI
+@testable import Cabalmail
+
+// Regression coverage for issue #838: the cancel-compose dialog offered
+// "Discard Draft" and "Save Draft", with the *cancel* role on Save Draft.
+// SwiftUI drops the cancel-role button when a confirmation dialog renders
+// as a popover — which is what iPhone does here — so the user saw a single
+// destructive button under a message promising a keep option, and an
+// outside tap (the popover's cancel path) silently saved and closed the
+// composer with no way back to it.
+//
+// The fix gives the dialog all three outcomes and moves the cancel role
+// onto a no-op "Keep Editing", so the popover's outside tap returns the
+// user to the composer and both draft actions stay visible.
+final class ComposeCancelChoiceTests: XCTestCase {
+
+    func testOffersAllThreeOutcomesInOrder() {
+        XCTAssertEqual(
+            ComposeCancelChoice.allCases.map(\.title),
+            ["Discard Draft", "Save Draft", "Keep Editing"]
+        )
+    }
+
+    func testNoDraftActionCarriesTheCancelRole() {
+        // The role is the whole defect: a cancel-roled button disappears in
+        // popover presentation and runs on an outside tap instead. Neither
+        // draft action may hold it, on any platform.
+        let cancelRoled = ComposeCancelChoice.allCases.filter { $0.role == .cancel }
+        XCTAssertFalse(cancelRoled.contains(.discard))
+        XCTAssertFalse(cancelRoled.contains(.saveDraft))
+    }
+
+    func testKeepEditingRoleMatchesThePlatformPresentation() {
+        #if os(macOS)
+        // Alert presentation shows every button and maps Escape to the
+        // cancel-roled one.
+        XCTAssertEqual(ComposeCancelChoice.keepEditing.role, .cancel)
+        #else
+        // Popover presentation would swallow a cancel-roled button, which
+        // is how "Save Draft" went missing in the first place.
+        XCTAssertNil(ComposeCancelChoice.keepEditing.role)
+        #endif
+    }
+
+    func testDraftActionsSurvivePopoverPresentation() {
+        // Both draft outcomes must be non-cancel so they render even when
+        // the dialog comes up as a popover.
+        XCTAssertEqual(ComposeCancelChoice.discard.role, .destructive)
+        XCTAssertNil(ComposeCancelChoice.saveDraft.role)
+    }
+}

--- a/changelog.d/compose-cancel-keep-editing.fixed.md
+++ b/changelog.d/compose-cancel-keep-editing.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Cancelling a compose offers all three outcomes.** The confirmation showed
+  only "Discard Draft" under a message promising a keep option, and an accidental tap
+  outside it saved the draft and closed the composer with no way back. It now lists
+  "Discard Draft", "Save Draft" and "Keep Editing", and dismissing it leaves the
+  composer exactly as it was.


### PR DESCRIPTION
## What was wrong

Tapping **Cancel** in the composer raised a dialog reading *"Keep a copy of the draft
for later, or discard it now."* with exactly one button: **Discard Draft**. The keep
half had no control, and tapping outside the bubble dismissed it *and* closed the
composer — so both reachable outcomes abandoned the message being written, and the only
labelled one was destructive.

## Root cause

Not a missing button — a misplaced role. The dialog did declare `Save Draft`, but with
`role: .cancel`:

```swift
Button("Discard Draft", role: .destructive) { … }
Button("Save Draft", role: .cancel) { … }
```

On iPhone this `confirmationDialog` comes up as a **popover** (confirmed on the sim —
screenshot in the issue, and the AX dump below). SwiftUI omits cancel-role buttons from
a popover, treating an outside tap as the cancel instead. So `Save Draft` was rendered
invisible *and* wired to the accidental gesture: the draft was saved, but only as a side
effect of a dismissal that also tore down the composer.

## The fix

The three outcomes move into a `ComposeCancelChoice` enum that the dialog builds its
buttons from, so the set and its roles are unit-testable:

| choice | role | behavior |
|---|---|---|
| Discard Draft | `.destructive` | unchanged |
| Save Draft | none (was `.cancel`) | unchanged action; now always rendered |
| Keep Editing | `.cancel` on macOS, none on iOS | no-op — dismisses the dialog, composer stays |

The role fork is deliberate and commented: on iOS a cancel-roled button would be
swallowed by the popover — the very bug being fixed — so `Keep Editing` stays roleless
there and the outside tap falls through to SwiftUI's implicit cancel, which is the same
no-op. macOS renders an alert that shows every button and maps Escape to the cancel-roled
one, so there the role is worth keeping.

Alternative considered: leaving `.cancel` on `Keep Editing` everywhere. It fixes the
silent-close, but on iPhone the keep-editing route stays unlabelled and undiscoverable —
half the reported problem.

The `Discard/Save` action bodies are unchanged, macOS close-coordinator handling
included; they just moved into a `perform(_:)` switch.

## Test evidence

New `apple/CabalmailTests/ComposeCancelChoiceTests.swift` (4 tests: the choice set and
order, that neither draft action carries `.cancel`, and the per-platform Keep Editing
role). Shimming the enum back to the pre-fix two-choice set fails all of them
(`Executed 3 tests, with 4 failures`); after the fix `Executed 4 tests, with 0 failures`,
and the full app-target suite is green (`Executed 55 tests, with 0 failures`).
`swiftlint --strict` from `apple/`: `0 violations in 247 files`.

Live on the iPhone 17 sim (iOS 26.5), `idb ui describe-all` with the dialog up — all
three buttons now render in the popover:

```
97 198 208 48 | Button | 'Discard Draft'
97 254 208 48 | Button | 'Save Draft'
97 310 208 48 | Button | 'Keep Editing'
```

(before: only the first two, and pre-fix only `Discard Draft`.) Tapping **Keep Editing**
returns to the composer with the fields intact; tapping *outside* the popover now also
leaves the composer up (`composer fields present: True | dialog gone: True`) instead of
saving and closing.

Addresses #838