### PR TITLE
Return a clean 404 when a requested message is gone from the folder

### DIFF
--- a/changelog.d/message-gone-404.fixed.md
+++ b/changelog.d/message-gone-404.fixed.md
@@ -1,0 +1,7 @@
+- **Clean 404 when a message is no longer in the folder.** Requesting a message
+  whose UID has been expunged (moved, deleted, or emptied from Trash by another
+  client) and whose body was never cached raised a `KeyError` inside the shared
+  message loader, which API Gateway turned into a bodiless 502. `fetch_message`,
+  `fetch_attachment`, `list_attachments`, and `fetch_inline_image` now return a
+  404 naming the folder, so clients can tell "this message is gone, refresh the
+  folder" from "the server is broken".

--- a/lambda/api/_shared/helper.py
+++ b/lambda/api/_shared/helper.py
@@ -110,6 +110,15 @@ class MaintenanceError(Exception):
         super().__init__('IMAP is in planned maintenance')
 
 
+class MessageGoneError(Exception):
+    '''Raised by get_message when the requested UID is no longer in the folder.
+    message_gone_guard translates it into a 404 the clients can act on.'''
+    def __init__(self, folder, msg_id):
+        self.folder = folder
+        self.msg_id = msg_id
+        super().__init__(f'no message with UID {msg_id} in {folder}')
+
+
 def _read_maintenance_param():
     '''Returns the parsed maintenance flag dict, or None. TTL-cached per warm
     container. Fails open to None on any read/parse error.'''
@@ -175,6 +184,33 @@ def maintenance_response(state):
             "retry_after": retry_after,
         })
     }
+
+
+def message_gone_response(folder, msg_id):
+    '''Builds the 404 served when a requested UID is no longer in the folder.'''
+    return {
+        "statusCode": 404,
+        "body": json.dumps({
+            "status": f"That message is no longer in {folder.split('.')[-1]}",
+            "folder": folder,
+            "id": msg_id,
+        })
+    }
+
+
+def message_gone_guard(handler):
+    '''Decorator: turns a MessageGoneError raised anywhere inside a handler
+    that loads a message body into a 404. Left unhandled it escaped as a
+    KeyError, and API Gateway turned that into a bodiless 502 -- clients could
+    not tell "this message is gone" (refresh the folder) from "the server is
+    broken" (retry later).'''
+    @functools.wraps(handler)
+    def wrapper(event, context):
+        try:
+            return handler(event, context)
+        except MessageGoneError as err:
+            return message_gone_response(err.folder, err.msg_id)
+    return wrapper
 
 
 def maintenance_guard(handler):
@@ -876,8 +912,12 @@ def get_message(_host, user, folder, msg_id):
     else:
         client = get_imap_client(IMAP_HOST, user, folder, True)
         message = client.fetch([msg_id],['RFC822'])
-        email_body_raw = message[msg_id][b'RFC822']
         client.logout()
+        # A UID FETCH for a UID that is no longer in the mailbox succeeds and
+        # returns an empty dict, so the subscript below is not guaranteed.
+        if msg_id not in message:
+            raise MessageGoneError(folder, msg_id)
+        email_body_raw = message[msg_id][b'RFC822']
         upload_object(bucket, key, "text/plain", email_body_raw)
     message = email.message_from_bytes(email_body_raw, policy=default_policy)
     return message

