### PR TITLE
Share the co-tenant subdomain scan between revoke and suspend

### DIFF
--- a/lambda/api/_shared/helper.py
+++ b/lambda/api/_shared/helper.py
@@ -809,6 +809,36 @@ def delete_address_dns_records(zone_id, subdomain, tld, control_domain):
             HostedZoneId=zone_id, ChangeBatch={'Changes': changes})
 
 
+def active_addresses_on_subdomain(subdomain, tld, address):
+    '''Checks if other non-suspended addresses share the same subdomain and TLD.
+    The DNS records of a subdomain are shared by every address on it, so
+    suspend/revoke only delete them once this returns False. Suspended
+    co-tenants do not count: their contract is already "DNS absent", and
+    reinstate republishes the records if one comes back.'''
+    scan_kwargs = {
+        'FilterExpression': (
+            'subdomain = :sub AND tld = :tld AND address <> :addr '
+            'AND (attribute_not_exists(#s) OR #s = :false)'
+        ),
+        'ExpressionAttributeNames': {'#s': 'suspended'},
+        'ExpressionAttributeValues': {
+            ':sub': subdomain,
+            ':tld': tld,
+            ':addr': address,
+            ':false': False
+        },
+        'ProjectionExpression': 'address'
+    }
+    while True:
+        response = ddb_table.scan(**scan_kwargs)
+        if response.get('Items'):
+            return True
+        if 'LastEvaluatedKey' not in response:
+            break
+        scan_kwargs['ExclusiveStartKey'] = response['LastEvaluatedKey']
+    return False
+
+
 # Folder-size observability (Layer 4.1 of the large-mailbox hardening plan).
 # Each list handler emits one key=value log line tagging the request with a
 # coarse folder-size bucket so CloudWatch Logs Insights can correlate request

--- a/lambda/api/revoke/function.py
+++ b/lambda/api/revoke/function.py
@@ -4,6 +4,7 @@ import json
 import os
 from datetime import datetime, timezone
 import boto3  # pylint: disable=import-error
+from helper import active_addresses_on_subdomain  # pylint: disable=import-error
 from helper import delete_address_dns_records  # pylint: disable=import-error
 from helper import parse_json_body  # pylint: disable=import-error
 from helper import user_authorized_for_sender  # pylint: disable=import-error
@@ -34,10 +35,11 @@ def handler(event, _context):
     # Take subdomain/tld/zone from the STORED row for `address`, never from the
     # request body. Authorization above is on `address` only, so honoring a
     # client-supplied subdomain/tld would let a caller who owns any one address
-    # delete another user's DNS records: delete_dns_records targets
-    # `{subdomain}.{tld}`, and the co-tenant guard (other_addresses_on_subdomain)
-    # returns False for a single-tenant victim subdomain, so the DELETE would
-    # proceed. The caller owns `address`, so its row is the authoritative source.
+    # delete another user's DNS records: delete_address_dns_records targets
+    # `{subdomain}.{tld}`, and the co-tenant guard
+    # (active_addresses_on_subdomain) returns False for a single-tenant victim
+    # subdomain, so the DELETE would proceed. The caller owns `address`, so its
+    # row is the authoritative source.
     item = table.get_item(Key={'address': address}).get('Item') or {}
     subdomain = item.get('subdomain')
     tld = item.get('tld')
@@ -72,32 +74,6 @@ def handler(event, _context):
             'address': address
         })
     }
-
-
-def active_addresses_on_subdomain(subdomain, tld, address):
-    '''Checks if other non-suspended addresses share the same subdomain and TLD'''
-    scan_kwargs = {
-        'FilterExpression': (
-            'subdomain = :sub AND tld = :tld AND address <> :addr '
-            'AND (attribute_not_exists(#s) OR #s = :false)'
-        ),
-        'ExpressionAttributeNames': {'#s': 'suspended'},
-        'ExpressionAttributeValues': {
-            ':sub': subdomain,
-            ':tld': tld,
-            ':addr': address,
-            ':false': False
-        },
-        'ProjectionExpression': 'address'
-    }
-    while True:
-        response = table.scan(**scan_kwargs)
-        if response.get('Items'):
-            return True
-        if 'LastEvaluatedKey' not in response:
-            break
-        scan_kwargs['ExclusiveStartKey'] = response['LastEvaluatedKey']
-    return False
 
 
 def revoke_address(address):

