### PR TITLE
Prune the sent draft's row from the Drafts list on send

### DIFF
--- a/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
@@ -200,6 +200,21 @@ extension ComposeViewModel {
         "\(address.mailbox)@\(address.host)"
     }
 
+    /// UID of the server-side Drafts copy that a completed send has just
+    /// superseded, or nil when there's nothing for the Drafts list to
+    /// prune. `/send` discards that copy server-side as part of delivery,
+    /// so the row the user is looking at is stale the moment this returns
+    /// a value — the compose surface signals the list rather than leaving
+    /// it to the next background reconcile a minute later.
+    ///
+    /// A queued send keeps its draft on purpose (the outbox hasn't
+    /// delivered anything yet, and the ref is dropped rather than
+    /// discarded), so it reports nothing.
+    var supersededDraftUID: UInt32? {
+        guard lastSendOutcome == .sent else { return nil }
+        return serverDraftRef?.uid
+    }
+
     func describe(_ error: CabalmailError) -> String {
         switch error {
         case .invalidCredentials: return "Send failed: your credentials were rejected."

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -211,6 +211,17 @@ struct ComposeView: View {
                     if !sent { closeCoordinator.allowsClose = false }
                     #endif
                     guard sent else { return }
+                    // Sending from a draft discards the server copy, so the
+                    // Drafts list is showing a message that no longer
+                    // exists. Prune it through the same signal the reader's
+                    // archive/move actions use instead of waiting for the
+                    // next background reconcile (the folder is unsubscribed
+                    // by default, so that took over a minute). "Drafts" is
+                    // the mailbox `/save_draft` pins every draft to; see
+                    // `MessageDetailViewModel.isDraftsFolder`.
+                    if let uid = model.supersededDraftUID {
+                        appState.signalDisposed(folderPath: "Drafts", uid: uid)
+                    }
                     // Surface the outcome as a toast on the shared AppState
                     // so the user sees confirmation after the sheet dismisses.
                     // `.queued` means the message is in the outbox and

--- a/apple/CabalmailTests/DraftPruneOnSendTests.swift
+++ b/apple/CabalmailTests/DraftPruneOnSendTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Regression coverage for issue #837: sending a draft from inside the app
+// left the row sitting in the Drafts list for 60–80s. `/send` discards the
+// server copy as part of delivery, but nothing told the open list, so it
+// waited on a slow background reconcile (Drafts is unsubscribed, so it
+// isn't proactively refreshed). The compose surface now prunes the row
+// through the same `signalDisposed` path the reader's dispose actions use,
+// driven by `supersededDraftUID`.
+@MainActor
+final class DraftPruneOnSendTests: XCTestCase {
+
+    private func makeModel(draftUID: UInt32?) throws -> ComposeViewModel {
+        let model = try TestFixtures.makeComposeModel()
+        model.serverDraftRef = draftUID.map { DraftServerRef(uid: $0, uidValidity: 9) }
+        return model
+    }
+
+    func testCompletedSendReportsTheSupersededDraftRow() throws {
+        let model = try makeModel(draftUID: 42)
+
+        model.lastSendOutcome = .sent
+
+        XCTAssertEqual(model.supersededDraftUID, 42)
+    }
+
+    func testQueuedSendKeepsItsDraft() throws {
+        // Nothing has been delivered yet and the server copy is deliberately
+        // left in place, so pruning the row would hide a real message.
+        let model = try makeModel(draftUID: 42)
+
+        model.lastSendOutcome = .queued(UUID())
+
+        XCTAssertNil(model.supersededDraftUID)
+    }
+
+    func testFreshComposeHasNoDraftRowToPrune() throws {
+        let model = try makeModel(draftUID: nil)
+
+        model.lastSendOutcome = .sent
+
+        XCTAssertNil(model.supersededDraftUID)
+    }
+
+    func testUnsentComposeReportsNothing() throws {
+        let model = try makeModel(draftUID: 42)
+
+        XCTAssertNil(model.lastSendOutcome)
+        XCTAssertNil(model.supersededDraftUID)
+    }
+}

--- a/changelog.d/drafts-prune-on-send.fixed.md
+++ b/changelog.d/drafts-prune-on-send.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Sending a draft clears it from the Drafts list right away.** The row stayed
+  on screen for a minute or more after the send completed, even though the server copy
+  was already gone, because nothing invalidated the folder the app had just acted on.
+  The compose surface now prunes the row the moment the send lands, the same way the
+  reader's archive and move actions do.


### PR DESCRIPTION
## What was wrong

Sending a draft from inside the app left it listed in **Drafts** for 60–80s, even though
the server-side copy was gone the moment `/send` returned.

## Root cause

`/send` discards the draft copy server-side (`client.send(message, discardingDraft:)`),
but nothing on the client invalidated the folder. Every other local mutation that
removes a row — the reader's archive, delete and move — posts
`appState.signalDisposed(folderPath:uid:)`, which the open `MessageListView` observes and
turns into a `pruneEnvelope`. The send path had no such call, so the row survived until
the next reconcile. Drafts is unsubscribed by default (`This unsubscribed folder is not
kept up-to-date automatically`), so there is no proactive refresh to catch it sooner —
that slow fallback was all there was. This also explains the asymmetry the tester spotted:
an *external* removal reconciles in ≤10s because it lands on a poll the app already runs,
while the app's own send waited on the long path.

## The fix

`ComposeViewModel` exposes `supersededDraftUID` — the server draft UID a *completed* send
has just invalidated — and `ComposeView` prunes that row through `signalDisposed` right
after the send succeeds, before the outcome toast. A `.queued` send reports nothing: the
outbox hasn't delivered anything yet and its draft copy is deliberately left in place, so
pruning would hide a real message.

Deliberately not in this PR (happy to follow up on any of them):

- **Insert-on-save**, the other half of the tester's note. A new draft appearing in the
  open list needs a synthesized envelope rather than a prune, which is a different
  mechanism; the reported failure is the send.
- **Discarding** a resumed draft leaves the same phantom row via `discard()`. Same
  one-line shape, but it isn't what was reported.
- **The All pill.** Its count is server-sourced by design (`totalMessages` from STATUS),
  so it corrects on the next refresh rather than at prune time — as it already does after
  an archive or a move from the reader. Making optimistic prunes adjust the folder totals
  is a folder-wide change, not a Drafts one.

## Test evidence

New `apple/CabalmailTests/DraftPruneOnSendTests.swift` (4 tests: completed send reports
the draft UID, queued send reports nothing, fresh compose reports nothing, unsent compose
reports nothing). Shimming `supersededDraftUID` back to the pre-fix "nothing is pruned"
behavior fails the first (`XCTAssertEqual failed: ("nil") is not equal to
("Optional(42)")`); after the fix all 4 pass and the full app-target suite is green
(`Executed 56 tests, with 0 failures`). `swiftlint --strict` from `apple/`:
`0 violations in 246 files`.

Live on the iPhone 17 sim (iOS 26.5) against stage, running the tester's exact steps —
saved a draft ("Fixer 837 prune probe"), opened it, Edit Draft, Send:

- Drafts list before: one row, `All, 1`.
- ~6s after Send: `Message sent.` toast, and the row is **gone** from the list
  (`idb ui describe-all` shows no message rows) — previously it was still there at +44s.

Observed while verifying, unchanged by this PR: the pill still reads `All, 1` until the
next STATUS (see above), and the reader that was showing the draft lands on the "No
message selected" placeholder with a working Back — the same end state as disposing a
message from the reader.

Addresses #837