### PR TITLE
Make links in plain-text message bodies tappable

### DIFF
--- a/apple/Cabalmail/Views/LinkMenu.swift
+++ b/apple/Cabalmail/Views/LinkMenu.swift
@@ -26,6 +26,18 @@ struct LinkMenuTarget: Identifiable, Equatable {
         return scheme == "http" || scheme == "https"
     }
 
+    /// A link activated in a plain-text body, where there is no web view to
+    /// report a bounding box — the menu anchors to the body instead.
+    init?(url: URL, text: String) {
+        guard
+            let scheme = url.scheme?.lowercased(),
+            !Self.blockedSchemes.contains(scheme)
+        else { return nil }
+        self.url = url
+        self.text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.rect = .zero
+    }
+
     init?(bridgePayload payload: [String: Any]) {
         guard
             let href = payload["href"] as? String,

--- a/apple/Cabalmail/Views/MessageDetailView+Scroll.swift
+++ b/apple/Cabalmail/Views/MessageDetailView+Scroll.swift
@@ -66,12 +66,7 @@ extension MessageDetailView {
     @ViewBuilder
     private func plainBodyView(_ plain: String) -> some View {
         ScrollView {
-            Text(plain)
-                .font(.body)
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
+            PlainTextBodyView(plain: plain)
         }
         .scrollPosition($plainScrollPosition)
         .onScrollGeometryChange(for: CGFloat.self) { geometry in

--- a/apple/Cabalmail/Views/PlainTextBodyView.swift
+++ b/apple/Cabalmail/Views/PlainTextBodyView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// URLs and email addresses found in a plain-text body, ready to render.
+/// `labels` maps each destination back to the text the user actually sees, so
+/// the link menu can offer "Copy Link Text" when it differs from the address.
+struct PlainTextLinks: Equatable {
+    let attributed: AttributedString
+    let labels: [URL: String]
+
+    static let empty = PlainTextLinks(attributed: AttributedString(), labels: [:])
+}
+
+/// Linkifies plain-text bodies. A `text/plain` part carries no markup, so the
+/// only way its URLs become actionable is to detect them: `NSDataDetector` is
+/// the same machinery Mail and Messages use, and it already handles trailing
+/// punctuation and bare `www.` hosts.
+enum PlainTextLinkDetector {
+    private static let detector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+    )
+
+    /// Returns `plain` with `.link` runs (and link styling) over every detected
+    /// URL. The character content is untouched — the reader's plain-text scroll
+    /// restore reports exact content offsets, so the body must not reflow.
+    static func scan(_ plain: String) -> PlainTextLinks {
+        var attributed = AttributedString(plain)
+        guard let detector else { return PlainTextLinks(attributed: attributed, labels: [:]) }
+        let full = NSRange(plain.startIndex..., in: plain)
+        var labels: [URL: String] = [:]
+        for match in detector.matches(in: plain, range: full) {
+            guard
+                let url = match.url,
+                let stringRange = Range(match.range, in: plain),
+                let range = Range(stringRange, in: attributed)
+            else { continue }
+            attributed[range].link = url
+            attributed[range].underlineStyle = .single
+            labels[url] = String(plain[stringRange])
+        }
+        return PlainTextLinks(attributed: attributed, labels: labels)
+    }
+
+    /// Builds the menu target for a link the user activated in a plain-text
+    /// body. The visible text of a detected link is usually the address itself;
+    /// passing it through as the link text would give the menu two rows that
+    /// copy the same string, so an identical label is reported as absent (the
+    /// menu hides "Copy Link Text" for an empty one).
+    static func menuTarget(for url: URL, labels: [URL: String]) -> LinkMenuTarget? {
+        let label = labels[url] ?? ""
+        let distinct = label == url.absoluteString ? "" : label
+        return LinkMenuTarget(url: url, text: distinct)
+    }
+}
+
+/// Plain-text body content: the message text with its URLs made tappable and
+/// routed through the reader's link menu, so the plain path offers the same
+/// actions as the HTML one (issue #765). Presentation lives here rather than in
+/// `MessageDetailView` so the menu state travels with the body it belongs to.
+struct PlainTextBodyView: View {
+    let plain: String
+
+    @State private var links: PlainTextLinks?
+    @State private var linkMenu: LinkMenuTarget?
+    /// Resolved from the ambient environment, above the override installed on
+    /// the text below — the menu's "Open" action must reach the system opener,
+    /// not bounce back into the menu.
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        let scanned = links ?? PlainTextLinks.empty
+        Text(links == nil ? AttributedString(plain) : scanned.attributed)
+            .font(.body)
+            .foregroundStyle(.primary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .environment(\.openURL, OpenURLAction { url in
+                guard let target = PlainTextLinkDetector.menuTarget(
+                    for: url,
+                    labels: scanned.labels
+                ) else { return .systemAction }
+                linkMenu = target
+                return .handled
+            })
+            .popover(item: $linkMenu) { target in
+                LinkActionMenuView(target: target) { action in
+                    handleMenuAction(action, for: target)
+                }
+                .presentationCompactAdaptation(.popover)
+            }
+            .task(id: plain) { links = PlainTextLinkDetector.scan(plain) }
+    }
+
+    private func handleMenuAction(_ action: LinkActionMenuView.Action, for target: LinkMenuTarget) {
+        switch action {
+        case .copyText:
+            copyToPasteboard(target.text)
+        case .copyAddress:
+            copyToPasteboard(target.url.absoluteString)
+        case .open:
+            openURL(target.url)
+        }
+        linkMenu = nil
+    }
+}

--- a/apple/CabalmailTests/PlainTextLinkDetectorTests.swift
+++ b/apple/CabalmailTests/PlainTextLinkDetectorTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import Cabalmail
+
+/// Linkification of plain-text message bodies (issue #765): the `text/plain`
+/// path used to render a bare `Text`, so URLs in it were inert while the HTML
+/// path had the full reader link menu.
+final class PlainTextLinkDetectorTests: XCTestCase {
+
+    private func links(in attributed: AttributedString) -> [URL] {
+        attributed.runs.compactMap { $0.link }
+    }
+
+    private func linkedText(_ attributed: AttributedString, for url: URL) -> String? {
+        for run in attributed.runs where run.link == url {
+            return String(attributed[run.range].characters)
+        }
+        return nil
+    }
+
+    func testBareURLBecomesALink() {
+        let scanned = PlainTextLinkDetector.scan(
+            "See https://example.com/plain-link-0730 for details."
+        )
+        XCTAssertEqual(
+            links(in: scanned.attributed).map(\.absoluteString),
+            ["https://example.com/plain-link-0730"]
+        )
+        XCTAssertEqual(
+            linkedText(scanned.attributed, for: URL(string: "https://example.com/plain-link-0730")!),
+            "https://example.com/plain-link-0730"
+        )
+    }
+
+    func testEmailAddressBecomesAMailtoLink() {
+        let scanned = PlainTextLinkDetector.scan("Write to someone@example.com any time.")
+        XCTAssertEqual(
+            links(in: scanned.attributed).map(\.absoluteString),
+            ["mailto:someone@example.com"]
+        )
+    }
+
+    func testSeveralLinksAreAllDetected() {
+        let scanned = PlainTextLinkDetector.scan(
+            """
+            First: https://one.example.com/a
+            Second: http://two.example.com/b
+            """
+        )
+        XCTAssertEqual(
+            Set(links(in: scanned.attributed).map(\.absoluteString)),
+            ["https://one.example.com/a", "http://two.example.com/b"]
+        )
+    }
+
+    func testProseWithoutURLsGetsNoLinks() {
+        let scanned = PlainTextLinkDetector.scan("Nothing to see here, thanks.")
+        XCTAssertTrue(links(in: scanned.attributed).isEmpty)
+    }
+
+    func testCharacterContentIsUnchanged() {
+        // The reader restores plain-text scroll by exact content offset, so
+        // linkification must not add, drop, or rewrite a single character.
+        let plain = "Top line\n\nhttps://example.com/x?q=1&r=2\n\nTrailing line\n"
+        let scanned = PlainTextLinkDetector.scan(plain)
+        XCTAssertEqual(String(scanned.attributed.characters), plain)
+    }
+
+    func testMenuTargetDropsALabelIdenticalToTheAddress() throws {
+        let scanned = PlainTextLinkDetector.scan("Go to https://example.com/x now")
+        let url = try XCTUnwrap(links(in: scanned.attributed).first)
+        let target = try XCTUnwrap(
+            PlainTextLinkDetector.menuTarget(for: url, labels: scanned.labels)
+        )
+        XCTAssertEqual(target.url, url)
+        // "Copy Link Text" would duplicate "Copy Link Address" here, and the
+        // menu hides that row for an empty label.
+        XCTAssertEqual(target.text, "")
+    }
+
+    func testMenuTargetKeepsALabelThatDiffersFromTheAddress() throws {
+        // NSDataDetector completes a bare host into a scheme-qualified URL, so
+        // the text the user saw and the destination are not the same string.
+        let scanned = PlainTextLinkDetector.scan("Visit www.example.com today")
+        let url = try XCTUnwrap(links(in: scanned.attributed).first)
+        let target = try XCTUnwrap(
+            PlainTextLinkDetector.menuTarget(for: url, labels: scanned.labels)
+        )
+        XCTAssertEqual(target.text, "www.example.com")
+    }
+
+    func testMenuTargetRejectsAnExecutableScheme() {
+        let url = URL(string: "javascript:alert(1)")!
+        XCTAssertNil(PlainTextLinkDetector.menuTarget(for: url, labels: [:]))
+    }
+}

--- a/changelog.d/plain-text-body-links.fixed.md
+++ b/changelog.d/plain-text-body-links.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Tappable links in plain-text bodies.** URLs and email addresses in a
+  `text/plain` message body rendered as inert text — none of the reader's link
+  handling reached them, because the plain path drew a bare `Text`. They are now
+  detected, styled as links, and activate the same link menu (copy text / copy
+  address / open / share) the HTML path offers.


### PR DESCRIPTION
## What was wrong

A `text/plain` message body rendered every URL as ordinary text: no styling, no
tap target, none of #764's link handling. The tester's verification on #765
confirmed it on the iPhone sim — three taps across the URL's frame left the
screen pixel-identical, while the same URL in the same message's HTML part
raised the full link menu.

## Root cause

`plainBodyView` (`MessageDetailView+Scroll.swift`) drew a bare
`Text(plain).textSelection(.enabled)`. Plain text carries no markup, so unless
the reader detects links there is nothing for the link machinery to attach to —
this is a gap, not a regression.

## The fix

New `PlainTextBodyView` (+ `PlainTextLinkDetector`) replaces the bare `Text`:

- `NSDataDetector` finds URLs and email addresses (it already handles trailing
  punctuation and bare `www.` hosts, and turns an address into `mailto:`); each
  match becomes a `.link` run with an underline.
- Activation is intercepted with an `OpenURLAction` override on the text and
  presents the *existing* `LinkActionMenuView`, so the plain path offers the same
  actions as the HTML path. The system opener is captured from the environment
  *above* the override, so "Open in Browser" cannot bounce back into the menu.
- The detected label is dropped when it equals the destination, so a bare URL
  doesn't get a "Copy Link Text" row that duplicates "Copy Link Address".
- Character content is untouched — the reader restores plain-text scroll by exact
  content offset, so the body must not reflow. There's a test pinning that.

`LinkMenuTarget` gains an `init?(url:text:)` for the no-web-view case, keeping the
same blocked-scheme guard (`javascript:`, `data:`, `file:`, …) as the bridge init.

This is in `Cabalmail/Views`, which compiles into **CabalmailMac** too, so macOS
gets it as well.

## Test evidence

New `apple/CabalmailTests/PlainTextLinkDetectorTests.swift` (8 tests, run in the
`CabalmailMacTests` target): bare URL, email → `mailto:`, several links, prose
with none, character content unchanged, label-equals-address, label-differs
(`www.` completion), and executable-scheme rejection.

- After: `Executed 8 tests, with 0 failures`.
- Before (with `scan` shimmed back to the old "no links" behaviour):
  `Executed 8 tests, with 6 failures`.
- `swiftlint` from `apple/`: clean.

Live repro on the iPhone 17 sim (iOS 26.5), stage account, this build, using the
tester's own seed message ("Link seed 0726"), following the steps from #765:

1. Open the message → ••• → **Show plain text**: the two URLs now render green +
   underlined (they were plain black text before).
2. Single tap on `https://example.com/tester-0726` → the reader link menu opens
   anchored at the link, showing the destination plus *Copy Link Address* /
   *Open in Browser* / *Share…* — and correctly no *Copy Link Text*, since the
   visible text is the address.
3. *Share…* raised the system share sheet for `example.com`.

Sim state restored afterwards: HTML view re-selected and the tester's build
reinstalled from `/tmp/cabal-dd-sim`, still signed in to stage.

Addresses #765