### PR TITLE
Hoist the shared folder ordering into FolderTree.sidebarOrder

### DIFF
--- a/apple/Cabalmail/ViewModels/FolderListViewModel.swift
+++ b/apple/Cabalmail/ViewModels/FolderListViewModel.swift
@@ -264,19 +264,10 @@ final class FolderListViewModel {
 
     /// Inbox first, then user folders arranged as a `/`-delimited tree
     /// (peers alphabetical, children directly under their parent), then
-    /// system folders grouped at the bottom.
+    /// system folders grouped at the bottom. `\Noselect` containers can't be
+    /// opened, so they're dropped from the user section.
     private func sortForSidebar(_ input: [Folder]) -> [Folder] {
-        let systemNames: Set<String> = ["Sent", "Drafts", "Trash", "Junk", "Archive"]
-        let inbox = input.filter { $0.path.caseInsensitiveCompare("INBOX") == .orderedSame }
-        let system = input
-            .filter { systemNames.contains($0.path) }
-            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
-        let userFolders = input.filter { folder in
-            !inbox.contains(folder)
-                && !system.contains(folder)
-                && !folder.attributes.contains("\\Noselect")
-        }
-        return inbox + FolderTree.sortUserTree(userFolders) + system
+        FolderTree.sidebarOrder(input, dropNoselectUserFolders: true)
     }
 
     /// Indentation depth - delegates to `FolderTree.depth(for:)`.

--- a/apple/Cabalmail/Views/MoveToFolderSheet.swift
+++ b/apple/Cabalmail/Views/MoveToFolderSheet.swift
@@ -143,25 +143,16 @@ struct MoveToFolderSheet: View {
     }
 
     /// Subscribed folders minus the source and any `\Noselect` containers,
-    /// sorted with INBOX pinned first, then user folders in tree order, then
-    /// the remaining system folders. Same shape as the sidebar so the
-    /// picker order doesn't surprise.
+    /// then the shared sidebar order so the picker doesn't surprise. The
+    /// `\Noselect` filter runs here rather than through
+    /// `dropNoselectUserFolders` because the sheet drops such containers
+    /// even when they carry a system name.
     private func sortForPicker(_ input: [Folder]) -> [Folder] {
         let candidates = input.filter { folder in
             folder.isSubscribed
                 && folder.path != currentFolder.path
                 && !folder.attributes.contains("\\Noselect")
         }
-        let systemNames: Set<String> = ["Sent", "Drafts", "Trash", "Junk", "Archive"]
-        let inbox = candidates.filter { folder in
-            folder.path.caseInsensitiveCompare("INBOX") == .orderedSame
-        }
-        let system = candidates
-            .filter { systemNames.contains($0.path) }
-            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
-        let userFolders = candidates.filter { folder in
-            !inbox.contains(folder) && !system.contains(folder)
-        }
-        return inbox + FolderTree.sortUserTree(userFolders) + system
+        return FolderTree.sidebarOrder(candidates)
     }
 }

--- a/apple/Cabalmail/Views/NotificationSettingsSection.swift
+++ b/apple/Cabalmail/Views/NotificationSettingsSection.swift
@@ -370,17 +370,7 @@ struct NotificationFolderPickerView: View {
     /// pinned first, user folders in tree order, system folders last — but
     /// nothing is filtered out: any folder can be a notification source.
     private func sortForPicker(_ input: [Folder]) -> [Folder] {
-        let systemNames: Set<String> = ["Sent", "Drafts", "Trash", "Junk", "Archive"]
-        let inbox = input.filter { folder in
-            folder.path.caseInsensitiveCompare("INBOX") == .orderedSame
-        }
-        let system = input
-            .filter { systemNames.contains($0.path) }
-            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
-        let userFolders = input.filter { folder in
-            !inbox.contains(folder) && !system.contains(folder)
-        }
-        return inbox + FolderTree.sortUserTree(userFolders) + system
+        FolderTree.sidebarOrder(input)
     }
 }
 #endif

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/FolderTree.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/FolderTree.swift
@@ -50,6 +50,34 @@ public enum FolderTree {
         return out
     }
 
