### PR TITLE
Make the _shared test suites independent of import order

### DIFF
--- a/lambda/api/_shared/tests/test_folder_subscriptions.py
+++ b/lambda/api/_shared/tests/test_folder_subscriptions.py
@@ -99,6 +99,25 @@ sys.modules['imap_session'] = _imap_session
 
 import helper  # noqa: E402  pylint: disable=wrong-import-position
 
+_SAVED = {}
+
+
+def setUpModule():
+    '''Binds this suite's fake into `helper`.
+
+    The `sys.modules` fake above only takes effect if this file is what first
+    imports `helper`. Under a directory-wide `discover` run it usually isn't:
+    `helper` is already imported, still holding a sibling suite's fake, and the
+    `import helper` above is a no-op. Rebinding here runs whatever the import
+    order turns out to be (#860).
+    '''
+    _SAVED['open_imap_client'] = helper.open_imap_client
+    helper.open_imap_client = _open_imap_client
+
+
+def tearDownModule():
+    helper.open_imap_client = _SAVED['open_imap_client']
+
 
 class UnsubscribeFolderTest(unittest.TestCase):
 

--- a/lambda/api/_shared/tests/test_get_message_gone.py
+++ b/lambda/api/_shared/tests/test_get_message_gone.py
@@ -10,6 +10,7 @@ sys.modules before import, so the suite needs no AWS access and never dials an
 IMAP server. The fake client mirrors the behavior under test: like a real
 server, an IMAP UID FETCH for a UID that has been expunged succeeds and returns
 an empty dict rather than failing.'''
+import importlib.util
 import os
 import sys
 import types
@@ -20,7 +21,6 @@ os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
 
 _SHARED = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, _SHARED)
-sys.path.insert(0, os.path.join(os.path.dirname(_SHARED), 'fetch_message'))
 
 # --- fake boto3 / botocore ---------------------------------------------------
 
@@ -98,9 +98,45 @@ sys.modules['imap_session'] = _imap_session
 
 import helper  # noqa: E402  pylint: disable=wrong-import-position
 
-# fetch_message's handler imports `helper` by name, exactly as it does inside
-# its deployed zip, so the real module above is what it binds to.
-import function as fetch_message  # noqa: E402  pylint: disable=wrong-import-position
+
+def _load_handler(name):
+    '''Imports lambda/api/<name>/function.py under a unique module name.
+
+    Every deployed zip names its handler module `function`, so a plain
+    `import function` lets whichever suite runs first win the `sys.modules`
+    slot and hands every later suite the wrong handler (#860). The handler
+    still imports `helper` by name, exactly as it does inside its zip, so the
+    real module above is what it binds to.
+    '''
+    path = os.path.join(os.path.dirname(_SHARED), name, 'function.py')
+    spec = importlib.util.spec_from_file_location(f'function_{name}', path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fetch_message = _load_handler('fetch_message')
+
+_SAVED = {}
+
+
+def setUpModule():
+    '''Binds this suite's fake into `helper`.
+
+    The `sys.modules` fake above only takes effect if this file is what first
+    imports `helper`. Under a directory-wide `discover` run it usually isn't:
+    `helper` is already imported, still holding a sibling suite's fake (whose
+    client has no `fetch`), and the `import helper` above is a no-op.
+    Rebinding here runs whatever the import order turns out to be (#860).
+    '''
+    _SAVED['open_imap_client'] = helper.open_imap_client
+    helper.open_imap_client = _open_imap_client
+
+
+def tearDownModule():
+    helper.open_imap_client = _SAVED['open_imap_client']
+
 
 UPLOADED = []
 
@@ -144,6 +180,19 @@ class GetMessageGoneTest(unittest.TestCase):
         message = helper.get_message(None, 'testuser', 'INBOX', 28)
         self.assertEqual(message.get('Subject'), 'still here')
         self.assertEqual(UPLOADED, ['testuser/INBOX/28/raw'])
+
+
+class SuiteIsolationTest(unittest.TestCase):
+    '''Guards the two ways a sibling suite used to hijack this one under a
+    directory-wide `discover` run (#860): `helper` already imported with
+    another suite's fake bound in, and another suite's handler sitting in the
+    `function` slot of sys.modules.'''
+
+    def test_this_suites_fake_is_what_helper_calls(self):
+        self.assertIs(helper.open_imap_client, _open_imap_client)
+
+    def test_the_handler_under_test_is_fetch_messages(self):
+        self.assertTrue(fetch_message.__file__.endswith('fetch_message/function.py'))
 
 
 class MessageGoneResponseTest(unittest.TestCase):


### PR DESCRIPTION
Addresses #860.

## What was wrong

`python3 -m unittest discover -s lambda/api/_shared/tests -p "test_*.py"` failed
with 4 errors (`AttributeError: _FakeImapClient object has no attribute fetch`)
on a tree where every suite passes alone.

## Root cause

Your diagnosis, confirmed. `test_folder_subscriptions` and `test_get_message_gone`
each install their own fake `imap_session` into `sys.modules` and then
`import helper`. Only the first importer's fake ever reaches `helper`, which
binds `open_imap_client` at import time; the second suite's `import helper` is a
no-op and its fake is silently discarded. Alphabetical order makes
`test_folder_subscriptions` the winner, and its client implements only
`unsubscribe_folder`/`logout`.

There is a second instance of the same collision that hadn't bitten yet: every
deployed zip names its handler module `function`, so `import function` is a race
for one `sys.modules` slot. A second suite importing a different handler would
have silently tested the first one's — the quiet version of this failure, which
as you say is the worse one.

## The fix

Each affected suite now rebinds its own fake into `helper` in `setUpModule` and
restores the previous binding in `tearDownModule`, so the fake in force is
whichever suite is running rather than whichever imported first. Handlers load
via `importlib` under a unique module name (`function_fetch_message`), so the
`function` slot isn't contested either.

`setUpModule`/`tearDownModule` rather than a shared conftest-style module: it's
stdlib, it's per-file, and it keeps each suite readable and directly runnable —
the docstring instruction (`python3 lambda/api/_shared/tests/test_x.py`) still
works unchanged.

## Test evidence

- Before: `Ran 27 tests ... FAILED (errors=4)`.
- After: `Ran 29 tests ... OK` under both `python3` (3.14.6) and
  `/usr/bin/python3` (3.9.6); every suite still `OK` run alone.
- The +2 are a new `SuiteIsolationTest` that pins both halves — that `helper`
  calls *this* suite's fake, and that the handler under test is the one from
  `fetch_message/`. Removing `setUpModule` again reproduces the original four
  errors plus a clean failure from the new test
  (`<function _open_imap_client at 0x1064…> is not <function _open_imap_client at 0x1067…>`).

No changelog fragment: this is test-plumbing only, nothing users see, per
`changelog.d/README.md`.

## Related, not done

As #856 already noted, these suites still never run in CI (`lint.yml` is pylint
only) — so nothing catches this class of breakage automatically. Now that a
directory run is green, wiring `unittest discover` into `lint.yml` is a
three-line job; it needs the workflows permission I don't have, so it's yours or
a follow-up issue if you want it.