--- a/lambda/api/suspend_address/function.py
+++ b/lambda/api/suspend_address/function.py
@@ -6,6 +6,7 @@ import json
 import os
 from datetime import datetime, timezone
 import boto3  # pylint: disable=import-error
+from helper import active_addresses_on_subdomain  # pylint: disable=import-error
 from helper import delete_address_dns_records  # pylint: disable=import-error
 from helper import parse_json_body  # pylint: disable=import-error
 from helper import user_authorized_for_sender  # pylint: disable=import-error
@@ -77,32 +78,6 @@ def handler(event, _context):
             'suspended': True
         })
     }
-
-
-def active_addresses_on_subdomain(subdomain, tld, address):
-    '''Checks if other non-suspended addresses share the same subdomain and TLD'''
-    scan_kwargs = {
-        'FilterExpression': (
-            'subdomain = :sub AND tld = :tld AND address <> :addr '
-            'AND (attribute_not_exists(#s) OR #s = :false)'
-        ),
-        'ExpressionAttributeNames': {'#s': 'suspended'},
-        'ExpressionAttributeValues': {
-            ':sub': subdomain,
-            ':tld': tld,
-            ':addr': address,
-            ':false': False
-        },
-        'ProjectionExpression': 'address'
-    }
-    while True:
-        response = table.scan(**scan_kwargs)
-        if response.get('Items'):
-            return True
-        if 'LastEvaluatedKey' not in response:
-            break
-        scan_kwargs['ExclusiveStartKey'] = response['LastEvaluatedKey']
-    return False
 
 
 def mark_suspended(address):


### PR DESCRIPTION
## What

`active_addresses_on_subdomain` existed as two byte-identical 25-line copies, in
`lambda/api/revoke/function.py` and `lambda/api/suspend_address/function.py`. It
moves to `lambda/api/_shared/helper.py`, immediately after
`delete_address_dns_records` — the call it guards — and both handlers import it.

Also corrects two stale symbol names in the revoke security comment: it referred
to `delete_dns_records` and `other_addresses_on_subdomain`, neither of which
exists. The real names are `delete_address_dns_records` and
`active_addresses_on_subdomain`. Comment only; the reasoning it documents is
unchanged and still accurate.

Net: +37 / -56.

## Why it's safe

- **The two copies were identical.** `diff` of the two function bodies on
  `origin/stage` (revoke lines 77-101, suspend_address lines 82-106) is empty.
  The moved body is unchanged apart from the table handle (below) and a longer
  docstring that folds in the two callers' inline "why" comments.
- **Same table, same client.** Each handler bound `table = ddb.Table('cabal-addresses')`
  at module scope; `helper.py` already binds `ddb_table = ddb.Table(TABLE)` with
  `TABLE = 'cabal-addresses'`. Same resource, same region, same credentials — the
  scan arguments are untouched, so the DynamoDB call is identical on the wire.
  No IAM change: both roles were already scanning this table from these handlers.
- **No new bundling rule.** Both handlers already `from helper import ...`, so
  `build-api-one.sh` already copies `helper.py` (plus `imap_session.py` /
  `imap_pool.py`) into both zips. Nothing about the zip contents changes.
- **No other callers.** `grep -rn active_addresses_on_subdomain` across the repo
  returns only the two definitions and their two call sites; nothing references
  it by string (no `.mc` template, shell script, workflow YAML, or route
  string). `reinstate_address` never had a copy — it republishes
  unconditionally.
- **The `# pylint: disable=duplicate-code` headers stay.** I checked: removing
  them re-triggers R0801 on the still-shared handler preamble (imports, the 403
  response block, the stored-row lookup). They are load-bearing for a different
  overlap than the one this PR removes.
- No handler entry point, response shape, status code, or control flow changed.

## Verified

- `python3 -m pylint --rcfile .pylintrc _shared/*.py */function.py push_dispatch/apns.py`
  from `lambda/api/` — **10.00/10**, no new messages.
- `ast.parse` on all three edited files.
- Confirmed no test module references either handler (`lambda/api/*/tests/` covers
  `delete_folder`, `fetch_bimi`, `new_folder` only), so no test needed updating.