### PR TITLE
Return a 400 from fetch_attachment for a malformed request

### DIFF
--- a/changelog.d/fetch-attachment-bad-request.fixed.md
+++ b/changelog.d/fetch-attachment-bad-request.fixed.md
@@ -1,0 +1,6 @@
+- **Clean 400 from `fetch_attachment` for a malformed request.** A missing or
+  non-integer `filename`/`index`/`folder`/`id` used to escape the handler as an
+  unhandled exception and reach the client as a bodiless 502 reading "Internal
+  server error", so a caller could not tell a bad request from a broken server.
+  The handler now validates its query string the way its `fetch_inline_image`
+  sibling already did.

--- a/lambda/api/_shared/helper.py
+++ b/lambda/api/_shared/helper.py
@@ -324,6 +324,7 @@ _FOLDER_NAME_RE = re.compile(r'^[A-Za-z0-9 _\-./]+$')
 _KEYWORD_RE = re.compile(r'^[A-Za-z0-9_\-]+$')
 _CONTROL_CHARS_RE = re.compile(r'[\x00-\x1f\x7f]')
 _CONTENT_ID_FORBIDDEN_RE = re.compile(r'[\x00-\x1f\x7f\s/\\]')
+_ATTACHMENT_NAME_FORBIDDEN_RE = re.compile(r'[\x00-\x1f\x7f/\\]')
 
 # Lowercased wire form -> canonical form. Only these five system flags are
 # client-settable; \Recent and friends are server-managed and never accepted.
@@ -602,6 +603,45 @@ def validate_content_id(value):
         raise ValueError('content-id must be a bracketed token')
     if _CONTENT_ID_FORBIDDEN_RE.search(value):
         raise ValueError('content-id contains illegal characters')
+    return value
+
+
+def validate_part_index(value):
+    '''Validates a MIME part serial number, returning an int >= 0.
+
+    A part index is a position in `message.walk()`, not a UID: part 0 is the
+    message itself and is a legal value, so validate_uid's [1, 2**32-1] range
+    doesn't apply. Booleans are rejected for the same reason as in
+    validate_uid_list.
+    '''
+    if isinstance(value, bool):
+        raise ValueError(f'invalid attachment index: {value!r}')
+    try:
+        index = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'invalid attachment index: {value!r}') from exc
+    if index < 0:
+        raise ValueError(f'attachment index out of range: {index}')
+    return index
+
+
+def validate_attachment_filename(value):
+    '''Validates the filename an attachment is cached under, returning it
+    unchanged.
+
+    The value becomes the last component of an S3 key, so path separators,
+    control bytes, and the traversal names are rejected. Otherwise it stays
+    permissive: this is a real MIME filename taken from the message, and
+    spaces, non-ASCII, and punctuation all occur in the wild.
+    '''
+    if not isinstance(value, str) or not value:
+        raise ValueError('filename is required')
+    if len(value.encode('utf-8')) > MAX_FOLDER_NAME_BYTES:
+        raise ValueError('filename is too long')
+    if _ATTACHMENT_NAME_FORBIDDEN_RE.search(value):
+        raise ValueError('filename contains illegal characters')
+    if value in ('.', '..'):
+        raise ValueError(f'invalid filename: {value!r}')
     return value
 
 

