### PR TITLE
Stub the SMTP dial tests at the transport, not at connect()

### DIFF
--- a/lambda/api/_shared/smtp_session.py
+++ b/lambda/api/_shared/smtp_session.py
@@ -5,10 +5,11 @@ SMTP_INTERNAL_HOST is set (the smtp-out task's Cloud Map name), the TCP
 connection goes there directly - no NLB, no NAT hairpin - while TLS
 verification keeps using the public submission hostname, because the
 container serves the wildcard *.<control-domain> certificate. The split
-lives in _get_socket: smtplib's SMTP_SSL wraps the socket with
-server_hostname=self._host (the constructor's host argument, which
-connect() never overwrites), so overriding only the TCP destination
-leaves the certificate check real and unchanged.
+lives in _get_socket: connect() records the public host it was given
+as self._host before asking _get_socket for the socket, and smtplib's
+SMTP_SSL wraps that socket with server_hostname=self._host, so
+overriding only the TCP destination leaves the certificate check real
+and unchanged.
 
 Unlike the IMAP path, this dial FALLS BACK to the public listener when
 the internal name does not resolve or refuses the connection. Cloud Map

--- a/lambda/api/_shared/tests/test_smtp_session_dial.py
+++ b/lambda/api/_shared/tests/test_smtp_session_dial.py
@@ -6,21 +6,25 @@ There is no pytest harness in this repo, so this runs under the stdlib:
     python3 lambda/api/_shared/tests/test_smtp_session_dial.py
 
 smtp_session is stdlib-only, so the module imports for real; the tests
-patch smtplib internals at the class level so nothing dials a network.
-The assertions pin the contract the cutover depends on:
+stub the transport - the TCP connect and the TLS wrap - and let the rest
+of smtplib run, so the assertions see the values smtplib itself computes.
+Stubbing any higher (SMTP.connect, say) would hide the very code that
+picks the TLS server_hostname. The assertions pin the contract the
+cutover depends on:
 
   - with SMTP_INTERNAL_HOST set, the TCP dial goes to the internal name
-    while self._host keeps the public name (which SMTP_SSL passes as
-    server_hostname, so the wildcard-certificate check is unchanged);
+    while TLS is negotiated for the public name (which is what the
+    wildcard certificate carries, so verification is unchanged);
   - a failed internal dial (gaierror et al.) falls back to the public
     listener, but an ssl.SSLError - despite subclassing OSError - does
     NOT fall back;
   - with the env var unset, a plain smtplib.SMTP_SSL(host) is built.
 '''
 import importlib
+import io
 import os
-import smtplib
 import socket
+import smtplib
 import ssl
 import sys
 import unittest
@@ -30,6 +34,7 @@ sys.path.insert(0, _SHARED_DIR)
 
 PUBLIC_HOST = 'smtp-out.control.example'
 INTERNAL = 'smtp-out.cabal.internal'
+SUBMISSION_PORT = 465
 
 
 def _import_smtp_session(internal_host):
@@ -43,27 +48,66 @@ def _import_smtp_session(internal_host):
     return importlib.import_module('smtp_session')
 
 
-class _RecordingConnects(unittest.TestCase):
-    '''Base: patches smtplib.SMTP.connect to record its host argument and
-    skip the network. connect() is what __init__ calls, and it is also the
-    only caller of _get_socket, so recording here captures the TCP target
-    each dial variant would use.'''
+class _FakeSocket:
+    '''The slice of the socket surface smtplib.connect uses: a greeting
+    to read back, and a close.'''
+
+    def makefile(self, *args, **kwargs):
+        del args, kwargs
+        return io.BytesIO(b'220 smtp-out.test ESMTP ready\r\n')
+
+    def close(self):
+        pass
+
+
+class _StubbedTransport(unittest.TestCase):
+    '''Base: replaces socket.create_connection (the TCP dial) and
+    SSLContext.wrap_socket (the TLS handshake), recording what each was
+    asked for, so a dial runs the real smtplib code path without a
+    network. Also pins socket.getfqdn - smtplib calls it to build the
+    EHLO name, and a unit test has no business consulting the resolver.
+
+    Subclasses may set self.dial_error (a callable taking the dial host
+    and returning an exception to raise, or None) and self.tls_error (an
+    exception to raise from the handshake) to inject failures.'''
 
     def setUp(self):
-        self.connects = []
+        self.dials = []       # (host, port) the TCP layer was asked for
+        self.tls_names = []   # server_hostname each handshake verified
+        self.dial_error = None
+        self.tls_error = None
         tests = self
 
-        def fake_connect(client, host='localhost', port=0, source_address=None):
-            del source_address
-            tests.connects.append((client, host, port))
-            return (220, b'ok')
+        def fake_create_connection(address, timeout=None,
+                                   source_address=None):
+            del timeout, source_address
+            host, port = address
+            tests.dials.append((host, port))
+            if tests.dial_error is not None:
+                err = tests.dial_error(host)
+                if err is not None:
+                    raise err
+            return _FakeSocket()
 
-        self._orig_connect = smtplib.SMTP.connect
-        smtplib.SMTP.connect = fake_connect
-        self.addCleanup(setattr, smtplib.SMTP, 'connect', self._orig_connect)
+        def fake_wrap_socket(context, sock, *args, server_hostname=None,
+                             **kwargs):
+            del context, args, kwargs
+            tests.tls_names.append(server_hostname)
+            if tests.tls_error is not None:
+                raise tests.tls_error
+            return sock
+
+        self._patch(socket, 'create_connection', fake_create_connection)
+        self._patch(ssl.SSLContext, 'wrap_socket', fake_wrap_socket)
+        self._patch(socket, 'getfqdn', lambda name='': 'lambda.test.invalid')
+
+    def _patch(self, target, name, replacement):
+        original = getattr(target, name)
+        setattr(target, name, replacement)
+        self.addCleanup(setattr, target, name, original)
 
 
-class PublicPathTest(_RecordingConnects):
+class PublicPathTest(_StubbedTransport):
 
     def setUp(self):
         super().setUp()
@@ -72,65 +116,44 @@ class PublicPathTest(_RecordingConnects):
     def test_plain_smtp_ssl_to_public_host(self):
         client = self.session.dial_smtp(PUBLIC_HOST)
         self.assertIs(type(client), smtplib.SMTP_SSL)
-        self.assertEqual(self.connects[-1][1], PUBLIC_HOST)
+        self.assertEqual(self.dials, [(PUBLIC_HOST, SUBMISSION_PORT)])
+        self.assertEqual(self.tls_names, [PUBLIC_HOST])
 
 
-class InternalPathTest(_RecordingConnects):
+class InternalPathTest(_StubbedTransport):
 
     def setUp(self):
         super().setUp()
         self.session = _import_smtp_session(INTERNAL)
 
     def test_host_stays_public_for_tls_verification(self):
-        client = self.session.dial_smtp(PUBLIC_HOST)
-        # smtplib.SMTP.__init__ stores the constructor host in _host and
-        # SMTP_SSL wraps sockets with server_hostname=self._host; the
-        # public name there is what keeps certificate verification real.
-        self.assertEqual(client._host, PUBLIC_HOST)  # pylint: disable=protected-access
+        self.session.dial_smtp(PUBLIC_HOST)
+        # SMTP_SSL hands the handshake server_hostname=self._host, the
+        # host the client was constructed with; the public name there is
+        # what keeps certificate verification real against the wildcard.
+        self.assertEqual(self.tls_names, [PUBLIC_HOST])
 
     def test_socket_override_dials_internal_name(self):
-        client = self.session.dial_smtp(PUBLIC_HOST)
-        wrapped = []
-
-        def fake_parent_get_socket(instance, host, port, timeout):
-            del instance, timeout
-            wrapped.append((host, port))
-            return 'sentinel-socket'
-
-        orig = smtplib.SMTP_SSL._get_socket
-        smtplib.SMTP_SSL._get_socket = fake_parent_get_socket
-        try:
-            result = client._get_socket(PUBLIC_HOST, 465, None)  # pylint: disable=protected-access
-        finally:
-            smtplib.SMTP_SSL._get_socket = orig
+        self.session.dial_smtp(PUBLIC_HOST)
         # The override swaps the public name for the internal one before
         # delegating to the parent (which does the TLS wrap).
-        self.assertEqual(result, 'sentinel-socket')
-        self.assertEqual(wrapped, [(INTERNAL, 465)])
+        self.assertEqual(self.dials, [(INTERNAL, SUBMISSION_PORT)])
 
     def test_gaierror_falls_back_to_public(self):
-        def failing_connect(client, host='localhost', port=0,
-                            source_address=None):
-            del source_address
-            if isinstance(client, self.session._InternalRouteSMTPSSL):  # pylint: disable=protected-access
-                raise socket.gaierror(8, 'name not yet registered')
-            self.connects.append((client, host, port))
-            return (220, b'ok')
-
-        smtplib.SMTP.connect = failing_connect
+        self.dial_error = lambda host: (
+            socket.gaierror(8, 'name not yet registered')
+            if host == INTERNAL else None)
         client = self.session.dial_smtp(PUBLIC_HOST)
         self.assertIs(type(client), smtplib.SMTP_SSL)
-        self.assertEqual(self.connects[-1][1], PUBLIC_HOST)
+        self.assertEqual(self.dials, [(INTERNAL, SUBMISSION_PORT),
+                                      (PUBLIC_HOST, SUBMISSION_PORT)])
 
     def test_ssl_error_does_not_fall_back(self):
-        def failing_connect(client, host='localhost', port=0,
-                            source_address=None):
-            del client, host, port, source_address
-            raise ssl.SSLError('certificate verify failed')
-
-        smtplib.SMTP.connect = failing_connect
+        self.tls_error = ssl.SSLError('certificate verify failed')
         with self.assertRaises(ssl.SSLError):
             self.session.dial_smtp(PUBLIC_HOST)
+        # No second dial: the public listener would fail the same way.
+        self.assertEqual(self.dials, [(INTERNAL, SUBMISSION_PORT)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses #855.

## What was wrong

`lambda/api/_shared/tests/test_smtp_session_dial.py` errors under Python 3.14:

```
ERROR: test_host_stays_public_for_tls_verification (InternalPathTest)
AttributeError: '_InternalRouteSMTPSSL' object has no attribute '_host'
Ran 5 tests — FAILED (errors=1)
```

## Root cause

The tester's correction is right, and it changes the fix. `_host` was not removed in
3.14 — the `self._host = host` assignment **moved** out of `smtplib.SMTP.__init__` and
into `smtplib.SMTP.connect`, immediately before the `_get_socket` call. Confirmed
against 3.14.6 source.

The suite's `_RecordingConnects` base replaced `smtplib.SMTP.connect` *wholesale*, so it
stubbed out the only code that now assigns the attribute it then asserted on. **The
harness broke, not the production path**: `connect()` still records the public host as
`_host` before `_get_socket` runs, so `SMTP_SSL` still hands the public wildcard name to
the TLS handshake. No TLS regression behind this.

## The fix

Stub one layer lower — at the transport — and let the real smtplib code run:

- `socket.create_connection` records the TCP target (and injects dial failures).
- `ssl.SSLContext.wrap_socket` records `server_hostname` (and injects TLS failures).
- The assertion is now on that recorded `server_hostname`, per the issue's own
  suggestion. It pins the behaviour rather than a CPython implementation detail, so it
  is version-proof — and it is a *stronger* test than before, because the real
  `connect` → `_InternalRouteSMTPSSL._get_socket` → `SMTP_SSL._get_socket` chain
  executes instead of being stubbed away.
- Failure injection moved to the same layer, so the gaierror-falls-back and
  SSLError-does-not-fall-back cases now drive the real `except` clauses in `dial_smtp`
  through a real dial attempt, rather than a fabricated exception from a stubbed
  `connect`. Both gained an assertion on the resulting dial sequence (fallback dials the
  public listener second; the SSL failure dials nothing further).

For the resolver: the tester established the 140 s was `socket.getfqdn()` (smtplib's
EHLO-name lookup, ~35 s × 4 clients on a cold resolver), not a dial — nothing in the
suite ever dialled `smtp-out`. `getfqdn` is pinned in the same `setUp`. Production
`dial_smtp` can't take `local_hostname=`, so patching is the right lever here.

Also dropped the `smtp_session.py` module docstring's claim that `server_hostname=self._host`
is "the constructor's host argument, which connect() never overwrites" — `connect()` is
now precisely what writes it. Same value either way, so the reasoning's conclusion stands;
only the false premise goes.

## Test evidence

Fails before / passes after, plus proof the new assertion has teeth:

- **Before**, on this branch point: `Ran 5 tests — FAILED (errors=1)` under 3.14.6.
- **After**: `Ran 5 tests in 0.001s — OK` under **3.14.6** *and* `/usr/bin/python3`
  3.9.6 (the CI-pinned interpreter is 3.12, between the two).
- **The assertion catches a real regression**: shimming `_get_socket` to also do
  `self._host = INTERNAL_HOST` (the naive way to write this override, which would make
  TLS verify the internal name and silently gut certificate checking) fails the test:
  `Lists differ: ['smtp-out.cabal.internal'] != ['smtp-out.control.example']`. Shim
  reverted, `git diff` clean of it.
- **No resolver contact**: re-ran the suite with `socket.getaddrinfo`,
  `gethostbyname`, `gethostname`, `getfqdn`, and `create_connection` all booby-trapped to
  raise — 5/5 OK, so every network entry point the suite reaches is a stub. Runtime is
  0.001–0.002 s, down from 0.05 s warm / 140 s cold.
- All 8 `lambda/api` stdlib suites green; `pylint --rcfile .pylintrc _shared/*.py
  */function.py push_dispatch/apns.py` → 10.00/10.

## Notes

- **No changelog fragment.** `changelog.d/README.md` says record only what shipped to
  users; this is a test-harness repair plus a docstring correction, with no behaviour
  change on any user-facing path. Say the word if you'd rather have one anyway.
- The issue's third point stands unchanged and is **not** addressed here: CI still never
  runs these stdlib suites (`lint.yml`'s python job is pylint-only, pinned to 3.12), so
  a broken suite stays invisible until someone runs it by hand. Wiring them into
  `lint.yml` needs a Workflows-scoped token I don't have — happy to write the job for you
  to commit if you want it.
- Offered, not shipped: production `dial_smtp` still calls `socket.getfqdn()` per dial
  via smtplib. In-VPC that resolves fast, but it is an avoidable per-send round trip and
  a cold-resolver tail-latency risk on `/send`; passing an explicit `local_hostname=` to
  both constructors would remove it. Out of scope for a test fix — say the word.