### PR TITLE
test: bound MailboxWatcherTests stream waits with a deadline

### DIFF
--- a/apple/CabalmailKit/Tests/CabalmailKitTests/MailboxWatcherTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/MailboxWatcherTests.swift
@@ -6,6 +6,14 @@ import XCTest
 /// which opens a real socket — we substitute a closure that returns
 /// pre-built `AsyncThrowingStream`s to drive the watcher's states without
 /// touching the network.
+///
+/// Every stream consumption here goes through `withDeadline`: an unbounded
+/// `for await` on the watcher stream waits forever if the expected event
+/// interleaving never arrives, and a hung test emits nothing — no failure,
+/// no output. On the visionOS 27.0 simulator (xcode-27 CI image,
+/// 2026-08-01) exactly that wedged xcodebuild for 57 silent minutes until
+/// the job timeout killed it. The deadline turns a stall into a named,
+/// diagnosable test failure on every platform.
 final class MailboxWatcherTests: XCTestCase {
     func testEmitsChangedForExistsExpungeFetch() async {
         let watcher = MailboxWatcher(
@@ -23,22 +31,27 @@ final class MailboxWatcherTests: XCTestCase {
             clock: { _ in }
         )
         let stream = await watcher.start()
-        var changes = 0
-        var sawActive = false
-        for await event in stream {
-            switch event {
-            case .active:
-                sawActive = true
-            case .changed:
-                changes += 1
-                if changes == 3 {
-                    await watcher.stop()
+        let outcome = await withDeadline {
+            var changes = 0
+            var sawActive = false
+            for await event in stream {
+                switch event {
+                case .active:
+                    sawActive = true
+                case .changed:
+                    changes += 1
+                    if changes == 3 {
+                        await watcher.stop()
+                    }
+                case .reconnecting:
                     break
                 }
-            case .reconnecting:
-                break
+                if changes >= 3 { break }
             }
-            if changes >= 3 { break }
+            return (sawActive: sawActive, changes: changes)
+        }
+        guard let (sawActive, changes) = outcome else {
+            return XCTFail("watcher stream stalled: no 3rd .changed within the deadline")
         }
         XCTAssertTrue(sawActive)
         XCTAssertEqual(changes, 3)
@@ -65,21 +78,48 @@ final class MailboxWatcherTests: XCTestCase {
             clock: { _ in }
         )
         let stream = await watcher.start()
-        var sawReconnecting = false
-        var sawChanged = false
-        for await event in stream {
-            switch event {
-            case .reconnecting: sawReconnecting = true
-            case .changed:      sawChanged = true
-            case .active:       break
+        let outcome = await withDeadline {
+            var sawReconnecting = false
+            var sawChanged = false
+            for await event in stream {
+                switch event {
+                case .reconnecting: sawReconnecting = true
+                case .changed:      sawChanged = true
+                case .active:       break
+                }
+                if sawReconnecting && sawChanged {
+                    await watcher.stop()
+                    break
+                }
             }
-            if sawReconnecting && sawChanged {
-                await watcher.stop()
-                break
-            }
+            return (sawReconnecting: sawReconnecting, sawChanged: sawChanged)
+        }
+        guard let (sawReconnecting, sawChanged) = outcome else {
+            return XCTFail("watcher stream stalled: no .reconnecting + .changed within the deadline")
         }
         XCTAssertTrue(sawReconnecting)
         XCTAssertTrue(sawChanged)
+    }
+
+    /// Races `operation` against a wall-clock deadline; `nil` means it
+    /// stalled. Generous by test standards (these suites complete in
+    /// milliseconds) so slow CI simulators don't flake, while a genuine
+    /// stall still fails within one test's budget instead of hanging the
+    /// whole run.
+    private func withDeadline<T: Sendable>(
+        seconds: TimeInterval = 10,
+        _ operation: @escaping @Sendable () async -> T
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
     }
 }
 


### PR DESCRIPTION
Both `MailboxWatcherTests` tests consumed the watcher's event stream with an unbounded `for await`. If the expected interleaving never arrives, the test hangs forever with no output — which is exactly what happened on the visionOS 27.0 simulator (xcode-27 preview CI image, run 30715777188): 57 minutes of silence immediately after `ImapParserTests` (the suite alphabetically before this one), ended only by the job-level timeout cancelling the whole run. `MailboxWatcherTests` never even logged its suite-start line; the orphan reaper found `xcodebuild` still alive.

The fix races each stream consumption against a 10-second wall-clock deadline (`withTaskGroup`, cancel the loser). A stall now surfaces as a named, diagnosable test failure — `watcher stream stalled: …` — within one test's budget, on every platform. Healthy runs are unaffected: the suite completes in ~2ms.

Verified locally on the Xcode 27 beta toolchain (the environment class that hung): the suite passes in 0.002s, full CabalmailKit run 372 tests / 0 failures, `swiftlint --strict` clean.

Companion to the CI-side containment in #880 (in-step `gtimeout` so any future hang fails the step instead of cancelling the job). `no-changelog`: test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)