--- a/lambda/api/_shared/tests/test_fetch_attachment_validation.py
+++ b/lambda/api/_shared/tests/test_fetch_attachment_validation.py
@@ -1,0 +1,199 @@
+'''Unit tests for fetch_attachment's query-string validation, and for the two
+validators it added to helper.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_fetch_attachment_validation.py
+
+helper.py's third-party imports (boto3, botocore, imap_session) are faked in
+sys.modules before import, so the suite needs no AWS access and never dials an
+IMAP server. The handler is loaded under a unique module name and its own
+helper bindings are patched per test, so nothing here depends on being the
+first suite to import `helper` (see #860).'''
+import email
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
+
+_SHARED = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_API = os.path.dirname(_SHARED)
+sys.path.insert(0, _SHARED)
+
+# --- fake boto3 / botocore ---------------------------------------------------
+
+
+class _FakeSSMExceptions:
+    class ParameterNotFound(Exception):
+        pass
+
+
+class _FakeSSM:
+    exceptions = _FakeSSMExceptions
+
+    def get_parameter(self, Name=None, **_kwargs):  # pylint: disable=invalid-name
+        if Name == '/cabal/maintenance/imap':
+            raise _FakeSSMExceptions.ParameterNotFound()
+        return {"Parameter": {"Value": "fake-master-password"}}
+
+
+class _FakeResource:
+    def Table(self, _name):  # pylint: disable=invalid-name
+        return types.SimpleNamespace()
+
+
+if 'boto3' not in sys.modules:
+    _boto3 = types.ModuleType("boto3")
+    _boto3.resource = lambda _name, **_kw: _FakeResource()
+    _boto3.client = lambda name, **_kw: _FakeSSM() if name == 'ssm' else types.SimpleNamespace()
+    _boto3.session = types.SimpleNamespace(Config=lambda **_kw: None)
+    sys.modules['boto3'] = _boto3
+
+    _botocore = types.ModuleType("botocore")
+    _botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+    class _ClientError(Exception):
+        pass
+
+    _botocore_exceptions.ClientError = _ClientError
+    _botocore.exceptions = _botocore_exceptions
+    sys.modules['botocore'] = _botocore
+    sys.modules['botocore.exceptions'] = _botocore_exceptions
+
+if 'imap_session' not in sys.modules:
+    _imap_session = types.ModuleType("imap_session")
+    _imap_session.open_imap_client = lambda *_a, **_kw: None
+    sys.modules['imap_session'] = _imap_session
+
+import helper  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _load_handler(name):
+    '''Imports lambda/api/<name>/function.py under a unique module name.
+
+    The deployed zips all name their handler module `function`, so importing
+    them as `function` lets whichever suite runs first win the sys.modules
+    slot and hands every later suite the wrong handler (#860).
+    '''
+    path = os.path.join(_API, name, 'function.py')
+    spec = importlib.util.spec_from_file_location(f'function_{name}', path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fetch_attachment = _load_handler('fetch_attachment')
+
+RAW_MESSAGE = (b'From: someone@example.com\r\n'
+               b'Subject: has an attachment\r\n'
+               b'Content-Type: multipart/mixed; boundary="b"\r\n\r\n'
+               b'--b\r\nContent-Type: text/plain\r\n\r\nbody\r\n'
+               b'--b\r\nContent-Type: text/plain\r\n'
+               b'Content-Disposition: attachment; filename="probe.txt"\r\n\r\n'
+               b'attached\r\n--b--\r\n')
+
+
+def _event(**params):
+    query = {'host': 'imap.test.example.com', 'folder': 'INBOX', 'id': '21',
+             'filename': 'probe.txt', 'index': '2'}
+    for key, value in params.items():
+        if value is None:
+            query.pop(key, None)
+        else:
+            query[key] = value
+    return {
+        'queryStringParameters': query,
+        'requestContext': {'authorizer': {'claims': {'cognito:username': 'testuser'}}},
+    }
+
+
+class FetchAttachmentValidationTest(unittest.TestCase):
+    '''A malformed request is the caller's fault: it used to escape as a
+    KeyError/ValueError and reach the client as a bodiless 502 that reads
+    "Internal server error" (#859).'''
+
+    def setUp(self):
+        self._saved = (fetch_attachment.get_message, fetch_attachment.key_exists,
+                       fetch_attachment.upload_object, fetch_attachment.sign_url)
+        self.fetched = []
+        fetch_attachment.get_message = self._fake_get_message
+        fetch_attachment.key_exists = lambda _bucket, _key: True
+        fetch_attachment.upload_object = lambda *_a: True
+        fetch_attachment.sign_url = lambda _bucket, key: f'https://example.invalid/{key}'
+
+    def tearDown(self):
+        (fetch_attachment.get_message, fetch_attachment.key_exists,
+         fetch_attachment.upload_object, fetch_attachment.sign_url) = self._saved
+
+    def _fake_get_message(self, *args):
+        self.fetched.append(args)
+        return email.message_from_bytes(RAW_MESSAGE)
+
+    def test_missing_filename_is_a_400(self):
+        response = fetch_attachment.handler(_event(filename=None), None)
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn('filename', response['body'])
+        # A bad request must not cost an IMAP round trip.
+        self.assertEqual(self.fetched, [])
+
+    def test_missing_index_is_a_400(self):
+        response = fetch_attachment.handler(_event(index=None), None)
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn('index', response['body'])
+
+    def test_non_integer_index_is_a_400(self):
+        response = fetch_attachment.handler(_event(index='abc'), None)
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn('index', response['body'])
+
+    def test_missing_folder_and_id_are_400s(self):
+        for param in ('folder', 'id'):
+            with self.subTest(param=param):
+                response = fetch_attachment.handler(_event(**{param: None}), None)
+                self.assertEqual(response['statusCode'], 400)
+
+    def test_traversal_shaped_filename_is_a_400(self):
+        response = fetch_attachment.handler(_event(filename='../../raw'), None)
+        self.assertEqual(response['statusCode'], 400)
+
+    def test_a_well_formed_request_still_serves_the_attachment(self):
+        response = fetch_attachment.handler(_event(), None)
+        self.assertEqual(response['statusCode'], 200)
+        self.assertIn('testuser/INBOX/21/probe.txt', response['body'])
+        # The UID reaches get_message as an int, and the folder unchanged.
+        self.assertEqual(self.fetched[-1][2:], ('INBOX', 21))
+
+
+class ValidatorTest(unittest.TestCase):
+
+    def test_part_index_accepts_zero(self):
+        # Part 0 is the message itself; validate_uid's [1, ...] floor would
+        # reject a legal index.
+        self.assertEqual(helper.validate_part_index('0'), 0)
+        self.assertEqual(helper.validate_part_index(4), 4)
+
+    def test_part_index_rejects_junk(self):
+        for value in (None, '', 'abc', '-1', True, [2]):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    helper.validate_part_index(value)
+
+    def test_filename_keeps_real_mime_names(self):
+        for name in ('probe.txt', 'Q3 résumé (final).pdf', 'photo-4DE49790.jpg'):
+            with self.subTest(name=name):
+                self.assertEqual(helper.validate_attachment_filename(name), name)
+
+    def test_filename_rejects_key_shaped_values(self):
+        for name in (None, '', '.', '..', 'a/b.txt', 'a\\b.txt', 'nul\x00.txt', 'x' * 300):
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    helper.validate_attachment_filename(name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/fetch_attachment/function.py
+++ b/lambda/api/fetch_attachment/function.py
@@ -5,6 +5,10 @@ from helper import upload_object # pylint: disable=import-error
 from helper import sign_url # pylint: disable=import-error
 from helper import key_exists # pylint: disable=import-error
 from helper import get_message # pylint: disable=import-error
+from helper import validate_attachment_filename # pylint: disable=import-error
+from helper import validate_folder_name # pylint: disable=import-error
+from helper import validate_part_index # pylint: disable=import-error
+from helper import validate_uid # pylint: disable=import-error
 from helper import CACHE_BUCKET # pylint: disable=import-error
 
 from helper import maintenance_guard # pylint: disable=import-error
@@ -16,13 +20,22 @@ from helper import message_gone_guard # pylint: disable=import-error
 def handler(event, _context):
     '''Preps an attachment for download from S3 given a folder, message ID,
     and attachment serial number'''
-    query_string = event['queryStringParameters']
+    query_string = event.get('queryStringParameters') or {}
     user = event['requestContext']['authorizer']['claims']['cognito:username']
+    try:
+        folder = validate_folder_name(query_string.get('folder'))
+        msg_id = validate_uid(query_string.get('id'))
+        filename = validate_attachment_filename(query_string.get('filename'))
+        index = validate_part_index(query_string.get('index'))
+    except ValueError as err:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"status": f"Invalid input: {err}"})
+        }
     bucket = CACHE_BUCKET