+    /// The canonical folder order used by every list that shows folders -
+    /// the sidebar, the "Move to folder…" sheet and the notification-scope
+    /// picker: INBOX first, then user folders as a `/`-delimited tree via
+    /// `sortUserTree`, then the remaining system folders alphabetically.
+    /// Anything not in `input` is not fabricated, and nothing is dropped
+    /// except as `dropNoselectUserFolders` asks.
+    ///
+    /// - Parameter dropNoselectUserFolders: when true, `\Noselect` container
+    ///   folders are omitted from the user-folder section. INBOX and the
+    ///   system folders are unaffected either way - callers that need those
+    ///   filtered too (the move sheet) pre-filter `input` themselves.
+    public static func sidebarOrder(
+        _ input: [Folder],
+        dropNoselectUserFolders: Bool = false
+    ) -> [Folder] {
+        let systemNames = systemPaths.subtracting(["INBOX"])
+        let inbox = input.filter { $0.path.caseInsensitiveCompare("INBOX") == .orderedSame }
+        let system = input
+            .filter { systemNames.contains($0.path) }
+            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+        let userFolders = input.filter { folder in
+            !inbox.contains(folder)
+                && !system.contains(folder)
+                && !(dropNoselectUserFolders && folder.attributes.contains("\\Noselect"))
+        }
+        return inbox + sortUserTree(userFolders) + system
+    }
+
     /// Indentation depth for the "All folders" section - system folders
     /// (Inbox + Sent/Drafts/etc.) sit at depth 0 regardless of any `/` in
     /// the name; user folders indent one step per path segment past the

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/FolderTreeTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/FolderTreeTests.swift
@@ -33,6 +33,69 @@ final class FolderTreeTests: XCTestCase {
         XCTAssertEqual(ordered, ["Other", "Projects/Alpha"])
     }
 