--- a/lambda/api/_shared/tests/test_get_message_gone.py
+++ b/lambda/api/_shared/tests/test_get_message_gone.py
@@ -1,0 +1,195 @@
+'''Unit tests for get_message's handling of a UID that is no longer in the
+folder, and for the 404 the guard builds from it.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_get_message_gone.py
+
+helper.py's third-party imports (boto3, botocore, imap_session) are faked in
+sys.modules before import, so the suite needs no AWS access and never dials an
+IMAP server. The fake client mirrors the behavior under test: like a real
+server, an IMAP UID FETCH for a UID that has been expunged succeeds and returns
+an empty dict rather than failing.'''
+import os
+import sys
+import types
+import unittest
+
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
+
+_SHARED = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SHARED)
+sys.path.insert(0, os.path.join(os.path.dirname(_SHARED), 'fetch_message'))
+
+# --- fake boto3 / botocore ---------------------------------------------------
+
+
+class _FakeSSMExceptions:
+    class ParameterNotFound(Exception):
+        pass
+
+
+class _FakeSSM:
+    exceptions = _FakeSSMExceptions
+
+    def get_parameter(self, Name=None, **_kwargs):  # pylint: disable=invalid-name
+        if Name == '/cabal/maintenance/imap':
+            raise _FakeSSMExceptions.ParameterNotFound()
+        return {"Parameter": {"Value": "fake-master-password"}}
+
+
+class _FakeResource:
+    def Table(self, _name):  # pylint: disable=invalid-name
+        return types.SimpleNamespace()
+
+
+_boto3 = types.ModuleType("boto3")
+_boto3.resource = lambda _name, **_kw: _FakeResource()
+_boto3.client = lambda name, **_kw: _FakeSSM() if name == 'ssm' else types.SimpleNamespace()
+_boto3.session = types.SimpleNamespace(Config=lambda **_kw: None)
+sys.modules['boto3'] = _boto3
+
+_botocore = types.ModuleType("botocore")
+_botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+
+class _ClientError(Exception):
+    pass
+
+
+_botocore_exceptions.ClientError = _ClientError
+_botocore.exceptions = _botocore_exceptions
+sys.modules['botocore'] = _botocore
+sys.modules['botocore.exceptions'] = _botocore_exceptions
+
+# --- fake imap_session -------------------------------------------------------
+
+# UIDs the fake server still holds; a FETCH for anything else comes back empty.
+PRESENT_UIDS = {}
+OPENED = []
+
+RAW_MESSAGE = (b'From: someone@example.com\r\n'
+               b'Subject: still here\r\n'
+               b'Content-Type: text/plain\r\n\r\n'
+               b'body\r\n')
+
+
+class _FakeImapClient:
+    def __init__(self):
+        self.logged_out = False
+
+    def fetch(self, uids, _parts):
+        return {uid: {b'RFC822': PRESENT_UIDS[uid]} for uid in uids if uid in PRESENT_UIDS}
+
+    def logout(self):
+        self.logged_out = True
+
+
+def _open_imap_client(host, user, folder, _read_only, _mpw):
+    client = _FakeImapClient()
+    OPENED.append({'host': host, 'user': user, 'folder': folder, 'client': client})
+    return client
+
+
+_imap_session = types.ModuleType("imap_session")
+_imap_session.open_imap_client = _open_imap_client
+sys.modules['imap_session'] = _imap_session
+
+import helper  # noqa: E402  pylint: disable=wrong-import-position
+
+# fetch_message's handler imports `helper` by name, exactly as it does inside
+# its deployed zip, so the real module above is what it binds to.
+import function as fetch_message  # noqa: E402  pylint: disable=wrong-import-position
+
+UPLOADED = []
+
+
+def _event(folder='INBOX', msg_id=27):
+    return {
+        'queryStringParameters': {'host': 'imap.test.example.com',
+                                  'folder': folder,
+                                  'id': str(msg_id)},
+        'requestContext': {'authorizer': {'claims': {'cognito:username': 'testuser'}}},
+    }
+
+
+class GetMessageGoneTest(unittest.TestCase):
+
+    def setUp(self):
+        PRESENT_UIDS.clear()
+        OPENED.clear()
+        UPLOADED.clear()
+        # Nothing is in the S3 cache, so every read goes to IMAP.
+        self._saved = (helper.key_exists, helper.upload_object)
+        helper.key_exists = lambda _bucket, _key: False
+        helper.upload_object = lambda bucket, key, ctype, obj: UPLOADED.append(key) or True
+
+    def tearDown(self):
+        helper.key_exists, helper.upload_object = self._saved
+
+    def test_expunged_uid_raises_message_gone(self):
+        # UID 27 was moved out of INBOX and expunged: the FETCH succeeds and
+        # returns nothing for it.
+        with self.assertRaises(helper.MessageGoneError) as caught:
+            helper.get_message(None, 'testuser', 'INBOX', 27)
+        self.assertEqual(caught.exception.folder, 'INBOX')
+        self.assertEqual(caught.exception.msg_id, 27)
+        self.assertTrue(OPENED[-1]['client'].logged_out)
+        # Nothing may be written to the body cache for a message that is gone.
+        self.assertEqual(UPLOADED, [])
+
+    def test_present_uid_still_loads(self):
+        PRESENT_UIDS[28] = RAW_MESSAGE
+        message = helper.get_message(None, 'testuser', 'INBOX', 28)
+        self.assertEqual(message.get('Subject'), 'still here')
+        self.assertEqual(UPLOADED, ['testuser/INBOX/28/raw'])
+
+
+class MessageGoneResponseTest(unittest.TestCase):
+
+    def test_guard_turns_the_error_into_a_404(self):
+        @helper.message_gone_guard
+        def handler(_event, _context):
+            raise helper.MessageGoneError('Archive.2026', 27)
+
+        response = handler({}, None)
+        self.assertEqual(response['statusCode'], 404)
+        self.assertIn('2026', response['body'])
+
+    def test_guard_passes_a_normal_response_through(self):
+        @helper.message_gone_guard
+        def handler(_event, _context):
+            return {'statusCode': 200, 'body': '{}'}
+
+        self.assertEqual(handler({}, None)['statusCode'], 200)
+
+
+class FetchMessageHandlerTest(unittest.TestCase):
+    '''The handler is what the clients see: an expunged UID used to escape as a
+    KeyError and reach the client as a bodiless 502.'''
+
+    def setUp(self):
+        PRESENT_UIDS.clear()
+        OPENED.clear()
+        self._saved = (helper.key_exists, helper.upload_object)
+        helper.key_exists = lambda _bucket, _key: False
+        helper.upload_object = lambda _bucket, _key, _ctype, _obj: True
+
+    def tearDown(self):
+        helper.key_exists, helper.upload_object = self._saved
+
+    def test_expunged_uid_is_a_404_not_a_502(self):
+        response = fetch_message.handler(_event(msg_id=27), None)
+        self.assertEqual(response['statusCode'], 404)
+        self.assertTrue(response['body'])
+
+    def test_present_uid_is_unaffected(self):
+        PRESENT_UIDS[28] = RAW_MESSAGE
+        fetch_message.sign_url = lambda _bucket, _key: 'https://example.invalid/raw'
+        response = fetch_message.handler(_event(msg_id=28), None)
+        self.assertEqual(response['statusCode'], 200)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/fetch_attachment/function.py
+++ b/lambda/api/fetch_attachment/function.py
@@ -8,9 +8,11 @@ from helper import get_message # pylint: disable=import-error
 from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
