### PR TITLE
Drop Chef-port leftovers from the sendmail config generator

### DIFF
--- a/docker/shared/generate-config.sh
+++ b/docker/shared/generate-config.sh
@@ -54,7 +54,6 @@ for item in items:
     username = item.get("username", {}).get("S", "")
     user = item.get("user", {}).get("S", "")
     subdomain = item.get("subdomain", {}).get("S", "") if "subdomain" in item else None
-    private_key = item.get("private_key", {}).get("S", "") if "private_key" in item else None
 
     # Skip rows whose username carries whitespace. Such a value is written
     # verbatim into virtusertable, where makemap rejects a leading space and
@@ -73,15 +72,10 @@ for item in items:
             "addresses": {},
             "subdomains": {},
         }
-        if private_key:
-            domains[tld]["private_key"] = private_key
 
     if subdomain:
         if subdomain not in domains[tld]["subdomains"]:
-            domains[tld]["subdomains"][subdomain] = {
-                "addresses": {},
-                "action": "nothing",
-            }
+            domains[tld]["subdomains"][subdomain] = {"addresses": {}}
         targets = user.split("/")
         domains[tld]["subdomains"][subdomain]["addresses"][username] = targets
     else:
@@ -90,18 +84,11 @@ for item in items:
 
 # ── Generator functions (one per template) ────────────────────
 
-def gen_relay_domains():
-    """Replaces relay-domains.erb — used by IMAP and SMTP-IN."""
-    lines = []
-    for tld in sorted(domains):
-        lines.append(tld)
-        for subd in sorted(domains[tld]["subdomains"]):
-            lines.append(f"{subd}.{tld}")
-    return "\n".join(lines) + "\n"
+def gen_domain_list():
+    """Every hosted name, one per line: each tld followed by its subdomains.
 
-
-def gen_masq_domains():
-    """Replaces masq-domains.erb — used by SMTP-IN and SMTP-OUT."""
+    relay-domains, local-host-names and masq-domains all want exactly this
+    list, so they share one generator."""
     lines = []
     for tld in sorted(domains):
         lines.append(tld)
@@ -158,36 +145,32 @@ def gen_aliases():
     return "\n".join(lines) + "\n"
 
 
-def gen_imap_access():
-    """Replaces imap-access.erb."""
+def gen_access(known, unknown):
+    """Access map: every provisioned address gets `known`, every bare domain
+    and subdomain gets `unknown` (there is no apex or catch-all addressing).
+    The two tiers differ only in which verbs they use."""
     lines = []
     for tld in sorted(domains):
         d = domains[tld]
         for addr in sorted(d["addresses"]):
-            lines.append(f"To:{addr}@{tld}\tOK")
+            lines.append(f"To:{addr}@{tld}\t{known}")
         for subd in sorted(d["subdomains"]):
             sd = d["subdomains"][subd]
             for addr in sorted(sd["addresses"]):
-                lines.append(f"To:{addr}@{subd}.{tld}\tOK")
-            lines.append(f"To:{subd}.{tld}\tTEMPFAIL")
-        lines.append(f"To:{tld}\tTEMPFAIL")
+                lines.append(f"To:{addr}@{subd}.{tld}\t{known}")
+            lines.append(f"To:{subd}.{tld}\t{unknown}")
+        lines.append(f"To:{tld}\t{unknown}")
     return "\n".join(lines) + "\n"
+
+
+def gen_imap_access():
+    """Replaces imap-access.erb."""
+    return gen_access("OK", "TEMPFAIL")
 
 
 def gen_in_access():
     """Replaces in-access.erb."""
-    lines = []
-    for tld in sorted(domains):
-        d = domains[tld]
-        for addr in sorted(d["addresses"]):
-            lines.append(f"To:{addr}@{tld}\tRELAY")
-        for subd in sorted(d["subdomains"]):
-            sd = d["subdomains"][subd]
-            for addr in sorted(sd["addresses"]):
-                lines.append(f"To:{addr}@{subd}.{tld}\tRELAY")
-            lines.append(f"To:{subd}.{tld}\tREJECT")
-        lines.append(f"To:{tld}\tREJECT")
-    return "\n".join(lines) + "\n"
+    return gen_access("RELAY", "REJECT")
 
 
 def gen_dkim_keytable():
@@ -227,21 +210,21 @@ def write(path, content):
     print(f"  Generated {path}")
 
 if tier == "imap":
-    write("/etc/mail/local-host-names", gen_relay_domains())
-    write("/etc/mail/relay-domains",    gen_relay_domains())
+    write("/etc/mail/local-host-names", gen_domain_list())
+    write("/etc/mail/relay-domains",    gen_domain_list())
     write("/etc/mail/access",           gen_imap_access())
     write("/etc/mail/virtusertable",    gen_virtusertable())
     write("/etc/aliases.dynamic",       gen_aliases())
 
 elif tier == "smtp-in":