+    // MARK: sidebarOrder
+
+    func testSidebarOrderPinsInboxFirstAndSystemFoldersLast() {
+        let input = folders([
+            "Trash",
+            "Projects/Zeta",
+            "INBOX",
+            "Archive",
+            "Newsletters",
+            "Projects",
+            "Sent",
+        ])
+        XCTAssertEqual(FolderTree.sidebarOrder(input).map(\.path), [
+            "INBOX",
+            "Newsletters",
+            "Projects",
+            "Projects/Zeta",
+            "Archive",
+            "Sent",
+            "Trash",
+        ])
+    }
+
+    func testSidebarOrderMatchesInboxCaseInsensitively() {
+        let input = folders(["Work", "inbox"])
+        XCTAssertEqual(FolderTree.sidebarOrder(input).map(\.path), ["inbox", "Work"])
+    }
+
+    func testSidebarOrderKeepsNoselectUserFoldersByDefault() {
+        let input = [
+            Folder(path: "INBOX"),
+            Folder(path: "Containers", attributes: ["\\Noselect"]),
+            Folder(path: "Containers/Real"),
+        ]
+        XCTAssertEqual(FolderTree.sidebarOrder(input).map(\.path), [
+            "INBOX",
+            "Containers",
+            "Containers/Real",
+        ])
+    }
+
+    func testSidebarOrderDropsNoselectUserFoldersWhenAsked() {
+        let input = [
+            Folder(path: "INBOX"),
+            Folder(path: "Containers", attributes: ["\\Noselect"]),
+            Folder(path: "Containers/Real"),
+        ]
+        let ordered = FolderTree.sidebarOrder(input, dropNoselectUserFolders: true)
+        XCTAssertEqual(ordered.map(\.path), ["INBOX", "Containers/Real"])
+    }
+
+    /// The drop flag is scoped to the user section: a `\Noselect` system
+    /// folder still shows. Callers that want those gone (the move sheet)
+    /// filter before calling.
+    func testSidebarOrderKeepsNoselectSystemFoldersEvenWhenDropping() {
+        let input = [
+            Folder(path: "INBOX", attributes: ["\\Noselect"]),
+            Folder(path: "Archive", attributes: ["\\Noselect"]),
+        ]
+        let ordered = FolderTree.sidebarOrder(input, dropNoselectUserFolders: true)
+        XCTAssertEqual(ordered.map(\.path), ["INBOX", "Archive"])
+    }
+
     // MARK: depth
 
     func testDepthIsZeroForSystemFoldersRegardlessOfSlashes() {


### PR DESCRIPTION
## What

Three places built the same folder list order by hand:

| Site | Copy |
|---|---|
| `Cabalmail/ViewModels/FolderListViewModel.swift` | `sortForSidebar` |
| `Cabalmail/Views/MoveToFolderSheet.swift` | `sortForPicker` |
| `Cabalmail/Views/NotificationSettingsSection.swift` | `sortForPicker` |

All three were the same shape — INBOX pinned first (case-insensitive match),
then user folders through `FolderTree.sortUserTree`, then the remaining system
folders alphabetically — plus a fourth literal of the `["Sent", "Drafts",
"Trash", "Junk", "Archive"]` set that `FolderTree.systemPaths` already holds.

This collapses them onto one `FolderTree.sidebarOrder(_:dropNoselectUserFolders:)`
in `CabalmailKit/Models/FolderTree.swift`, next to the `sortUserTree` /
`depth` / `hasChildren` helpers it already sits with.

Net: **+100 / -37**, and the ordering rule is now covered by `swift test`
instead of living in three view-layer copies that could drift apart.

## Why it's safe

**The three copies differed on exactly one axis**, and the helper takes it as a
parameter:

- The sidebar drops `\Noselect` containers from the *user* section
  (`dropNoselectUserFolders: true`); the two pickers don't (default `false`).
- `MoveToFolderSheet` keeps its own pre-filter (subscribed, not the source
  folder, not `\Noselect`) untouched, because it drops `\Noselect` folders even
  when they carry a system name — a stricter rule than the flag expresses. The
  comment now says so.
- `systemPaths.subtracting(["INBOX"])` is set-equal to the literal all three
  used.

**Differential proof.** A throwaway probe (`ZZDifferentialProbe`, deliberately
not committed) reimplemented all three pre-refactor functions verbatim from
`origin/stage` and asserted the new helper reproduces each of them over 4000
randomized folder sets — drawn from a 23-path pool covering `INBOX`/`inbox`
case variants, nested user trees, `Archive/2024` and `Trash/Old` (system name
as a tree root), non-ASCII and space-bearing names, with `\Noselect` and
`isSubscribed` randomized per folder. 12,000 comparisons, zero mismatches.
Five of those ordering cases are now pinned as permanent tests in
`FolderTreeTests`.

**No behavior surface touched**: no API contract, wire format, schema, IAM or
auth-flow change, and nothing user-visible — the rendered order is identical by
construction.

## Verified

- `swift test` (CabalmailKit): **377 passed**, 0 failures, 17 skipped —
  up from 372 on stage, the 5 new `sidebarOrder` cases. Needs
  `apple/scripts/sync-vendored.sh` first or `AcknowledgementsTests` +
  the RichText bridge tests fail on missing web assets.
- `xcodebuild test -scheme CabalmailMac -destination 'platform=macOS'`:
  **91 passed**, 0 failures. Run because a view model is touched.
- `xcodebuild -scheme Cabalmail -destination 'generic/platform=iOS' build`:
  **BUILD SUCCEEDED**.
- `swiftlint --strict` from `apple/`: **0 violations, 0 serious** in 258 files.
- No test assertion or expected value was changed; the diff to
  `FolderTreeTests.swift` is purely additive.

Local toolchain is Xcode 27.0 beta (27A5228h), so CI's stable toolchain is the
real gate.

## Not in scope, noted for later

`icon(for:)` is duplicated byte-for-byte between the two picker views, but the
sidebar's `FolderListView+Helpers.iconName(for:)` deliberately differs
(`Drafts` → `doc` vs `pencil.line`, `Junk` → `xmark.bin` vs
`exclamationmark.shield`). Unifying all three would change what the user sees,
so it stays out of a refactor PR.