+from helper import message_gone_guard # pylint: disable=import-error
 
 
 @maintenance_guard
+@message_gone_guard
 def handler(event, _context):
     '''Preps an attachment for download from S3 given a folder, message ID,
     and attachment serial number'''

--- a/lambda/api/fetch_inline_image/function.py
+++ b/lambda/api/fetch_inline_image/function.py
@@ -11,9 +11,11 @@ from helper import validate_uid # pylint: disable=import-error
 from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
+from helper import message_gone_guard # pylint: disable=import-error
 
 
 @maintenance_guard
+@message_gone_guard
 def handler(event, _context):
     '''Preps an inline image attachment for download from S3 given a folder,
     message ID, and attachment uuid'''

--- a/lambda/api/fetch_message/function.py
+++ b/lambda/api/fetch_message/function.py
@@ -6,9 +6,11 @@ from helper import sign_url # pylint: disable=import-error
 from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
+from helper import message_gone_guard # pylint: disable=import-error
 
 
 @maintenance_guard
+@message_gone_guard
 def handler(event, _context):
     '''Retrieves IMAP message given a folder and ID'''
     query_string = event['queryStringParameters']

--- a/lambda/api/list_attachments/function.py
+++ b/lambda/api/list_attachments/function.py
@@ -3,9 +3,11 @@ import json
 from helper import get_message # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
+from helper import message_gone_guard # pylint: disable=import-error
 
 
 @maintenance_guard
+@message_gone_guard
 def handler(event, _context):
     '''Retrieves list of attachments from a message given a folder and ID'''
     query_string = event['queryStringParameters']

