### PR TITLE
Show staged attachments above the compose editor on iOS

### DIFF
--- a/apple/Cabalmail/Views/ComposeFormSection.swift
+++ b/apple/Cabalmail/Views/ComposeFormSection.swift
@@ -1,0 +1,19 @@
+/// The order of the grouped-`Form` compose sections (iOS / iPadOS /
+/// visionOS). A pure list rather than a literal run of `Section`s so the
+/// one rule that governs it can be tested — `ComposeView`'s layout isn't
+/// reachable from a unit test, this is.
+///
+/// The rule: every section the user has to see or act on renders ABOVE
+/// `.message`. The body editor is greedy, so anything after it starts
+/// below the fold, and the `WKWebView` swallows the pan that would scroll
+/// down to it — a section placed there is invisible and unreachable, not
+/// merely off screen. That cost a send-blocking error banner (#812) and
+/// the staged-attachment list (#858).
+enum ComposeFormSection: CaseIterable {
+    case error
+    case from
+    case recipients
+    case subject
+    case attachments
+    case message
+}

--- a/apple/Cabalmail/Views/ComposeView.swift
+++ b/apple/Cabalmail/Views/ComposeView.swift
@@ -329,55 +329,41 @@ extension ComposeView {
 
     #if !os(macOS)
     private var composeForm: some View {
+        Form {
+            ForEach(ComposeFormSection.allCases, id: \.self) { section in
+                formSection(section)
+            }
+        }
+    }
+
+    /// Renders one section of `composeForm`. The order lives in
+    /// `ComposeFormSection`, which documents why nothing actionable may
+    /// follow `.message`.
+    @ViewBuilder
+    private func formSection(_ section: ComposeFormSection) -> some View {
         @Bindable var model = model
-        return Form {
-            // First section on purpose. As the last one it sat below the
-            // body editor, off the bottom of an iPhone screen, and the
-            // WKWebView swallows the pan that would scroll down to it — so
-            // a send-blocking error was invisible and Send looked dead
-            // (#812). macOS pins the same text to the window bottom, which
-            // is always on screen there.
+        switch section {
+        case .error:
             if let errorMessage = model.errorMessage {
                 Section {
                     Label(errorMessage, systemImage: "exclamationmark.triangle")
                         .foregroundStyle(.red)
                 }
             }
+        case .from:
             Section("From") {
                 FromPicker(
                     model: model,
                     onCreateAddress: { showNewAddressSheet = true }
                 )
             }
-            Section("Recipients") {
-                RecipientFieldWithSuggestions(
-                    label: "To",
-                    text: $model.toText,
-                    candidates: recipientCandidates,
-                    focusBinding: $focusedField,
-                    focusValue: Field.to
-                )
-                RecipientFieldWithSuggestions(
-                    label: "Cc",
-                    text: $model.ccText,
-                    candidates: recipientCandidates,
-                    focusBinding: $focusedField,
-                    focusValue: Field.cc
-                )
-                RecipientFieldWithSuggestions(
-                    label: "Bcc",
-                    text: $model.bccText,
-                    candidates: recipientCandidates,
-                    focusBinding: $focusedField,
-                    focusValue: Field.bcc
-                )
-            }
+        case .recipients:
+            recipientsSection
+        case .subject:
             Section("Subject") {
                 TextField("Subject", text: $model.subject)
             }
-            Section("Message") {
-                ComposerBody(model: model)
-            }
+        case .attachments:
             if !model.attachments.isEmpty {
                 Section("Attachments") {
                     ForEach(model.attachments) { attachment in
@@ -388,6 +374,37 @@ extension ComposeView {
                     }
                 }
             }
+        case .message:
+            Section("Message") {
+                ComposerBody(model: model)
+            }
+        }
+    }
+
+    private var recipientsSection: some View {
+        @Bindable var model = model
+        return Section("Recipients") {
+            RecipientFieldWithSuggestions(
+                label: "To",
+                text: $model.toText,
+                candidates: recipientCandidates,
+                focusBinding: $focusedField,
+                focusValue: Field.to
+            )
+            RecipientFieldWithSuggestions(
+                label: "Cc",
+                text: $model.ccText,
+                candidates: recipientCandidates,
+                focusBinding: $focusedField,
+                focusValue: Field.cc
+            )
+            RecipientFieldWithSuggestions(
+                label: "Bcc",
+                text: $model.bccText,
+                candidates: recipientCandidates,
+                focusBinding: $focusedField,
+                focusValue: Field.bcc
+            )
         }
     }
     #endif

--- a/apple/CabalmailTests/ComposeFormSectionTests.swift
+++ b/apple/CabalmailTests/ComposeFormSectionTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Cabalmail
+
+// Regression coverage for issue #858: a photo picked in the iPhone composer
+// left no trace on screen — no chip, no count, no way to remove it — because
+// the "Attachments" section rendered AFTER the body editor. The editor is
+// greedy, so that section started below the fold, and the WKWebView ate the
+// pan that would have scrolled to it, so the attachment could be neither
+// reviewed nor removed and repeat picks silently piled up. Same trap as the
+// send-blocking error banner in #812. Nothing actionable may follow
+// `.message`.
+final class ComposeFormSectionTests: XCTestCase {
+
+    private func index(of section: ComposeFormSection) throws -> Int {
+        try XCTUnwrap(ComposeFormSection.allCases.firstIndex(of: section))
+    }
+
+    func testAttachmentsRenderAboveTheBodyEditor() throws {
+        XCTAssertLessThan(
+            try index(of: .attachments),
+            try index(of: .message),
+            "attachments below the editor are unreachable: the WKWebView swallows the pan"
+        )
+    }
+
+    func testTheBodyEditorIsLast() throws {
+        XCTAssertEqual(
+            ComposeFormSection.allCases.last,
+            .message,
+            "the greedy editor strands every section placed after it"
+        )
+    }
+
+    func testErrorBannerStaysFirst() throws {
+        XCTAssertEqual(ComposeFormSection.allCases.first, .error)
+    }
+}

--- a/changelog.d/ios-compose-attachments-visible.fixed.md
+++ b/changelog.d/ios-compose-attachments-visible.fixed.md
@@ -1,0 +1,6 @@
+- Apple: **Staged attachments are visible in the iPhone composer.** The
+  "Attachments" list rendered after the body editor, which is greedy, so it
+  started below the fold — and the editor's web view swallows the pan that
+  would scroll down to it. A picked photo left no trace on screen and could
+  not be removed, and repeat picks piled up silently. The list now sits
+  above the editor, beside the send-error banner.


### PR DESCRIPTION
Addresses #858.

## What was wrong

Picking a photo in the iPhone composer changed nothing on screen — no chip, no
count, no badge, no way to remove it. The file *was* staged, so a user who
picked again (reasonably, having seen no confirmation) sent the same 4.1 MB
photo twice in an 11 MB message with nothing on screen ever hinting at it.

## Root cause

The UI exists and is correct; it was placed where it cannot be seen.
`composeForm` rendered `Section("Attachments")` **after** `Section("Message")`.
`ComposerBody` is greedy, so any section after it starts below the fold, and
the editor's `WKWebView` swallows the pan that would scroll down to it — a swipe
over the editor never reaches the Form, and the tester confirmed a swipe over
the header doesn't scroll it either. This is the same trap the send-blocking
error banner hit in #812, which was fixed by hoisting it to first; the comment
explaining that sat ten lines above the section that repeated the mistake.
macOS is unaffected: `macAttachmentStrip` is pinned to the window bottom.

## The fix

The Form's section order now lives in `ComposeFormSection` (a pure list, same
shape as `CompactColumnPolicy`), with `.attachments` above `.message` and
`.message` last. `composeForm` iterates it. That makes the rule — nothing
actionable may follow the greedy editor — a thing a test can hold, rather than
one every future section author has to rediscover. `recipientsSection` was
lifted out to keep the switch under SwiftLint's `function_body_length`.

Scoped to the reported failure. The duplicate-attachment behaviour is not
changed: with the list on screen, a second pick is now visible and removable,
which is what the report asks for. Content-hash de-duplication of two picks of
the same photo would be a design decision, not a bug fix — happy to do it if you
want it.

## Test evidence

- New `ComposeFormSectionTests` (3 tests). Fails-before verified by shimming the
  enum back to the pre-fix order: 2 of 3 fail
  (`XCTAssertLessThan failed: ("5") is not less than ("4")`), then pass with the
  order restored.
- Full app-target suite: `Executed 85 tests, with 0 failures` (`CabalmailMac`
  scheme, macOS). `swiftlint` clean from `apple/`.
- Live repro on the iPhone 17 sim (iOS 26.5) against this build, the issue's own
  steps: compose → paperclip → Add Photo → pick → confirm. The composer now
  shows **Attachments / photo-3DCA5CBB.jpg / 4.1 MB** with its remove control,
  above "Message", with no scrolling. Tapping the ✕ clears the section.
  Screenshots: `/tmp/fixer-858-final.png`, `/tmp/fixer-858-06.png`.

## Not covered

The report's adjacent, unverified note — whether EXIF GPS survives into the sent
MIME ("Location Is Included" in the picker footer) — is untouched here. Say the
word and I'll check it and strip it if it does.