### PR TITLE
Wire up the reader's Move button

### DIFF
--- a/changelog.d/reader-move-button.fixed.md
+++ b/changelog.d/reader-move-button.fixed.md
@@ -1,0 +1,4 @@
+- **Move works from the open message.** The reader's Move button was an
+  always-disabled placeholder, so relocating a message meant closing it and
+  going through bulk selection. It now opens a folder chooser and moves the
+  message you are reading.

--- a/react/admin/src/Email/MessageOverlay/MessageOverlay.css
+++ b/react/admin/src/Email/MessageOverlay/MessageOverlay.css
@@ -148,6 +148,33 @@
   flex-shrink: 0;
 }
 
+/* --- Move folder chooser ----------------------------------------------- */
+
+.reader-move {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Opens leftwards, like the overflow menu: the Move button sits close enough
+   to the pane's right edge that a left-anchored chooser is clipped. */
+.reader-move-picker {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 20;
+  min-width: 220px;
+  padding: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-menu);
+  color: var(--ink);
+  font-family: var(--font-ui);
+}
+
+.reader-move-picker .filter-folder { width: 100%; }
+.reader-move-picker select { width: 100%; }
+
 /* --- Overflow menu ----------------------------------------------------- */
 
 .reader-overflow {

--- a/react/admin/src/Email/MessageOverlay/MessageOverlay.test.jsx
+++ b/react/admin/src/Email/MessageOverlay/MessageOverlay.test.jsx
@@ -42,6 +42,9 @@ const mockApi = {
   setFlag: vi.fn().mockResolvedValue({}),
   moveMessages: vi.fn().mockResolvedValue({}),
   purgeMessages: vi.fn().mockResolvedValue({}),
+  getFolderList: vi.fn().mockResolvedValue({
+    data: { folders: ['INBOX', 'Archive', 'qamove', 'Trash'], sub_folders: ['INBOX', 'Archive', 'qamove'] },
+  }),
 };
 
 vi.mock('../../hooks/useApi', () => ({
@@ -266,6 +269,79 @@ describe('MessageOverlay (Reader)', () => {
     } finally {
       unmount();
     }
+  });
+
+  describe('the Move button', () => {
+    const pickerIn = (container) => container.querySelector('.reader-move-picker select');
+
+    it('is enabled and opens a folder chooser', async () => {
+      const { container, unmount } = renderOverlay();
+      try {
+        await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+        const moveButton = screen.getByLabelText('Move');
+        expect(moveButton).not.toBeDisabled();
+        fireEvent.click(moveButton);
+        await waitFor(() => expect(pickerIn(container)).toBeTruthy());
+        expect(within(pickerIn(container)).getByText('qamove')).toBeInTheDocument();
+      } finally {
+        unmount();
+      }
+    });
+
+    it('moves the open message to the chosen folder and hides the reader', async () => {
+      const hide = vi.fn();
+      const { container, unmount } = renderOverlay({ hide });
+      try {
+        await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+        fireEvent.click(screen.getByLabelText('Move'));
+        await waitFor(() => expect(pickerIn(container)).toBeTruthy());
+        fireEvent.change(pickerIn(container), { target: { value: 'qamove' } });
+        await waitFor(() => {
+          expect(mockApi.moveMessages).toHaveBeenCalledWith(
+            'INBOX', 'qamove', [1], '', expect.anything(),
+          );
+        });
+        await waitFor(() => expect(hide).toHaveBeenCalled());
+        expect(pickerIn(container)).toBeNull();
+      } finally {
+        unmount();
+      }
+    });
+
+    it("does nothing when the message's own folder is chosen", async () => {
+      const hide = vi.fn();
+      const { container, unmount } = renderOverlay({ hide });
+      try {
+        await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+        fireEvent.click(screen.getByLabelText('Move'));
+        await waitFor(() => expect(pickerIn(container)).toBeTruthy());
+        fireEvent.change(pickerIn(container), { target: { value: 'INBOX' } });
+        expect(mockApi.moveMessages).not.toHaveBeenCalled();
+        expect(hide).not.toHaveBeenCalled();
+      } finally {
+        unmount();
+      }
+    });
+
+    it('reports a failed move and keeps the reader open', async () => {
+      const hide = vi.fn();
+      mockApi.moveMessages.mockRejectedValueOnce(new Error('nope'));
+      const { container, unmount } = renderOverlay({ hide });
+      try {
+        await waitFor(() => expect(mockGetMessage).toHaveBeenCalled());
+        fireEvent.click(screen.getByLabelText('Move'));
+        await waitFor(() => expect(pickerIn(container)).toBeTruthy());
+        fireEvent.change(pickerIn(container), { target: { value: 'qamove' } });
+        await waitFor(() => {
+          expect(setMessage).toHaveBeenCalledWith(
+            expect.stringContaining('Unable to move message'), true,
+          );
+        });
+        expect(hide).not.toHaveBeenCalled();
+      } finally {
+        unmount();
+      }
+    });
   });
 
   describe('deleting from Trash', () => {

--- a/react/admin/src/Email/MessageOverlay/index.jsx
+++ b/react/admin/src/Email/MessageOverlay/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import React, {
-  useCallback, useEffect, useMemo, useState,
+  useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
 import {
   ArrowLeft,
@@ -13,6 +13,7 @@ import {
   Archive, FolderInput, Trash2, Flag, MailOpen, X,
 } from 'lucide-react';
 import ReaderBody from './ReaderBody';
+import FolderPicker from '../Messages/Folders';
 import Attachments from './Attachments';
 import OverflowMenu from './OverflowMenu';
 import ViewSourceModal from './ViewSourceModal';
@@ -70,6 +71,10 @@ function MessageOverlay({
   // Confirmation for permanent deletion out of Trash.
   const [confirmPurge, setConfirmPurge] = useState(false);
 
+  // Folder chooser hanging off the Move button.
+  const [movePickerOpen, setMovePickerOpen] = useState(false);
+  const moveRootRef = useRef(null);
+
   const envelopeId = envelope && envelope.id;
   const seen = envelope && envelope.flags
     ? envelope.flags.includes('\\Seen')
@@ -88,6 +93,7 @@ function MessageOverlay({
     setRawText('');
     setRawError(false);
     setSourceOpen(false);
+    setMovePickerOpen(false);
 
     api.getMessage(folder, envelopeId, seen).then((data) => {
       setMessageBodyPlain(data.data.message_body_plain || '');
@@ -160,6 +166,41 @@ function MessageOverlay({
         console.log(err);
       });
   }, [api, folder, envelopeId, hide, setMessage]);
+
+  const doMove = useCallback((target) => {
+    setMovePickerOpen(false);
+    // Selecting the folder the message already lives in is a no-op, not a
+    // round trip.
+    if (!envelopeId || !target || target === folder) return;
+    api.moveMessages(folder, target, [envelopeId], '', ARRIVAL.imap)
+      .then(() => hide())
+      .catch((err) => {
+        setMessage(`Unable to move message to ${target}.`, true);
+        console.log(err);
+      });
+  }, [api, folder, envelopeId, hide, setMessage]);
+
+  // Dismiss the folder chooser on an outside click or Escape, matching the
+  // overflow menu.
+  useEffect(() => {
+    if (!movePickerOpen) return undefined;
+    const onDocClick = (e) => {
+      if (!moveRootRef.current) return;
+      if (!moveRootRef.current.contains(e.target)) setMovePickerOpen(false);
+    };
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setMovePickerOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [movePickerOpen]);
 
   // In Trash, "Delete" purges the message for good (after confirmation)
   // instead of moving it into Trash again.
@@ -444,16 +485,29 @@ function MessageOverlay({
         >
           <Archive size={16} aria-hidden="true" />
         </button>
-        <button
-          type="button"
-          className="reader-btn icon-only"
-          onClick={() => setMessage('Move is coming in a later phase.', false)}
-          title="Move"
-          aria-label="Move"
-          disabled
-        >
-          <FolderInput size={16} aria-hidden="true" />
-        </button>
+        <div className="reader-move" ref={moveRootRef}>
+          <button
+            type="button"
+            className="reader-btn icon-only"
+            onClick={() => setMovePickerOpen((v) => !v)}
+            title="Move"
+            aria-label="Move"
+            aria-haspopup="true"
+            aria-expanded={movePickerOpen}
+          >
+            <FolderInput size={16} aria-hidden="true" />
+          </button>
+          {movePickerOpen && (
+            <div className="reader-move-picker">
+              <FolderPicker
+                folder={folder}
+                setFolder={doMove}
+                setMessage={setMessage}
+                label="Move to"
+              />
+            </div>
+          )}
+        </div>
         <button
           type="button"
           className="reader-btn icon-only"


### PR DESCRIPTION
Addresses #870.

## What was wrong

The reader toolbar's **Move** button rendered `disabled` for every message, in
every folder, at every point after load — while every sibling control worked.
Moving an open message meant closing the reader and re-selecting it in bulk
mode.

## Root cause

Not a regression: the button was never implemented. It shipped hard-`disabled`
with a placeholder handler behind it —
`onClick={() => setMessage('Move is coming in a later phase.', false)}` — so no
prop or state could ever enable it, which matches the tester's finding that no
folder, message, timing or subscription state made a difference. The capability
was fine because the bulk toolbar has its own, real, implementation.

## The fix

Hang the existing folder chooser off the button — the same `Folders` component
the bulk toolbar's "Move to" picker uses — and move the open message through
the same `moveMessages` call `Archive` already makes, hiding the reader on
success. The chooser dismisses on outside click or Escape, following the
overflow menu's pattern, and closes when the reader switches message.

Two smaller decisions:

- Choosing the folder the message is already in does nothing rather than making
  a pointless round trip.
- The popover is right-anchored. Left-anchored it was clipped by the reader
  pane's `overflow: hidden` when the addresses rail was open (caught in the
  live pass, screenshot before/after).

The chooser is the bulk component verbatim, so it inherits that component's
presentation and its two quirks the tester noted in passing — INBOX listed
twice, and the current folder offered as a target (harmless here, given the
no-op guard). Cleaning up the shared picker is a separate change; happy to do
it if you want it.

## Test evidence

Four new cases in `MessageOverlay.test.jsx` (enabled + chooser opens, move
issues the call and hides the reader, own-folder is a no-op, failure is
reported and the reader stays). Fails before, passes after:

```
before:  × is enabled and opens a folder chooser         expect(element).not.toBeDisabled()
         × moves the open message …                      AssertionError: expected null to be truthy
         × does nothing when the message's own folder …  AssertionError: expected null to be truthy
         × reports a failed move …                       AssertionError: expected null to be truthy
after:   Test Files 39 passed | Tests 386 passed
```

Live repro against a local build of this branch, signed in to stage:

```
[870] Move button: {"present":true,"disabled":false}
[870] chooser options: ["INBOX","INBOX","Archive","Drafts","Sent","Trash"]
[870] open message subject: "Fixer 837 prune probe"
[870] after choosing Archive: {"readerOpen":false,"pickerOpen":false}
     → server-side: INBOX [8,9,16,21] -> [8,9,16], Archive [1] -> [1,2]
[870] Escape closes the chooser, message stays put
     → geometry with the rail open: picker 979..1213 inside reader 847..1440
```

Screenshots: `~/Code/cabal/fixer/logs/0801f-870-picker.png`,
`0801f-870-after-move.png`. Mailbox restored afterwards (the probe message is
back in INBOX; a move rewrites the UID, as the issue notes).