-    key = f"{user}/{query_string['folder']}/{query_string['id']}/{query_string['filename']}"
-    index = int(query_string['index'])
-    message = get_message(query_string['host'], user,
-                          query_string['folder'].replace("/","."), query_string['id'])
+    key = f"{user}/{folder}/{msg_id}/{filename}"
+    message = get_message(query_string.get('host'), user,
+                          folder.replace("/","."), msg_id)
     i = 0
     if message.is_multipart():
         for part in message.walk():


### PR DESCRIPTION
Addresses #859.

## What was wrong

`GET /fetch_attachment` answered a bad request with a bodiless **502**
(`{"message": "Internal server error"}`) — for a missing `filename`, a missing
`index`, or a non-integer `index`. The sibling `fetch_inline_image` returns a
clean 400 naming the problem for the same shape of input.

## Root cause

Exactly as the report diagnosed: the handler subscripted the query string
directly (`query_string['filename']` → `KeyError`, `int(query_string['index'])`
→ `KeyError`/`ValueError`), with no validation, so the exception escaped and API
Gateway rendered it as a 502. The validators for `folder` and `id` already
existed and were simply not used here.

## The fix

`fetch_attachment` now validates its four inputs inside a `try` and returns a
400 on `ValueError`, mirroring `fetch_inline_image` line for line. Two
validators were missing and are new in `helper`:

- `validate_part_index` — a MIME part index is a position in `message.walk()`,
  where **0 is legal**, so `validate_uid`'s `[1, 2**32-1]` floor would reject a
  valid request.
- `validate_attachment_filename` — the value becomes the last component of an S3
  key. Deny-list only (path separators, control bytes, `.`/`..`, over-long), so
  real MIME filenames with spaces and non-ASCII still pass. Worth noting: on
  `stage` today `filename=../../raw` returns **200** and signs a URL for a
  traversal-shaped key; it now 400s. S3 keys aren't paths, so this was never an
  escape from the `{user}/` prefix, but the value had no business being unchecked.

Cache keys are unchanged: the validators return the folder unchanged and the
numeric id round-trips, so `{user}/{folder}/{id}/{filename}` is byte-identical
for every request that worked before.

## Test evidence

New `lambda/api/_shared/tests/test_fetch_attachment_validation.py` (10 tests),
covering all three reported cases plus a well-formed control that still serves
the attachment.

- Fails-before, with only `function.py` reverted to its `stage` version:
  `Ran 10 tests ... FAILED (failures=2, errors=5)`.
- After: `OK` under both `python3` (3.14.6) and `/usr/bin/python3` (3.9.6).
- `pylint --rcfile .pylintrc _shared/helper.py fetch_attachment/function.py` →
  **10.00/10**. (The suite itself scores like its neighbours — 8.12 vs 7.61 for
  `test_get_message_gone.py` — on test-docstring conventions; CI's glob doesn't
  cover `tests/`.)

The new suite is deliberately collision-safe under a directory-wide `discover`
run: it loads the handler under a unique module name and patches its bindings
per test rather than racing for the `helper`/`function` slots in `sys.modules`.
That's #860's bug, which is a separate PR.

## Offered, not done

The report notes `list_attachments` subscripts `[host]`/`[folder]`/`[id]` the
same way and is likely to behave identically — it wasn't probed, and I kept this
PR to the reported handler. Say the word and I'll sweep the rest of the
directly-subscripting handlers in one follow-up.