### PR TITLE
Keep the folder total in step with an optimistic prune

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Move.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Move.swift
@@ -18,7 +18,12 @@ extension MessageListViewModel {
         guard source != destination else { return }
         let originalIndex = envelopes.firstIndex { $0.uid == envelope.uid }
         let wasUnread = !envelope.flags.contains(.seen)
+        let loadedBefore = envelopes.count
         envelopes.removeAll { $0.uid == envelope.uid }
+        // Drop the vacated slot from the folder total too, or the index-
+        // addressed list keeps rendering an unresolvable skeleton row in it
+        // (and the All pill keeps counting it) until the next STATUS.
+        adjustTotalMessages(by: envelopes.count - loadedBefore)
         // Shield the removal from a concurrent refresh: until the move lands
         // the source folder still returns this UID, and an unshielded merge
         // would resurrect the row.
@@ -89,7 +94,9 @@ extension MessageListViewModel {
         // Shield every moving UID from a concurrent refresh until the whole
         // batch settles - the source folders keep returning them until their
         // move lands, and an unshielded merge would resurrect the rows.
+        let loadedBefore = envelopes.count
         envelopes.removeAll { movingUIDs.contains($0.uid) }
+        adjustTotalMessages(by: envelopes.count - loadedBefore)
         pendingRemovedUIDs.formUnion(movingUIDs)
         defer { pendingRemovedUIDs.subtract(movingUIDs) }
         for (source, count) in unreadBySource {
@@ -141,6 +148,7 @@ extension MessageListViewModel {
         let restored = snapshot.filter { sourceFolder(for: $0) == source }
         envelopes.append(contentsOf: restored)
         envelopes.sort(by: envelopeOrder)
+        adjustTotalMessages(by: restored.count)
         appState.applyUnreadDelta(folderPath: source, delta: unread)
         if !markSeenFirst {
             appState.applyUnreadDelta(folderPath: destination, delta: -unread)
@@ -165,6 +173,7 @@ extension MessageListViewModel {
         }
         envelopes.append(contentsOf: restored)
         envelopes.sort(by: envelopeOrder)
+        adjustTotalMessages(by: restored.count)
         if markSeenFirst {
             for envelope in restored {
                 applyOptimisticFlag(uid: envelope.uid, flag: .seen, add: true)

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Optimistic.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Optimistic.swift
@@ -72,6 +72,22 @@ extension MessageListViewModel {
         }
     }
 
+    /// Keep the server-sourced folder total in step with an optimistic prune
+    /// (or its revert). The index-addressed list renders
+    /// `max(totalMessages, loaded rows)` slots and the All filter pill reads
+    /// `totalMessages` straight through, so a row removed locally leaves a
+    /// loading skeleton behind in its slot — a placeholder that can never
+    /// resolve, because the message it points at is gone — plus an inflated
+    /// pill, until the next STATUS corrects the count. Unsubscribed folders
+    /// (Drafts) get no proactive poll, so that wait runs to minutes rather
+    /// than the ~10s STATUS lag elsewhere. Clamped at zero, and skipped in
+    /// search mode, where the row count comes from the results rather than
+    /// STATUS.
+    func adjustTotalMessages(by delta: Int) {
+        guard !isSearchActive, delta != 0 else { return }
+        totalMessages = UInt32(max(0, Int(totalMessages) + delta))
+    }
+
     /// Leg of the two-stage row-disposal animation a row is currently in.
     /// `nil` (absent from `rowDisposalPhases`) is the normal, settled state.
     enum RowDisposalPhase: Equatable {
@@ -134,6 +150,9 @@ extension MessageListViewModel {
             envelopes.append(envelope)
             envelopes.sort { $0.uid > $1.uid }
         }
+        // The row is back, so hand the folder total back the slot the
+        // optimistic prune took off it.
+        adjustTotalMessages(by: 1)
     }
 
     /// Rebuilds an `Envelope` value with a different flag set. `Envelope`

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Purge.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Purge.swift
@@ -34,6 +34,7 @@ extension MessageListViewModel {
         let unreadCount = condemned.filter { !$0.flags.contains(.seen) }.count
 
         envelopes.removeAll { condemnedUIDs.contains($0.uid) }
+        adjustTotalMessages(by: -condemned.count)
         pendingRemovedUIDs.formUnion(condemnedUIDs)
         defer { pendingRemovedUIDs.subtract(condemnedUIDs) }
         if unreadCount > 0 {
@@ -49,6 +50,7 @@ extension MessageListViewModel {
         } catch {
             envelopes.append(contentsOf: condemned)
             envelopes.sort(by: envelopeOrder)
+            adjustTotalMessages(by: condemned.count)
             if unreadCount > 0 {
                 appState.applyUnreadDelta(folderPath: FolderTree.trashPath, delta: unreadCount)
             }

--- a/apple/Cabalmail/ViewModels/MessageListViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel.swift
@@ -555,6 +555,7 @@ final class MessageListViewModel {
             // height with nothing left to animate.
             await disposal.value
             envelopes.removeAll { $0.uid == envelope.uid }
+            adjustTotalMessages(by: -1)
             endRowDisposal(uid: envelope.uid)
             await pruneCachesAfter(move: source, uid: envelope.uid)
         } catch {
@@ -625,7 +626,11 @@ extension MessageListViewModel {
     /// touches the list's in-memory copy so the row disappears immediately
     /// without a server round trip.
     func pruneEnvelope(uid: UInt32) {
+        let loadedBefore = envelopes.count
         envelopes.removeAll { $0.uid == uid }
+        // Only adjust when a row really left the window: a signal for a UID
+        // we never had loaded says nothing reliable about the folder total.
+        adjustTotalMessages(by: envelopes.count - loadedBefore)
         // The folder lost a row (detail-view dispose, no cache-prune round
         // trip), so a staged bottom window may no longer line up -- drop it.
         invalidateBottomPrefetch()

--- a/apple/CabalmailTests/OptimisticPruneTotalTests.swift
+++ b/apple/CabalmailTests/OptimisticPruneTotalTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Regression coverage for issue #843: an optimistic prune dropped the
+// envelope but left `totalMessages` (the last STATUS count) untouched. The
+// index-addressed list renders `max(totalMessages, loaded rows)` slots, so
+// the vacated slot kept rendering a loading skeleton that could never
+// resolve — the message it pointed at was gone — and the All filter pill
+// kept counting it, until the next STATUS landed. On an unsubscribed folder
+// (Drafts, where sending a draft prunes its row) nothing polls, so that ran
+// to ~2 minutes; the human reported the same skeleton on archive elsewhere.
+// Every optimistic prune and its revert now adjust the total with the row.
+@MainActor
+final class OptimisticPruneTotalTests: XCTestCase {
+
+    private func makeModel(
+        imap: FakeImapClient = FakeImapClient(),
+        uids: [UInt32] = [1, 2],
+        folderPath: String = "INBOX"
+    ) throws -> MessageListViewModel {
+        let model = try TestFixtures.makeModel(
+            imap: imap,
+            envelopes: uids.map { TestFixtures.makeEnvelope(uid: $0, flags: [.seen]) },
+            folderPath: folderPath
+        )
+        // Server-sourced STATUS count as of the last refresh.
+        model.totalMessages = UInt32(uids.count)
+        return model
+    }
+
+    func testDisposeSignalledFromTheReaderDropsTheSlot() throws {
+        // The send-a-draft path: ComposeView posts `signalDisposed`, the list
+        // observes it and calls `pruneEnvelope`.
+        let model = try makeModel(uids: [7], folderPath: "Drafts")
+
+        model.pruneEnvelope(uid: 7)
+
+        XCTAssertTrue(model.envelopes.isEmpty)
+        XCTAssertEqual(
+            model.totalMessages, 0,
+            "the emptied Drafts folder must render no rows — a leftover total is a skeleton row"
+        )
+    }
+
+    func testPruneOfAnUnloadedUIDLeavesTheTotalAlone() throws {
+        let model = try makeModel(uids: [1, 2])
+
+        model.pruneEnvelope(uid: 99)
+
+        XCTAssertEqual(
+            model.totalMessages, 2,
+            "a signal for a UID we never had loaded says nothing about the folder total"
+        )
+    }
+
+    func testSuccessfulDisposeDropsTheSlot() async throws {
+        let model = try makeModel(uids: [1, 2])
+
+        await model.dispose(model.envelopes[0])
+
+        XCTAssertEqual(model.envelopes.map(\.uid), [2])
+        XCTAssertEqual(model.totalMessages, 1)
+    }
+
+    func testFailedDisposeKeepsTheTotal() async throws {
+        let imap = FakeImapClient()
+        await imap.scriptMoveResults([.failure(CabalmailError.network("boom"))])
+        let model = try makeModel(imap: imap, uids: [1, 2])
+
+        await model.dispose(model.envelopes[0])
+
+        // The row never left `envelopes`, so the total never lost its slot.
+        XCTAssertEqual(model.envelopes.map(\.uid), [1, 2])
+        XCTAssertEqual(model.totalMessages, 2)
+    }
+
+    func testMoveToDropsTheSlotAndRestoresItOnFailure() async throws {
+        let imap = FakeImapClient()
+        let model = try makeModel(imap: imap, uids: [1, 2])
+
+        await model.moveTo(model.envelopes[0], destination: "Archive")
+        XCTAssertEqual(model.totalMessages, 1)
+
+        await imap.scriptMoveResults([.failure(CabalmailError.network("boom"))])
+        await model.moveTo(model.envelopes[0], destination: "Archive")
+
+        XCTAssertEqual(model.envelopes.map(\.uid), [2])
+        XCTAssertEqual(
+            model.totalMessages, 1,
+            "a failed move puts the row back, so the folder total gets its slot back too"
+        )
+    }
+
+    func testBulkMoveDropsEverySlotAndRevertsTogether() async throws {
+        let imap = FakeImapClient()
+        let model = try makeModel(imap: imap, uids: [1, 2, 3])
+
+        await model.performMove(
+            uidsBySource: ["INBOX": [1, 2]], to: "Archive", markSeenFirst: true
+        )
+        XCTAssertEqual(model.totalMessages, 1)
+
+        await imap.scriptMoveResults([.failure(CabalmailError.network("boom"))])
+        await model.performMove(
+            uidsBySource: ["INBOX": [3]], to: "Archive", markSeenFirst: true
+        )
+
+        XCTAssertEqual(model.envelopes.map(\.uid), [3])
+        XCTAssertEqual(model.totalMessages, 1)
+    }
+
+    func testPurgeDropsEverySlot() async throws {
+        let imap = FakeImapClient()
+        let model = try makeModel(imap: imap, uids: [1, 2], folderPath: FolderTree.trashPath)
+
+        await model.purgeMessages(uids: [1, 2])
+
+        XCTAssertTrue(model.envelopes.isEmpty)
+        XCTAssertEqual(model.totalMessages, 0)
+    }
+
+    func testSearchResultsKeepTheirOwnRowCount() throws {
+        let model = try makeModel(uids: [1, 2])
+        model.isSearchActive = true
+
+        model.pruneEnvelope(uid: 1)
+
+        XCTAssertEqual(
+            model.totalMessages, 2,
+            "search lists derive their row count from the results, not from a folder STATUS"
+        )
+    }
+}

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -27,12 +27,19 @@ actor FakeImapClient: ImapClient {
         let markSeen: Bool
     }
 
+    struct PurgeCall {
+        let folder: String
+        let uids: Set<UInt32>
+    }
+
     private(set) var flagCalls: [FlagCall] = []
     private(set) var moveCalls: [MoveCall] = []
+    private(set) var purgeCalls: [PurgeCall] = []
     // FIFO scripts; an empty queue means "succeed". Seeded via the
     // scriptFlagResults / scriptMoveResults helpers below.
     private var flagResults: [Result<Void, Error>] = []
     private var moveResults: [Result<Void, Error>] = []
+    private var purgeResults: [Result<Void, Error>] = []
 
     func scriptFlagResults(_ results: [Result<Void, Error>]) {
         flagResults = results
@@ -40,6 +47,10 @@ actor FakeImapClient: ImapClient {
 
     func scriptMoveResults(_ results: [Result<Void, Error>]) {
         moveResults = results
+    }
+
+    func scriptPurgeResults(_ results: [Result<Void, Error>]) {
+        purgeResults = results
     }
 
     // Initial-load script (status + top page), used by the loadInitial
@@ -72,6 +83,13 @@ actor FakeImapClient: ImapClient {
         ))
         if !moveResults.isEmpty {
             try moveResults.removeFirst().get()
+        }
+    }
+
+    func purge(folder: String, uids: [UInt32]) async throws {
+        purgeCalls.append(PurgeCall(folder: folder, uids: Set(uids)))
+        if !purgeResults.isEmpty {
+            try purgeResults.removeFirst().get()
         }
     }
 

--- a/changelog.d/optimistic-prune-folder-total.fixed.md
+++ b/changelog.d/optimistic-prune-folder-total.fixed.md
@@ -1,0 +1,8 @@
+- Apple: **Unresolvable skeleton row left behind by a locally-removed
+  message.** Archiving, moving, permanently deleting or sending a draft pruned
+  the row but left the folder's message total at its last server-reported
+  value, so the vacated slot went on rendering a loading placeholder that could
+  never resolve — and the `All` filter pill went on counting it — until the next
+  folder-status poll corrected the count, up to a couple of minutes in an
+  unsubscribed folder such as Drafts. Every optimistic removal now takes the
+  slot off the total with the row, and hands it back if the server write fails.


### PR DESCRIPTION
Addresses #843.

## What was wrong

Sending a draft pruned its row from the open Drafts list but left a grey
loading skeleton in the vacated slot — a placeholder that can never resolve,
because the message it points at no longer exists — and the `All` chip went on
counting it. On iPhone that persisted for ~2 minutes (measured 2/2 in the
issue); on iPad ~24s. The human reported the same skeleton in other folders on
archive.

## Root cause

The index-addressed list renders `max(totalMessages, loaded rows)` slots
(`MessageListView+Selection.swift`) and the `All` pill reads `totalMessages`
straight through (`MessageListView+Filter.swift`). `totalMessages` is only ever
written from a STATUS reply, so every optimistic removal — `pruneEnvelope` (the
reader/compose `signalDisposed` path, which is how a send prunes its draft),
`dispose`, `moveTo`, `performMove`, `purgeMessages` — dropped the envelope and
left the count claiming the row was still there. Drafts is unsubscribed and
gets no proactive poll, so the correction waited on the slow fallback
reconcile; polled folders showed the same skeleton, just briefly.

## The fix

One primitive, `adjustTotalMessages(by:)`, applied at every optimistic prune
and every revert:

* the four prune paths take the slot off the total with the row;
* the three restore paths (`restoreEnvelope`, `restoreAfterFailedMove`,
  `restoreAfterPartialMove`, purge's revert) hand it back;
* clamped at zero, and skipped while a search is active — search lists derive
  their row count from the results, not from a folder STATUS.

Prune sites that could be handed a UID that isn't in the loaded window measure
the actual removal (`envelopes.count` before/after) rather than assuming one,
so a signal for a row we never had loaded leaves the total alone.

This is deliberately the shared path rather than just the reported send case:
the mechanism is one missing decrement, and fixing only `pruneEnvelope` would
have left the archive case the human reported still broken.

## Verification

`CabalmailTests/OptimisticPruneTotalTests.swift` — 8 cases over the
reader-signalled prune, unloaded-UID no-op, dispose success/failure, `moveTo`
and its revert, bulk move and its revert, purge, and search mode. Shimming
`adjustTotalMessages` back to a no-op fails 5 of them (7 assertions); with the
fix, 8/8 pass. Full app-target suite green (66 tests), `swift test` green (372),
`swiftlint` clean.

Live on the iPhone 17 sim (iOS 26.5) against stage, build off this branch
merged with #844/#845:

* Drafts, saved draft, Edit Draft → Send: at +7s the list is empty and reads
  `All 0` — no skeleton row. Still `All 0` at +79s (the old behaviour was
  `All 1` + skeleton until ~+150s).
* INBOX reader → Archive: `All` drops 5 → 4 the moment the list comes back, no
  placeholder — the human's archive case.

## Known gap, not addressed here

A refresh whose STATUS was taken before the server move lands can still
re-inflate the count for one cycle: `pendingRemovedUIDs` shields `envelopes`
from a stale merge but nothing shields the counts. It needs the shield extended
to `captureCounts`, which is a bigger change than this bug wants; happy to do
it as a follow-up if you'd like.

While verifying I noticed the `Unread` pill does NOT decrement when an unread
message is archived from the reader (`All 4 / Unread 5` above) — pre-existing,
and only conspicuous now that `All` is correct. Filed separately rather than
folded in; say the word and I'll take it.