### PR TITLE
Keep the new-address form's input when the request is incomplete

### DIFF
--- a/changelog.d/new-address-domain-guard.fixed.md
+++ b/changelog.d/new-address-domain-guard.fixed.md
@@ -1,0 +1,5 @@
+- **New-address form no longer discards what you typed.** Requesting an address
+  without picking a domain now says which field is missing and leaves the form
+  intact, instead of clearing every field with no error and creating nothing. A
+  request the server rejects is reported the same way rather than failing
+  silently.

--- a/react/admin/src/Addresses/Request.jsx
+++ b/react/admin/src/Addresses/Request.jsx
@@ -86,6 +86,18 @@ function Request({ domains, callback, setMessage }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    // Validate before touching the form: an incomplete request would post a
+    // malformed address and, on rejection, leave the user with a cleared form
+    // and no explanation.
+    const missing = [
+      !username && 'a username',
+      !subdomain && 'a subdomain',
+      !domain && 'a domain',
+    ].filter(Boolean);
+    if (missing.length > 0) {
+      setMessage(`Please enter ${missing.join(', ')} before requesting an address.`, true);
+      return;
+    }
     const requestButton = e.target;
     requestButton.classList.add('sending');
     const submitUsername = username;
@@ -93,16 +105,23 @@ function Request({ domains, callback, setMessage }) {
     const submitDomain = domain;
     const submitComment = comment;
     const submitAddress = submitUsername + '@' + submitSubdomain + '.' + submitDomain;
-    setUsername("");
-    setSubdomain("");
-    setDomain("");
-    setComment("");
     api.newAddress(
       submitUsername, submitSubdomain, submitDomain, submitComment, submitAddress
     ).then(data => {
       requestButton.classList.remove('sending');
+      setUsername("");
+      setSubdomain("");
+      setDomain("");
+      setComment("");
       setMessage(`Successfully requested ${data.data.address}.`, false);
       callback(data.data.address);
+    }, err => {
+      // Keep what was typed so the request can be corrected and retried.
+      requestButton.classList.remove('sending');
+      setMessage(
+        `Failed to request ${submitAddress}: ` + (err?.response?.data?.message || err?.message || err),
+        true
+      );
     });
   };
 

--- a/react/admin/src/Addresses/Request.test.jsx
+++ b/react/admin/src/Addresses/Request.test.jsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Request from './Request';
+import AuthContext from '../contexts/AuthContext';
+
+const mockNewAddress = vi.fn();
+const mockListMyDomains = vi.fn();
+
+const mockApi = {
+  newAddress: mockNewAddress,
+  listMyDomains: mockListMyDomains,
+};
+
+vi.mock('../hooks/useApi', () => ({
+  default: () => mockApi,
+}));
+
+const authValue = { token: 'tok', api_url: 'http://api', host: 'host' };
+
+function renderRequest(props = {}) {
+  const setMessage = props.setMessage || vi.fn();
+  const callback = props.callback || vi.fn();
+  const utils = render(
+    <AuthContext.Provider value={authValue}>
+      <Request
+        domains={[{ domain: 'cabalmail.com' }]}
+        setMessage={setMessage}
+        callback={callback}
+      />
+    </AuthContext.Provider>
+  );
+  return { ...utils, setMessage, callback };
+}
+
+function fillForm({ domain } = {}) {
+  fireEvent.change(screen.getByPlaceholderText('username'), { target: { name: 'username', value: 'qa0801' } });
+  fireEvent.change(screen.getByPlaceholderText('subdomain'), { target: { name: 'subdomain', value: 'probe0801' } });
+  fireEvent.change(screen.getByPlaceholderText('optional note'), { target: { name: 'comment', value: 'probe note' } });
+  if (domain) {
+    fireEvent.change(screen.getByRole('combobox'), { target: { name: 'domain', value: domain } });
+  }
+}
+
+function expectFormValues({ username, subdomain, comment }) {
+  expect(screen.getByPlaceholderText('username').value).toBe(username);
+  expect(screen.getByPlaceholderText('subdomain').value).toBe(subdomain);
+  expect(screen.getByPlaceholderText('optional note').value).toBe(comment);
+}
+
+describe('Address request form', () => {
+  beforeEach(() => {
+    mockListMyDomains.mockResolvedValue({ data: { Domains: ['cabalmail.com'] } });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refuses to submit without a domain, keeps the typed input and says why', async () => {
+    const { setMessage } = renderRequest();
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cabalmail.com' })).toBeTruthy());
+
+    fillForm();
+    fireEvent.click(screen.getByRole('button', { name: /^Request/ }));
+
+    expect(mockNewAddress).not.toHaveBeenCalled();
+    expect(setMessage).toHaveBeenCalledWith(expect.stringContaining('a domain'), true);
+    expectFormValues({ username: 'qa0801', subdomain: 'probe0801', comment: 'probe note' });
+  });
+
+  it('submits and clears the form once the domain is picked', async () => {
+    mockNewAddress.mockResolvedValue({ data: { address: 'qa0801@probe0801.cabalmail.com' } });
+    const { setMessage, callback } = renderRequest();
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cabalmail.com' })).toBeTruthy());
+
+    fillForm({ domain: 'cabalmail.com' });
+    fireEvent.click(screen.getByRole('button', { name: /^Request/ }));
+
+    await waitFor(() => expect(callback).toHaveBeenCalledWith('qa0801@probe0801.cabalmail.com'));
+    expect(mockNewAddress).toHaveBeenCalledWith(
+      'qa0801', 'probe0801', 'cabalmail.com', 'probe note', 'qa0801@probe0801.cabalmail.com'
+    );
+    expect(setMessage).toHaveBeenCalledWith(expect.stringContaining('Successfully requested'), false);
+    expectFormValues({ username: '', subdomain: '', comment: '' });
+  });
+
+  it('reports a rejected request and keeps the typed input', async () => {
+    mockNewAddress.mockRejectedValue({ response: { data: { message: 'Address already exists' } } });
+    const { setMessage, callback } = renderRequest();
+    await waitFor(() => expect(screen.getByRole('option', { name: 'cabalmail.com' })).toBeTruthy());
+
+    fillForm({ domain: 'cabalmail.com' });
+    fireEvent.click(screen.getByRole('button', { name: /^Request/ }));
+
+    await waitFor(() => expect(setMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Address already exists'), true
+    ));
+    expect(callback).not.toHaveBeenCalled();
+    expectFormValues({ username: 'qa0801', subdomain: 'probe0801', comment: 'probe note' });
+  });
+});


### PR DESCRIPTION
Addresses #869.

## What was wrong

Filling in username, subdomain and a comment but leaving the domain picker on
"Select a domain" and clicking **Request** cleared every field, left the modal
open, showed no error anywhere, and created nothing — pixel-identical to
pressing **Clear**.

## Root cause

`Request.handleSubmit` had no validation and cleared the form *before* the
call, and its `.then` had only a fulfillment handler:

- `setUsername("")` … `setComment("")` ran unconditionally, so the typed input
  was gone the moment the button was clicked;
- `/new` was then posted a malformed address (`qa0801@probe0801.`), which the
  backend rejects;
- with no rejection handler the failure was swallowed — hence "no inline
  message, no red toast, nothing", and the `sending` class was never removed.

So the reported symptom has two authors: the missing guard, and the missing
error path. A server-side rejection of a *complete* request (duplicate
address, denied domain) reproduced it just as well.

## The fix

- Validate the required parts up front and name what's missing
  ("Please enter a domain before requesting an address."), leaving the form
  untouched. The tester's expected behaviour offered "disable the button" as
  the alternative; a disabled button explains nothing, so this takes the
  option that gives a reason.
- Clear the form only once the address actually exists.
- Report a rejected request (`err.response.data.message`) and keep the typed
  input so it can be corrected and retried.

The button stays enabled, which is what makes the explanation reachable.

## Test evidence

New `src/Addresses/Request.test.jsx` — three cases (no-domain guard, happy
path clears, rejection keeps input). Fails before, passes after:

```
before:  × refuses to submit without a domain …   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
         × reports a rejected request …           AssertionError: expected "vi.fn()" to be called with …
after:   Test Files 39 passed | Tests 386 passed
```

Live repro against a local build of this branch, signed in to stage, exactly
the issue's steps:

```
[869] before Request: {"username":"qa0801f","subdomain":"probe0801f","comment":"no-domain probe","domain":""}
[869] after Request:  {"username":"qa0801f","subdomain":"probe0801f","comment":"no-domain probe","domain":""}
[869] message shown:  "Please enter a domain before requesting an address."  (_error_ variant)
```

Screenshot: `~/Code/cabal/fixer/logs/0801f-869-nodomain.png`.