--- a/lambda/api/push_envelope/function.py
+++ b/lambda/api/push_envelope/function.py
@@ -22,6 +22,7 @@ from helper import get_message  # pylint: disable=import-error
 from helper import get_object  # pylint: disable=import-error
 from helper import key_exists  # pylint: disable=import-error
 from helper import maintenance_guard  # pylint: disable=import-error
+from helper import MessageGoneError  # pylint: disable=import-error
 from helper import parse_json_body  # pylint: disable=import-error
 from helper import upload_object  # pylint: disable=import-error
 from helper import validate_content_id  # pylint: disable=import-error
@@ -150,7 +151,7 @@ def handler(event, _context):
     else:
         try:
             message = get_message(None, user, folder, uid)
-        except KeyError:
+        except MessageGoneError:
             message = None
     if uid is None or message is None:
         # No UID resolvable, expunged, or a stale hint.


### PR DESCRIPTION
## What was wrong

Opening a message whose UID is no longer in the folder returned a bodiless
`502 {"message": "Internal server error"}`. The Apple reader surfaces that
verbatim (`server(code: "502", …)`), and no client can tell "this message is
gone — refresh the folder" from "the server is broken — retry later".

## Root cause

`helper.get_message` subscripts the FETCH result without a membership check:

```python
message = client.fetch([msg_id], ['RFC822'])
email_body_raw = message[msg_id][b'RFC822']
```

An IMAP `UID FETCH` for an expunged UID *succeeds* and returns an empty dict, so
that subscript raises `KeyError`, and the unhandled exception becomes an API
Gateway 502.

The tester's verification on #840 pins the trigger more precisely than the title
does: the 502 needs the UID to be gone **and** the body to have never been cached
in S3 — `get_message` short-circuits on the `{user}/{folder}/{id}/raw` key before
it talks to IMAP, which is why only never-opened rows 502.

## The fix

- `get_message` raises a typed `MessageGoneError(folder, msg_id)` instead of
  falling into the subscript, and logs the client out before it raises (the old
  `KeyError` path leaked the connection).
- New `message_gone_guard` decorator, alongside the existing `maintenance_guard`,
  turns that into `404 {"status": "That message is no longer in <Folder>", …}`.
- Applied to all four handlers that load a message body — `fetch_message`,
  `fetch_attachment`, `list_attachments`, `fetch_inline_image`. They all call the
  same `get_message`, so fixing only the reported one would leave the same
  expunged UID 502ing on three sibling endpoints, which would read as
  nondeterministic.
- `push_envelope` already had a not-found path built on `except KeyError`; it now
  catches `MessageGoneError` so the NSE keeps its 404.

## Test evidence

New `lambda/api/_shared/tests/test_get_message_gone.py` (6 tests; stdlib
unittest, boto3/imap_session faked in `sys.modules`, per the existing
`_shared/tests` harness). It covers the helper, the guard, and the real
`fetch_message` handler wired to the real helper.

Fails before (pre-fix subscript restored):

```
ERROR: test_expunged_uid_raises_message_gone
  File ".../helper.py", line 915, in get_message
    email_body_raw = message[msg_id][b'RFC822']
KeyError: 27
Ran 6 tests — FAILED (errors=2)
```

— the same stack the issue quotes from CloudWatch. Passes after: `Ran 6 tests … OK`.

Also green: every other `lambda/api` suite (`delete_folder`, `new_folder`,
`fetch_bimi`, `_shared/test_imap_pool`, `test_imap_session_dial`,
`test_folder_subscriptions`) and `pylint --rcfile .pylintrc _shared/*.py
*/function.py push_dispatch/apns.py` at 10.00/10.

Not exercised against live stage — read-only AWS access here, and the change is
on the deploy path.

## Offered, not taken

The tester's second finding: the **cached** path still serves the body of a
message the server no longer has (a message opened once before it vanished keeps
returning 200 forever). That is a deliberate-looking cache behaviour with real
upside offline, and turning it into a "gone" verdict means either a UID
existence probe on every cache hit or cache invalidation on the mutation paths
(`move_messages`, `purge_messages`, `empty_trash`) — a bigger change than this
one, and a product call. Happy to take it as a follow-up if you want the two
paths to agree.

Addresses #840