### PR TITLE
Run the _shared unittest suites in the lint PR gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,9 @@ name: Lint
 #                (from infra.yml), using the same pinned tool versions,
 #                shared tflint config, per-stack checkov/trivy configs, and
 #                baseline/ignore drift checks.
-#   - Python:    pylint over lambda/api and lambda/counter (from app.yml).
+#   - Python:    pylint over lambda/api and lambda/counter (from app.yml),
+#                plus the lambda/api/_shared unittest suites (new for the PR
+#                gate; no deploy workflow runs them).
 #   - Swift:     swiftlint --strict (from apple.yml).
 #   - React:     eslint (new for the PR gate; the deploy path only builds).
 #
@@ -199,6 +201,12 @@ jobs:
       run: cd ./lambda/api && pylint --rcfile .pylintrc _shared/*.py */function.py
     - name: pylint-counter
       run: pylint --rcfile ./lambda/api/.pylintrc ./lambda/counter/*/function.py
+    - name: unittest-shared
+      # The _shared suites fake their third-party deps (imapclient, boto3) via
+      # sys.modules, so they run on a bare interpreter — no pip install needed.
+      # Same invocation as the docstring in each test file; suites are
+      # import-order independent since #863.
+      run: python3 -m unittest discover -s lambda/api/_shared/tests -p "test_*.py"
 
   # ---------------------------------------------------------------------------
   # Swift. swiftlint --strict, the same gate apple.yml runs on its macOS leg.


### PR DESCRIPTION
Implements the "Related, not done" recommendation from #863 (originally noted in #856): the `lambda/api/_shared/tests` suites never run in CI — `lint.yml`'s python job is pylint only, and no deploy workflow runs them.

## What this does

Adds a `unittest-shared` step to the existing `python` job in `lint.yml`:

```
python3 -m unittest discover -s lambda/api/_shared/tests -p "test_*.py"
```

This is the same invocation each test file's docstring documents. The suites fake their third-party dependencies (`imapclient`, `boto3`) via `sys.modules`, so the bare setup-python interpreter is enough — no pip installs added. The `lambda/**` path filter already covers the tests, so no filter changes either.

## Merge after #863

The directory run only passes with #863's import-order isolation fix. On stage's current tree it fails with 6 errors — which is exactly the class of breakage this gate exists to catch. Expect this PR's new step to show red until #863 merges; after that, re-running the check (or pushing any update) goes green, since `pull_request` checks build the merge of this branch into stage.

Verified locally: `unittest discover` on stage = `Ran 37 tests ... FAILED (errors=6)`; with #863 merged in = `OK`.

No changelog fragment: CI-only, nothing users see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)