### PR TITLE
Pop the compact reader when its message goes away

### DIFF
--- a/apple/Cabalmail/Views/CompactColumnPolicy.swift
+++ b/apple/Cabalmail/Views/CompactColumnPolicy.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Which column the collapsed (iPhone-compact) navigation should show after
+/// the read message changed. A pure rule rather than an inline `if` so it can
+/// be tested directly — `MailRootView`'s `@State` isn't reachable from a unit
+/// test, this is.
+enum CompactColumnPolicy {
+    static func column(
+        hasSelectedMessage: Bool,
+        current: NavigationSplitViewColumn
+    ) -> NavigationSplitViewColumn {
+        if hasSelectedMessage { return .detail }
+        // The message being read is gone — pruned by a send, archive or move
+        // from the reader itself. A collapsed navigation has no list beside
+        // the reader to fall back on, so leaving the column on `.detail`
+        // strands the user on the empty-selection placeholder, whose "pick a
+        // message from the list" copy is addressed to a layout that isn't on
+        // screen. Pop back to the list instead. A selection cleared while the
+        // reader ISN'T up (a folder switch clearing both at once) leaves the
+        // column where it is.
+        return current == .detail ? .content : current
+    }
+}

--- a/apple/Cabalmail/Views/MailRootView.swift
+++ b/apple/Cabalmail/Views/MailRootView.swift
@@ -284,11 +284,13 @@ struct MailRootView: View {
                 appState.navCoordinator?.recordFolder(path)
             }
         }
-        // Compact navigation: a selected message pushes the reader; navigating
-        // back out (the binding falls off `.detail`) clears the selection so
-        // the same row can be reopened. No-ops on regular width / iPad.
+        // Compact navigation: a selected message pushes the reader, and losing
+        // the selection while the reader is up pops back to the list (see
+        // `CompactColumnPolicy`); navigating back out by hand (the binding
+        // falls off `.detail`) clears the selection so the same row can be
+        // reopened. No-ops on regular width / iPad.
         .onChange(of: selectedEnvelope) { _, envelope in
-            if envelope != nil { compactColumn = .detail }
+            compactColumn = CompactColumnPolicy.column(hasSelectedMessage: envelope != nil, current: compactColumn)
             // Record the open message (or its absence) for the cursor. Skipped
             // while searching — the search surface has no single folder to
             // anchor the cursor to.

--- a/apple/CabalmailTests/CompactColumnPolicyTests.swift
+++ b/apple/CabalmailTests/CompactColumnPolicyTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftUI
+@testable import Cabalmail
+
+// Regression coverage for issue #844: sending a draft from inside the reader
+// on iPhone left the user on the "No message selected / Pick a message from
+// the list to read it." placeholder, full screen, with no list beside it to
+// pick from. The send prunes the row backing the pushed reader, selection
+// goes nil, and the collapsed navigation stayed parked on `.detail`. The same
+// dead end applies to an archive or move made from the reader when there's no
+// next message to advance to. Losing the selection while the reader is up now
+// pops back to the message list.
+final class CompactColumnPolicyTests: XCTestCase {
+
+    func testSelectingAMessagePushesTheReader() {
+        XCTAssertEqual(
+            CompactColumnPolicy.column(hasSelectedMessage: true, current: .content),
+            .detail
+        )
+    }
+
+    func testLosingTheReadMessagePopsBackToTheList() {
+        XCTAssertEqual(
+            CompactColumnPolicy.column(hasSelectedMessage: false, current: .detail),
+            .content,
+            "the message being read is gone, and compact has no list beside the reader to fall back on"
+        )
+    }
+
+    func testSelectionClearedWhileOnTheListStaysOnTheList() {
+        XCTAssertEqual(
+            CompactColumnPolicy.column(hasSelectedMessage: false, current: .content),
+            .content
+        )
+    }
+
+    func testSelectionClearedWhileOnTheSidebarStaysOnTheSidebar() {
+        // A folder switch clears the selection and parks the column itself;
+        // this must not yank the user off the folder list.
+        XCTAssertEqual(
+            CompactColumnPolicy.column(hasSelectedMessage: false, current: .sidebar),
+            .sidebar
+        )
+    }
+}

--- a/changelog.d/compact-reader-pops-when-message-gone.fixed.md
+++ b/changelog.d/compact-reader-pops-when-message-gone.fixed.md
@@ -1,0 +1,6 @@
+- Apple: **iPhone reader stranded on the empty-selection placeholder.**
+  Sending a draft — or archiving or moving the last message — from inside the
+  reader removed the message being read but left the reader on screen, showing
+  a full-screen "No message selected / Pick a message from the list to read it."
+  under the folder's title bar, with no list to pick from. The reader now pops
+  back to the message list when the message it was showing goes away.


### PR DESCRIPTION
Addresses #844.

## What was wrong

Sending a draft from inside the draft reader on iPhone left the reader on
screen showing the empty-selection placeholder — "No message selected / Pick a
message from the list to read it." — full screen, under the `Drafts` title bar,
with no list beside it to pick from. Recoverable via the back chevron, but the
copy is addressed to a split-view layout that isn't there.

## Root cause

Compact navigation drives `MailRootView.compactColumn` to push the reader, but
only in one direction: `if envelope != nil { compactColumn = .detail }`. The
send prunes the row backing the pushed reader, the selection goes nil, and the
column stayed parked on `.detail`, where the detail builder falls through to
its `ContentUnavailableView`. Archiving or moving the last message from the
reader dead-ends the same way — the advance-to-next-unread has nothing to
advance to.

## The fix

Losing the selection while the reader is up pops back to the message list. A
selection cleared while the reader ISN'T up (a folder switch, which clears the
selection and parks the column itself in the same handler) is left alone, so
this can't yank the user off the folder list.

The rule lives in `CompactColumnPolicy` rather than inline: `MailRootView`'s
`@State` isn't reachable from a unit test, a pure function is. (It also keeps
`MailRootView.swift` under SwiftLint's file-length ceiling, which it was two
lines short of.)

## Verification

`CabalmailTests/CompactColumnPolicyTests.swift` — 4 cases: push on select, pop
on losing the read message, and the two "leave it alone" cases (selection
cleared while on the list / on the sidebar). Shimming the rule back to
"leave the column parked" fails the pop case; with the fix, 4/4 pass. Full
app-target suite green (62 tests), `swiftlint` clean.

Live on the iPhone 17 sim (iOS 26.5) against stage, build off this branch
merged with #843/#845:

* Drafts → draft → Edit Draft → Send: lands back on the **Drafts list** (back
  chevron, compose button, filter pills, unsubscribed banner all present), not
  the placeholder.
* INBOX reader → Archive with another unread message below: the reader stays up
  and advances to it, unchanged — the pop only fires when there's nothing to
  advance to.

Incidentally this also gets the iPhone the "Message sent." toast the tester
noted was iPad-only (#843 comment): the toast overlay is hosted with the list,
so it was previously raised behind a reader that never popped.