### PR TITLE
Scope the last-release run table to the merge's own workflows

### DIFF
--- a/scripts/release-dashboard.py
+++ b/scripts/release-dashboard.py
@@ -325,8 +325,26 @@ def shape_run(run):
 
 
 def runs_for_sha(sha):
+    """The repo's own workflow runs that the push of `sha` triggered.
+
+    Two filters, both on properties GitHub reports rather than a hand-kept
+    workflow list (which would drift as workflows are added):
+
+      * event == push: a head_sha match alone is not enough - issue-event
+        runs (claude.yml) execute against the default branch tip, so they
+        carry main's head SHA without being part of the release.
+      * an in-house path: GitHub-managed workflows (pages, default-setup
+        CodeQL) live under dynamic/, not .github/workflows/, and are noise
+        next to the release's own deploys.
+
+    Everything that survives is one of the push-to-main workflows (app.yml /
+    apple.yml / infra.yml / logo-assets.yml / release.yml), and only when the
+    release's diff matched its path filter.
+    """
     data = rest("GET", f"/repos/{REPO_SLUG}/actions/runs?head_sha={sha}&per_page=100")
-    runs = [shape_run(r) for r in (data or {}).get("workflow_runs") or []]
+    runs = [shape_run(r) for r in (data or {}).get("workflow_runs") or []
+            if r.get("event") == "push"
+            and (r.get("path") or "").startswith(".github/workflows/")]
     runs.sort(key=lambda r: r["name"].lower())
     return runs
 
@@ -763,7 +781,9 @@ PAGE = r"""<!DOCTYPE html>
     the merge actually triggered — path filtering happens on GitHub's side, so a release
     that changed nothing under <code>apple/</code> simply has no <code>apple.yml</code>
     run here — until every run concludes and <code>release.yml</code> has published the
-    GitHub release. Promote, Merge, and Approve are real changes (a push to stage, a
+    GitHub release. Only the repo's own push-triggered workflows count: GitHub-managed
+    runs (pages, default-setup CodeQL) and issue-triggered automation on the same
+    commit are excluded. Promote, Merge, and Approve are real changes (a push to stage, a
     merge to main, a prod deploy) and each asks for confirmation; everything else is
     read-only. While something is in flight the page re-polls itself every few seconds
     regardless of the refresh-interval setting.


### PR DESCRIPTION
## Summary

Follow-up to #874/#877. The **Last release** table (and the phase derived from it) now counts only the runs the release merge itself triggered, filtered on two properties GitHub reports per run — no hand-maintained workflow list to drift:

- **`event == push`** — this also fixes a real bug: issue-event runs (`claude.yml`) execute against the default branch tip, so they carry main's head SHA and were showing up in the release table. A failed Claude Automation run would even have flagged the release as "needs attention".
- **path under `.github/workflows/`** — GitHub-managed workflows (pages, default-setup CodeQL's "Push on main") live under `dynamic/` and are excluded.

What survives is exactly the repo's push-to-main workflows — `app.yml`, `apple.yml`, `infra.yml`, `logo-assets.yml`, `release.yml` — each appearing only when the release's diff matched its path filter. `release.yml` stays visible deliberately: it's the run that publishes the GitHub release the card tracks, so hiding it would leave a failed "publishing release…" state with nothing to look at. The footer discloses the exclusions. The global **Waiting for approval** section is intentionally untouched — it stays repo-wide.

## Testing

Ran `build_model()` live against the real repo: the 0.11.20 release now lists exactly `Build and Deploy Application` and `Release` — the seven `claude.yml` issue runs, `pages build and deployment`, and CodeQL's `Push on main` (all sharing the merge SHA) are filtered out. `ast.parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)