### PR TITLE
Size the reader header to its contents so the auth line is visible

### DIFF
--- a/apple/Cabalmail/Views/MessageDetailView.swift
+++ b/apple/Cabalmail/Views/MessageDetailView.swift
@@ -58,21 +58,37 @@ struct MessageDetailView: View {
     // `nil` until the first scroll report — a sentinel `Int.min` would overflow
     // the `offset - lastReportedPlainOffset` delta on the first callback.
     @State var lastReportedPlainOffset: Int?
+    // Measured height of `headerBlock`, so the header sizes to its content
+    // instead of to a fixed slice of the pane. See
+    // `ReaderHeaderHeightPolicy`.
+    @State var headerContentHeight: CGFloat = 0
 
     var body: some View {
         GeometryReader { proxy in
             VStack(alignment: .leading, spacing: 0) {
                 // Subject is shown in full in the pane (the list truncates
                 // it) and the header is allowed to grow with a wrapping
-                // subject. Cap at 15% of the pane's height and let the
-                // header scroll when a very long subject or sprawling
-                // recipient list would otherwise eat the reading area.
+                // subject. The block takes the height its content actually
+                // needs, and only scrolls once that would claim more of the
+                // pane than `ReaderHeaderHeightPolicy` allows. A ScrollView
+                // is greedy along its scroll axis, so this has to be an
+                // explicit height rather than a `maxHeight` — a cap alone
+                // makes the block exactly that tall whatever it holds, which
+                // is what pushed the authentication line out of view.
                 ScrollView(.vertical) {
                     headerBlock
                         .padding(.horizontal)
                         .padding(.vertical, 8)
+                        .onGeometryChange(for: CGFloat.self) { headerProxy in
+                            headerProxy.size.height
+                        } action: { newHeight in
+                            headerContentHeight = newHeight
+                        }
                 }
-                .frame(maxHeight: proxy.size.height * 0.15)
+                .frame(height: ReaderHeaderHeightPolicy.height(
+                    contentHeight: headerContentHeight,
+                    paneHeight: proxy.size.height
+                ))
                 if let attachments = model?.attachments, !attachments.isEmpty {
                     AttachmentStrip(attachments: attachments)
                         .padding(.vertical, 8)

--- a/apple/Cabalmail/Views/ReaderHeaderHeightPolicy.swift
+++ b/apple/Cabalmail/Views/ReaderHeaderHeightPolicy.swift
@@ -1,0 +1,28 @@
+import CoreGraphics
+
+/// How tall the reader's scrollable header block may be, given what it
+/// actually needs and how much room the pane has. A pure rule rather than an
+/// inline `.frame(maxHeight:)` so it can be tested directly — the view's
+/// geometry isn't reachable from a unit test, this is.
+enum ReaderHeaderHeightPolicy {
+    /// The most of the pane the header may claim. Beyond this the reading
+    /// area starts to disappear, so a pathological header (a subject that
+    /// wraps five times, a sprawling Cc list) scrolls inside the block
+    /// instead of pushing the body off screen.
+    static let maxPaneFraction: CGFloat = 0.45
+
+    /// - Parameters:
+    ///   - contentHeight: the header's measured ideal height; `<= 0` means
+    ///     it hasn't been measured yet.
+    ///   - paneHeight: the height available to the whole reader.
+    static func height(contentHeight: CGFloat, paneHeight: CGFloat) -> CGFloat {
+        // No pane to divide up yet: ask for exactly what the content needs.
+        guard paneHeight > 0 else { return max(contentHeight, 0) }
+        let cap = paneHeight * maxPaneFraction
+        // Before the first measurement, take the cap rather than zero — a
+        // zero-height header would collapse the block on the first layout
+        // pass.
+        guard contentHeight > 0 else { return cap }
+        return min(contentHeight, cap)
+    }
+}

--- a/apple/CabalmailTests/ReaderHeaderHeightPolicyTests.swift
+++ b/apple/CabalmailTests/ReaderHeaderHeightPolicyTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import Cabalmail
+
+// Regression coverage for issue #871: the reader's header block was pinned to
+// 15% of the pane's height. A ScrollView is greedy along its scroll axis, so
+// the block was always exactly that tall — and the standard iPhone header
+// (subject + from + To + date + sender authentication) needs about a line
+// more than that, which put `AuthResultsLine` just below the block's bottom
+// edge, covered by the body web view. The verdict a user most needs to see,
+// "not verified", was the one that was never visible.
+final class ReaderHeaderHeightPolicyTests: XCTestCase {
+
+    // The geometry the tester captured on an iPhone 16 Pro: a 788pt reading
+    // pane, a header needing ~231pt for its five lines. The old 15% rule gave
+    // it 118pt.
+    private let paneHeight: CGFloat = 788
+    private let standardHeaderHeight: CGFloat = 231
+
+    func testAStandardHeaderGetsAllTheRoomItNeeds() {
+        XCTAssertEqual(
+            ReaderHeaderHeightPolicy.height(
+                contentHeight: standardHeaderHeight,
+                paneHeight: paneHeight
+            ),
+            standardHeaderHeight,
+            "the authentication line has to fit inside the block, not below it"
+        )
+    }
+
+    func testAStandardHeaderClearsTheOldFixedSlice() {
+        // Guards the specific arithmetic that broke: whatever the cap is, the
+        // header this size must not be clipped by it.
+        XCTAssertGreaterThan(standardHeaderHeight, paneHeight * 0.15)
+        XCTAssertLessThanOrEqual(
+            standardHeaderHeight,
+            paneHeight * ReaderHeaderHeightPolicy.maxPaneFraction
+        )
+    }
+
+    func testAShortHeaderDoesNotClaimTheWholeCap() {
+        XCTAssertEqual(
+            ReaderHeaderHeightPolicy.height(contentHeight: 90, paneHeight: paneHeight),
+            90,
+            "a one-recipient header shouldn't leave a band of blank space above the body"
+        )
+    }
+
+    func testASprawlingHeaderIsCappedSoTheBodySurvives() {
+        let capped = ReaderHeaderHeightPolicy.height(
+            contentHeight: 2_000,
+            paneHeight: paneHeight
+        )
+        XCTAssertEqual(capped, paneHeight * ReaderHeaderHeightPolicy.maxPaneFraction)
+        XCTAssertLessThan(capped, paneHeight / 2, "the reading area keeps the larger share")
+    }
+
+    func testAnUnmeasuredHeaderFallsBackToTheCapNotToZero() {
+        XCTAssertEqual(
+            ReaderHeaderHeightPolicy.height(contentHeight: 0, paneHeight: paneHeight),
+            paneHeight * ReaderHeaderHeightPolicy.maxPaneFraction
+        )
+    }
+
+    func testNoPaneYetAsksForWhatTheContentNeeds() {
+        XCTAssertEqual(
+            ReaderHeaderHeightPolicy.height(contentHeight: 231, paneHeight: 0),
+            231
+        )
+        XCTAssertEqual(
+            ReaderHeaderHeightPolicy.height(contentHeight: -1, paneHeight: 0),
+            0
+        )
+    }
+}

--- a/changelog.d/reader-auth-line-visible.fixed.md
+++ b/changelog.d/reader-auth-line-visible.fixed.md
@@ -1,0 +1,6 @@
+- Apple: **Sender-authentication verdict is visible again in the reader.** The
+  message header was pinned to a fixed 15% of the pane, which left the
+  SPF/DKIM/DMARC line — and the "not verified" fallback that matters most —
+  just below the header's bottom edge, hidden under the message body. The
+  header now takes the height its contents need, and only scrolls when a
+  sprawling subject or recipient list would crowd out the reading area.


### PR DESCRIPTION
Addresses #871.

## What was wrong

`AuthResultsLine` — the SPF/DKIM/DMARC chips, or the muted "Not verified"
fallback — was laid out but never visible in the iOS reader: it sat just below
the header container's bottom edge, covered by the body web view.

## Root cause

Confirmed as the issue suspected, and it is OS-independent arithmetic rather
than anything 27-specific.

`MessageDetailView` puts `headerBlock` in a `ScrollView` with
`.frame(maxHeight: proxy.size.height * 0.15)`. A `ScrollView` is greedy along
its scroll axis, so that cap was also its floor — the block was *always*
exactly 15% of the pane, whatever it held. `AuthResultsLine` was appended to
`headerBlock` later (98fd102e) without revisiting the number, and the standard
iPhone header (subject + from + To + date + auth) needs roughly a line more
than 15%. The auth line is precisely the row that overflowed. It was nominally
scrollable, but with no affordance the region reads as static, so in practice
the verdict was never seen.

The 15% rule applies on every platform, so a mac window tall enough to make
15% smaller than the header had the same hole.

## The fix

Measure the header via `.onGeometryChange` and give the block that height,
clamped by a new `ReaderHeaderHeightPolicy` (45% of the pane) so a
pathological header — a five-line subject, a sprawling Cc list — still can't
crowd out the reading area and scrolls inside the block as originally
intended. A short header no longer leaves a band of blank space above the
body either.

The rule lives in its own file as a pure function because the view's geometry
isn't reachable from a unit test, following `CompactColumnPolicy` /
`ComposeFormSection`.

### One thing from the report that isn't a defect

The "degenerate 66.0pt width for a 35-character string" is the frame of the
*rendered* text, "Not verified", at caption size; the 35-character string is
the accessibility label ("Sender authentication: not verified"). The same
66.0pt width shows up with the fix in place, with the line fully visible.

## Test evidence

New `CabalmailTests/ReaderHeaderHeightPolicyTests.swift`, pinned to the
geometry the tester captured (788pt pane, ~231pt header). Shimming the policy
back to the old `paneHeight * 0.15` rule fails 5 of its 6 cases:

```
testAStandardHeaderGetsAllTheRoomItNeeds       ("118.2") is not equal to ("231.0")
testAShortHeaderDoesNotClaimTheWholeCap        ("118.2") is not equal to ("90.0")
testASprawlingHeaderIsCappedSoTheBodySurvives  ("118.2") is not equal to ("354.6")
testAnUnmeasuredHeaderFallsBackToTheCapNotToZero
testNoPaneYetAsksForWhatTheContentNeeds
```

With the fix: `Executed 91 tests, with 0 failures` (CabalmailMac scheme),
`swiftlint --strict` clean, iOS generic build OK.

Live on the iPhone 17 simulator against stage, both messages the issue names:

```
StaticText {16.0, 124.0}  {140.3, 24.0}   'Link seed 0726'
StaticText {68.0, 156.0}  {240.3, 20.3}   'daily@qa0722.cabal-mail.com'
StaticText {68.0, 180.3}  {17.3, 14.3}    'To:'
StaticText {68.0, 198.7}  {133.3, 14.3}   'Jul 26, 2026 at 6:21 AM'
StaticText {68.0, 217.0}  {66.0, 14.3}    'Sender authentication: not verified'  <- on screen
```

Screenshots: `~/Code/cabal/fixer/logs/0801f-871-reader.png` (no body) and
`0801f-871-reader2.png` (with body — the divider and web view now start below
the auth line, with no blank band). Simulator restored to the tester's build,
signed in, parked on INBOX.