-    write("/etc/mail/masq-domains",     gen_masq_domains())
+    write("/etc/mail/masq-domains",     gen_domain_list())
     write("/etc/mail/access",           gen_in_access())
-    write("/etc/mail/relay-domains",    gen_relay_domains())
+    write("/etc/mail/relay-domains",    gen_domain_list())
     write("/etc/mail/mailertable",      gen_mailertable())
     write("/etc/mail/virtusertable",    gen_virtusertable())
 
 elif tier == "smtp-out":
-    write("/etc/mail/masq-domains",     gen_masq_domains())
+    write("/etc/mail/masq-domains",     gen_domain_list())
     write("/etc/mail/mailertable",      gen_mailertable())
     write("/etc/opendkim/KeyTable",     gen_dkim_keytable())
     write("/etc/opendkim/SigningTable",  gen_dkim_signingtable())


### PR DESCRIPTION
## What

Three dead/duplicated things in `docker/shared/generate-config.sh`, all left over from the Chef-to-container port. No generated file changes by a single byte.

1. **`private_key` is read but never used.** Each DynamoDB row was unwrapped into a local `private_key` and stashed at `domains[tld]["private_key"]`. Nothing reads that key. Removed.
2. **`"action": "nothing"` on every subdomain node** — a leftover Chef resource attribute with no reader. Removed.
3. **Two duplicated generator pairs unified.**
   - `gen_relay_domains()` and `gen_masq_domains()` had byte-identical bodies -> one `gen_domain_list()`.
   - `gen_imap_access()` and `gen_in_access()` were identical except for their two verbs (`OK`/`TEMPFAIL` vs `RELAY`/`REJECT`) -> shared `gen_access(known, unknown)`, with **both original names kept as thin wrappers** (`gen_imap_access` is referenced by name from a comment in `terraform/infra/modules/monitoring/healthchecks.tf`, and the docstrings still record which `.erb` each replaced).

Net -41/+24, one file.

## Why it's safe

**Dead-symbol proof.**

- `private_key`: `grep -rn 'private_key'` over the repo finds no writer of a `private_key` attribute on the `cabal-addresses` table, and no other reader of the domain tree. DKIM signing uses a single global key — SSM `/cabal/dkim_private_key` -> `DKIM_PRIVATE_KEY` (`terraform/infra/modules/ecs/task-definitions.tf:401`) -> written to `/etc/opendkim/keys/cabal` by `entrypoint.sh`, and `gen_dkim_keytable()` hardcodes that same path for every domain. The per-row attribute has no path to any output.
- `"action"`: the only occurrence in the file was the assignment; the domain tree is in-memory only and never serialized.
- Function renames: `gen_relay_domains` / `gen_masq_domains` appear only in this file and in `docs/0.4.x/containerization-plan.md` (the historical planning record, deliberately untouched). `gen_imap_access` / `gen_in_access` keep their names, so the `healthchecks.tf` comment reference stays accurate.

**Differential output test.** Extracted the inline `PYEOF` Python block from both the `origin/stage` version and this one, ran each for all three tiers against a synthetic `dynamodb scan` payload with every branch exercised — bare-tld addresses, single- and multi-target subdomain addresses, a combined-alias set repeated under two subdomains, a domain carrying `private_key`, two TLDs for cross-TLD sort order, and four rejected usernames (empty, embedded space, embedded tab, leading space) — with all writes captured in memory. Compared every generated file plus stderr:

| tier | files compared |
|---|---|
| `imap` | `local-host-names`, `relay-domains`, `access`, `virtusertable`, `aliases.dynamic` |
| `smtp-in` | `masq-domains`, `access`, `relay-domains`, `mailertable`, `virtusertable` |
| `smtp-out` | `masq-domains`, `mailertable`, `KeyTable`, `SigningTable`, `TrustedHosts` |

All 15 outputs and all four skip-warnings are byte-identical before and after.

**Lint.** `bash -n` clean. `python3 -m pylint` on the extracted block reports the same four pre-existing messages before and after (`multiple-imports`, two `unspecified-encoding`, one `consider-using-dict-items`) — no new message, in particular no unused-variable. Note `shellcheck` is not installed on this machine and CI does not run it; the diff is entirely inside the Python heredoc, with no shell-side change.

## Heads-up on merge cost

`docker/shared/**` is a rebuild trigger for all three core tiers, so merging this rebuilds and rolls `imap`, `smtp-in` and `smtp-out` in stage. Nothing here needs to ship urgently — worth batching with the next docker change if you'd rather not spend a mail-plane roll on a cleanup.