### PR TITLE
Title the composer "Draft" when editing a saved draft

### DIFF
--- a/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
@@ -6,6 +6,17 @@ import CabalmailKit
 /// to keep the type body under the SwiftLint length ceiling. Everything
 /// here is `@MainActor` by inheritance from the host class.
 extension ComposeViewModel {
+    // MARK: - Presentation
+
+    /// Title for the compose surface (the sheet's navigation bar on iPhone,
+    /// the window title elsewhere). "New Message" is a lie when the user
+    /// tapped Edit Draft on a saved draft: the form comes up populated, and
+    /// sending replaces that draft rather than adding a second one. Replies
+    /// and forwards keep the generic title — they really are new messages.
+    var navigationTitle: String {
+        isResumedServerDraft ? "Draft" : "New Message"
+    }
+
     // MARK: - Editor bridge health
 
     /// Banner copy for a dead editor bridge. One phrasing for both the

--- a/apple/Cabalmail/ViewModels/ComposeViewModel.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel.swift
@@ -107,6 +107,12 @@ final class ComposeViewModel {
     /// discards). Seeded from the draft when resuming; updated after every
     /// successful `/save_draft` round trip.
     var serverDraftRef: DraftServerRef?
+    /// Whether this surface opened on a draft that already exists in the
+    /// server Drafts folder (Edit Draft), rather than on a new message, reply
+    /// or forward. Captured at init rather than read off `serverDraftRef`,
+    /// which also becomes non-nil once a fresh compose autosaves: the title
+    /// describes what the user opened, not what has since been saved.
+    let isResumedServerDraft: Bool
     /// Serializes server saves so the debounce loop and an in-progress
     /// close-without-send can't append racing copies.
     var serverSaveInFlight = false
@@ -158,6 +164,7 @@ final class ComposeViewModel {
         self.references = seed.references
         self.composeIntent = seed.composeIntent ?? .new
         self.serverDraftRef = seed.serverRef
+        self.isResumedServerDraft = seed.serverRef != nil
         // Append the preference signature to the seeded body, but only once.
         // Replies / forwards seed with an attribution + quoted body; the
         // signature goes *above* that block so the user's reply text lands

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -61,7 +61,7 @@ struct ComposeView: View {
     var body: some View {
         NavigationStack {
             composeContent
-            .navigationTitle("New Message")
+            .navigationTitle(model.navigationTitle)
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif

--- a/apple/CabalmailTests/ComposeTitleTests.swift
+++ b/apple/CabalmailTests/ComposeTitleTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Regression coverage for issue #845: tapping Edit Draft on a saved draft
+// put up a composer titled "New Message", on both iPhone and iPad. It isn't
+// a new message — the form comes up populated from the draft, and sending it
+// replaces that draft rather than creating a second one. The title now keys
+// off whether the surface opened on an existing server-side Drafts copy.
+@MainActor
+final class ComposeTitleTests: XCTestCase {
+
+    func testEditingASavedDraftSaysDraft() throws {
+        // What `DraftResume.seed` produces: an ordinary compose seed carrying
+        // the Drafts-folder coordinates of the copy being resumed.
+        let model = try TestFixtures.makeComposeModel(
+            seed: Draft(subject: "Half-written", serverUid: 42, serverUidValidity: 9)
+        )
+
+        XCTAssertEqual(model.navigationTitle, "Draft")
+    }
+
+    func testFreshComposeSaysNewMessage() throws {
+        let model = try TestFixtures.makeComposeModel()
+
+        XCTAssertEqual(model.navigationTitle, "New Message")
+    }
+
+    func testReplyIsStillANewMessage() throws {
+        let model = try TestFixtures.makeComposeModel(
+            seed: Draft(subject: "Re: hello", inReplyTo: "<abc@example.com>", composeIntent: .reply)
+        )
+
+        XCTAssertEqual(
+            model.navigationTitle, "New Message",
+            "a reply really is a new message — only a resumed Drafts copy isn't"
+        )
+    }
+
+    func testAutosavingAFreshComposeDoesNotRetitleIt() throws {
+        let model = try TestFixtures.makeComposeModel()
+
+        // The first `/save_draft` round trip of a brand-new compose records a
+        // server ref; the title must keep describing what the user opened.
+        model.serverDraftRef = DraftServerRef(uid: 7, uidValidity: 9)
+
+        XCTAssertEqual(model.navigationTitle, "New Message")
+    }
+}

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -217,10 +217,14 @@ enum TestFixtures {
     /// it; the bridge-health tests drive the failure hooks directly rather
     /// than depending on whether `editor.html` loads in the test host.
     @MainActor
-    static func makeComposeModel(imap: FakeImapClient = FakeImapClient()) throws -> ComposeViewModel {
+    static func makeComposeModel(
+        seed: Draft = Draft(),
+        imap: FakeImapClient = FakeImapClient()
+    ) throws -> ComposeViewModel {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("cabalmail-compose-tests-\(UUID().uuidString)")
         return ComposeViewModel(
+            seed: seed,
             client: try makeClient(imap: imap),
             draftStore: try DraftStore(directory: tmp),
             preferences: Preferences(store: InMemoryPreferenceStore()),

--- a/changelog.d/edit-draft-composer-title.fixed.md
+++ b/changelog.d/edit-draft-composer-title.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Composer titled "New Message" when editing a saved draft.** Opening
+  a draft for editing put up a populated form under a "New Message" title,
+  though sending it replaces that draft rather than creating a second one. The
+  composer now reads "Draft" when it opened on a saved draft; new messages,
+  replies and forwards are unchanged.


### PR DESCRIPTION
Addresses #845.

## What was wrong

Opening a saved draft for editing put up a composer titled **"New Message"**,
on iPhone and iPad both, with the draft's From, To, subject and body already
populated — and sending it replaces that draft rather than creating a second
one. Since #839 made `Edit Draft` a first-class reader action it's easy to hit.

## Root cause

`ComposeView` hard-coded `.navigationTitle("New Message")`. The same surface
serves compose, reply, forward and edit-draft, so nothing distinguished them.

## The fix

The title now keys off whether the surface opened on a draft that already
exists in the server Drafts folder — "Draft" if so, "New Message" otherwise.
Replies and forwards keep the generic title; they really are new messages.

Captured at init (`isResumedServerDraft`) rather than read off the live
`serverDraftRef`, which also becomes non-nil once a fresh compose autosaves:
the title should describe what the user opened, not what has since been saved.
The title string itself lives on the view model (`navigationTitle`) so it's
testable and the view stays declarative.

I went with "Draft" over the draft's subject (the issue offered either): a
subject-derived title would change under the user as they type it, and an
untitled draft would leave the bar empty.

## Verification

`CabalmailTests/ComposeTitleTests.swift` — resumed draft says "Draft", fresh
compose and reply say "New Message", and autosaving a fresh compose doesn't
retitle it. Shimming the title back to a constant fails the resumed-draft case;
with the fix, 4/4 pass. Full app-target suite green (62 tests), `swiftlint`
clean.

Live on the iPhone 17 sim (iOS 26.5) against stage: Drafts → draft →
`Edit Draft` shows a populated form titled **Draft**; the toolbar compose
button still opens **New Message**.

Not touched: the macOS/iPad compose `WindowGroup("New Message")` default, which
`.navigationTitle` overrides once content renders.