### PR TITLE
Stop an all-mail search crashing when two results share a UID

### DIFF
--- a/apple/Cabalmail/ViewModels/MessageListScope.swift
+++ b/apple/Cabalmail/ViewModels/MessageListScope.swift
@@ -8,7 +8,7 @@ import CabalmailKit
 /// - `.search` is the global, cross-folder search surface. It has no anchor
 ///   folder, runs no folder lifecycle (no STATUS / pagination / IDLE / 60s
 ///   poll), and populates `envelopes` only via `runSearch`. Per-row source
-///   folders come from `sourceFolderByUID`, so dispose / flag / move / read
+///   folders come from `sourceFolderIndex`, so dispose / flag / move / read
 ///   still route to each result's true mailbox.
 ///
 /// The view model keeps a resolved `folder` anchor either way (a sentinel for

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Refresh.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Refresh.swift
@@ -120,7 +120,7 @@ extension MessageListViewModel {
         unseen = 0
         flagged = 0
         hasMore = true
-        sourceFolderByUID = [:]
+        sourceFolderIndex = SearchSourceFolderIndex()
         resetWindow()
         await refresh()
     }

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Search.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Search.swift
@@ -16,7 +16,7 @@ extension MessageListViewModel {
     /// Phase 5 of `docs/0.9.x/imap-search-plan.md` switched the wire
     /// path off the raw IMAP-SEARCH passthrough; the structured contract
     /// returns envelopes plus per-row source folders in a single round
-    /// trip. Cross-folder results populate `sourceFolderByUID` so
+    /// trip. Cross-folder results populate `sourceFolderIndex` so
     /// dispose / flag operations route per-row to the correct mailbox.
     func runSearch(resetFilterTab: Bool = true) async {
         // A text search is "All" mode -- its loaded results drive the pill
@@ -49,9 +49,7 @@ extension MessageListViewModel {
                 maxResults: searchResultCap
             )
             envelopes = result.envelopes.map(\.envelope)
-            sourceFolderByUID = Dictionary(uniqueKeysWithValues: result.envelopes.map {
-                ($0.envelope.uid, $0.folder)
-            })
+            sourceFolderIndex = SearchSourceFolderIndex(result.envelopes)
             searchTotalEstimate = result.totalEstimate
             searchTruncated = result.truncated
             searchFoldersSearched = result.foldersSearched
@@ -107,7 +105,7 @@ extension MessageListViewModel {
         // can't strand a highlighted pill over a plain folder view.
         filterTab = .all
         isSearchActive = false
-        sourceFolderByUID = [:]
+        sourceFolderIndex = SearchSourceFolderIndex()
         searchTotalEstimate = 0
         searchTruncated = false
         searchFoldersSearched = []
@@ -127,10 +125,10 @@ extension MessageListViewModel {
     /// Resolves the IMAP mailbox that owns `envelope`. In folder mode
     /// and in single-folder searches this is always `folder.path`; in
     /// cross-folder search mode the per-row entry from
-    /// `sourceFolderByUID` wins so dispose / flag operations target the
+    /// `sourceFolderIndex` wins so dispose / flag operations target the
     /// right mailbox.
     func sourceFolder(for envelope: Envelope) -> String {
-        sourceFolderByUID[envelope.uid] ?? folder.path
+        sourceFolderIndex.folder(for: envelope) ?? folder.path
     }
 
     /// Per-request chunk size for `runSearch`'s envelope fetch. The match set

--- a/apple/Cabalmail/ViewModels/MessageListViewModel+Sort.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel+Sort.swift
@@ -29,7 +29,7 @@ extension MessageListViewModel {
         dbg("setSort \(criterion.field)")
         sortCriterion = criterion
         envelopes.removeAll()
-        sourceFolderByUID = [:]
+        sourceFolderIndex = SearchSourceFolderIndex()
         resetWindow()
         await refresh()
         // Re-stage the bottom window in the new order (resetWindow dropped the

--- a/apple/Cabalmail/ViewModels/MessageListViewModel.swift
+++ b/apple/Cabalmail/ViewModels/MessageListViewModel.swift
@@ -123,11 +123,11 @@ final class MessageListViewModel {
     var searchTruncated: Bool = false
     var searchFoldersSearched: [String] = []
 
-    /// Per-uid source folder for cross-folder results. Empty in folder
+    /// Per-row source folder for cross-folder results. Empty in folder
     /// mode and single-folder searches; `sourceFolder(for:)` falls back
     /// to `folder.path` then. Internal (not private) so the search
     /// extension in `+Search.swift` can populate it.
-    var sourceFolderByUID: [UInt32: String] = [:]
+    var sourceFolderIndex = SearchSourceFolderIndex()
 
     private var uidValidity: UInt32?
     // Folder message count from the last STATUS. Pagination loads until the

--- a/apple/Cabalmail/ViewModels/SearchSourceFolderIndex.swift
+++ b/apple/Cabalmail/ViewModels/SearchSourceFolderIndex.swift
@@ -1,0 +1,58 @@
+import Foundation
+import CabalmailKit
+
+/// Resolves the mailbox that owns each row of a cross-folder search
+/// result. Pure value type so the lookup rules are testable without a
+/// view model; `MessageListViewModel` holds one and consults it from
+/// `sourceFolder(for:)`.
+///
+/// IMAP UIDs are unique only *within* a folder, so a result set spanning
+/// folders routinely carries the same UID twice (Archive UID 1 and
+/// `zeta0802` UID 1, say). A plain `[UID: folder]` map is therefore both
+/// lossy and, when built with `Dictionary(uniqueKeysWithValues:)`, fatal
+/// — the duplicate key traps and takes the app down. The index keys on
+/// UID *plus* Message-ID, which separates same-UID rows in different
+/// folders while still separating the other collision shape: one message
+/// filed in two folders, same Message-ID under two different UIDs.
+///
+/// A row whose envelope has no Message-ID falls back to the UID-only
+/// map, which keeps the first row seen for that UID — the same
+/// best-effort answer the old map gave, minus the trap.
+struct SearchSourceFolderIndex: Equatable {
+    /// Exact per-row key. `messageID` is nil for envelopes the server
+    /// returned without a Message-ID header.
+    private struct RowKey: Hashable {
+        let uid: UInt32
+        let messageID: String?
+    }
+
+    private var byRow: [RowKey: String] = [:]
+    private var byUID: [UInt32: String] = [:]
+
+    /// Empty index — folder mode and single-folder searches, where
+    /// `sourceFolder(for:)` falls back to the model's own folder.
+    init() {}
+
+    init(_ rows: [SearchedEnvelope]) {
+        // First-wins on both maps: duplicates are a genuine ambiguity
+        // (two rows the index can't tell apart), and keeping the first
+        // match in server order is the row the user sees highest.
+        byRow = Dictionary(
+            rows.map { (RowKey(uid: $0.envelope.uid, messageID: $0.envelope.messageId), $0.folder) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        byUID = Dictionary(
+            rows.map { ($0.envelope.uid, $0.folder) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+    var isEmpty: Bool { byRow.isEmpty }
+
+    /// The folder `envelope` came from, or nil when this index doesn't
+    /// know it (folder mode, or a row that was never part of the result
+    /// set).
+    func folder(for envelope: Envelope) -> String? {
+        byRow[RowKey(uid: envelope.uid, messageID: envelope.messageId)] ?? byUID[envelope.uid]
+    }
+}

--- a/apple/Cabalmail/Views/MessageListView.swift
+++ b/apple/Cabalmail/Views/MessageListView.swift
@@ -170,7 +170,7 @@ struct MessageListView: View {
     @ViewBuilder
     private func moveSheet(for envelope: Envelope) -> some View {
         if let client = appState.client {
-            // Cross-folder search rows live in `sourceFolderByUID`; the
+            // Cross-folder search rows live in `sourceFolderIndex`; the
             // sidebar's `folder` is the search scope, not the row's true
             // mailbox. Excluding the row's actual source folder from the
             // picker is what the user expects.

--- a/apple/CabalmailTests/SearchSourceFolderTests.swift
+++ b/apple/CabalmailTests/SearchSourceFolderTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Cross-folder search rows and the mailbox each one belongs to. IMAP UIDs
+// are unique only within a folder, so a result set spanning folders can
+// hand the client the same UID twice; the index has to survive that and
+// still route each row to its own mailbox.
+@MainActor
+final class SearchSourceFolderTests: XCTestCase {
+
+    // MARK: - The index
+
+    func testDuplicateUIDsAcrossFoldersResolveSeparately() {
+        let index = SearchSourceFolderIndex([
+            SearchedEnvelope(
+                envelope: TestFixtures.makeEnvelope(uid: 1, messageId: "<archive@example.com>"),
+                folder: "Archive"
+            ),
+            SearchedEnvelope(
+                envelope: TestFixtures.makeEnvelope(uid: 1, messageId: "<zeta@example.com>"),
+                folder: "zeta0802"
+            ),
+        ])
+        XCTAssertEqual(
+            index.folder(for: TestFixtures.makeEnvelope(uid: 1, messageId: "<archive@example.com>")),
+            "Archive"
+        )
+        XCTAssertEqual(
+            index.folder(for: TestFixtures.makeEnvelope(uid: 1, messageId: "<zeta@example.com>")),
+            "zeta0802",
+            "the second row keeps its own mailbox rather than inheriting the first row's"
+        )
+    }
+
+    func testSameMessageFiledInTwoFoldersResolvesByUID() {
+        // The other collision shape: one Message-ID, two folders, two UIDs.
+        let index = SearchSourceFolderIndex([
+            SearchedEnvelope(
+                envelope: TestFixtures.makeEnvelope(uid: 7, messageId: "<copy@example.com>"),
+                folder: "Archive"
+            ),
+            SearchedEnvelope(
+                envelope: TestFixtures.makeEnvelope(uid: 12, messageId: "<copy@example.com>"),
+                folder: "INBOX"
+            ),
+        ])
+        XCTAssertEqual(
+            index.folder(for: TestFixtures.makeEnvelope(uid: 7, messageId: "<copy@example.com>")),
+            "Archive"
+        )
+        XCTAssertEqual(
+            index.folder(for: TestFixtures.makeEnvelope(uid: 12, messageId: "<copy@example.com>")),
+            "INBOX"
+        )
+    }
+
+    func testMissingMessageIDFallsBackToTheUIDMap() {
+        let index = SearchSourceFolderIndex([
+            SearchedEnvelope(envelope: TestFixtures.makeEnvelope(uid: 3), folder: "Archive"),
+            SearchedEnvelope(envelope: TestFixtures.makeEnvelope(uid: 3), folder: "zeta0802"),
+        ])
+        // Nothing tells these two apart, so first-in-server-order wins --
+        // best effort, but not a trap.
+        XCTAssertEqual(index.folder(for: TestFixtures.makeEnvelope(uid: 3)), "Archive")
+        // A row whose Message-ID isn't in the index still resolves by UID.
+        XCTAssertEqual(
+            index.folder(for: TestFixtures.makeEnvelope(uid: 3, messageId: "<late@example.com>")),
+            "Archive"
+        )
+    }
+
+    func testUnknownRowAndEmptyIndexResolveToNil() {
+        XCTAssertTrue(SearchSourceFolderIndex().isEmpty)
+        XCTAssertNil(SearchSourceFolderIndex().folder(for: TestFixtures.makeEnvelope(uid: 1)))
+        let index = SearchSourceFolderIndex([
+            SearchedEnvelope(envelope: TestFixtures.makeEnvelope(uid: 1), folder: "Archive"),
+        ])
+        XCTAssertNil(index.folder(for: TestFixtures.makeEnvelope(uid: 99)))
+    }
+
+    // MARK: - Through the view model
+
+    func testSearchWithCollidingUIDsRoutesEachRowToItsFolder() async throws {
+        let imap = FakeImapClient()
+        let archived = TestFixtures.makeEnvelope(
+            uid: 1, messageId: "<archive@example.com>", subject: "Fixer 843 draft probe"
+        )
+        let zeta = TestFixtures.makeEnvelope(
+            uid: 1, messageId: "<zeta@example.com>", subject: "smtp cutover probe 0726"
+        )
+        await imap.scriptSearch(SearchResult(
+            envelopes: [
+                SearchedEnvelope(envelope: archived, folder: "Archive"),
+                SearchedEnvelope(envelope: zeta, folder: "zeta0802"),
+            ],
+            totalEstimate: 2,
+            nextCursor: nil,
+            foldersSearched: ["Archive", "zeta0802"],
+            truncated: false
+        ))
+        let model = try TestFixtures.makeModel(imap: imap, envelopes: [])
+        model.searchQuery = "probe"
+
+        // Before the fix this trapped in Dictionary(uniqueKeysWithValues:)
+        // -- "Fatal error: Duplicate values for key: '1'" -- taking the
+        // whole app down the instant the results came back.
+        await model.runSearch()
+
+        XCTAssertNil(model.errorMessage)
+        XCTAssertTrue(model.isSearchActive)
+        XCTAssertEqual(model.envelopes.count, 2, "both matches render")
+        XCTAssertEqual(model.sourceFolder(for: archived), "Archive")
+        XCTAssertEqual(model.sourceFolder(for: zeta), "zeta0802")
+    }
+
+    func testClearingASearchDropsTheIndex() async throws {
+        let imap = FakeImapClient()
+        let hit = TestFixtures.makeEnvelope(uid: 1, messageId: "<archive@example.com>")
+        await imap.scriptSearch(SearchResult(
+            envelopes: [SearchedEnvelope(envelope: hit, folder: "Archive")],
+            totalEstimate: 1,
+            nextCursor: nil,
+            foldersSearched: ["Archive"],
+            truncated: false
+        ))
+        let model = try TestFixtures.makeModel(imap: imap, envelopes: [])
+        model.searchQuery = "probe"
+        await model.runSearch()
+        XCTAssertEqual(model.sourceFolder(for: hit), "Archive")
+
+        // `clearSearch` runs a folder refresh the fake traps on; the state
+        // reset it does first is what this asserts.
+        await model.clearSearch()
+        XCTAssertTrue(model.sourceFolderIndex.isEmpty)
+        XCTAssertEqual(model.sourceFolder(for: hit), "INBOX", "folder mode owns every row again")
+    }
+}

--- a/apple/CabalmailTests/TestSupport.swift
+++ b/apple/CabalmailTests/TestSupport.swift
@@ -63,6 +63,19 @@ actor FakeImapClient: ImapClient {
         topEnvelopesResult = topEnvelopes
     }
 
+    // Structured-search script (one page; `searchEnvelopesChunked`'s
+    // default implementation stops when `nextCursor` is nil).
+    private var searchResult: SearchResult?
+
+    func scriptSearch(_ result: SearchResult) {
+        searchResult = result
+    }
+
+    func searchEnvelopes(_ query: SearchQuery) async throws -> SearchResult {
+        guard let searchResult else { return try trap() }
+        return searchResult
+    }
+
     func setFlags(
         folder: String,
         uids: [UInt32],
@@ -250,10 +263,16 @@ enum TestFixtures {
         )
     }
 
-    static func makeEnvelope(uid: UInt32, flags: Set<Flag> = []) -> Envelope {
+    static func makeEnvelope(
+        uid: UInt32,
+        flags: Set<Flag> = [],
+        messageId: String? = nil,
+        subject: String? = nil
+    ) -> Envelope {
         Envelope(
             uid: uid,
-            subject: "Subject \(uid)",
+            messageId: messageId,
+            subject: subject ?? "Subject \(uid)",
             from: [EmailAddress(name: "Sender", mailbox: "sender\(uid)", host: "example.com")],
             flags: flags
         )

--- a/changelog.d/search-uid-collision-crash.fixed.md
+++ b/changelog.d/search-uid-collision-crash.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **All-mail search crash when two results share a UID.** IMAP UIDs are
+  unique only within a folder, so a cross-folder search routinely returns the same
+  UID from two mailboxes; building the per-row source-folder map assumed otherwise
+  and trapped, killing the app the instant results arrived. Each row now resolves
+  to its own mailbox, so dispose, flag, move and open all target the right folder.


### PR DESCRIPTION
Addresses #885.

## What was wrong

An all-mail (cross-folder) search terminated the app the instant results
arrived, whenever two matching messages in different folders happened to
share an IMAP UID:

```
Swift/NativeDictionary.swift:792: Fatal error: Duplicate values for key: '1'
```

UIDs are unique only *within* a folder, so this is ordinary mailbox
state, not a corner case — the tester hit it with `Archive` UID 1 and
`zeta0802` UID 1 both matching `probe`, on both iPhone and iPad.

## Root cause

`MessageListViewModel+Search.runSearch()` built its per-row source-folder
map with `Dictionary(uniqueKeysWithValues:)` keyed on `envelope.uid`
alone. That initializer traps on a duplicate key. The report's diagnosis
was correct, and it named the right site — the sibling uses of the same
initializer (`+Refresh.swift:167`, `+Bulk.swift:156`) are folder-scoped,
so this was the only cross-folder one.

The crash is the loud half of the defect. The quiet half is that
`[UID: folder]` is the wrong shape for a cross-folder result set at all:
with the trap simply removed, one of the two colliding rows would still
resolve to the *other* row's mailbox, so tapping it would open the wrong
message and disposing it would move the wrong one. Same root cause — the
map assumed a UID identifies a row — so both are fixed here.

## The fix

New `SearchSourceFolderIndex` (`apple/Cabalmail/ViewModels/`), a pure
value type the view model consults from `sourceFolder(for:)`. It keys on
UID **plus Message-ID**, which separates the two collision shapes that
actually occur:

| shape | example | resolves via |
|---|---|---|
| same UID, different messages, different folders | `Archive` UID 1 + `zeta0802` UID 1 | Message-ID distinguishes them |
| same message filed in two folders | one Message-ID, UIDs 7 and 12 | UID distinguishes them |
| no Message-ID on the envelope | pre-feature / malformed mail | first-wins UID map — best effort, no trap |

Preferring Message-ID *unconditionally* would have regressed the second
row of the table, which is why the index keeps both maps rather than
swapping one key for the other.

Lifting the rule into its own type also gives it a unit-test seam;
`sourceFolderByUID` is renamed to `sourceFolderIndex` at its three reset
sites and its callers go through the same `sourceFolder(for:)` as before.

## Test evidence

New `apple/CabalmailTests/SearchSourceFolderTests.swift` — four index
cases plus two through `MessageListViewModel.runSearch()` against a
scripted `FakeImapClient` (which grows a `searchEnvelopes` script and an
optional `messageId` on the envelope fixture).

**Fails before**: with the index shimmed back to the old
`Dictionary(uniqueKeysWithValues:)`-on-UID behaviour, the test process
dies with the exact production signature —

```
Swift/NativeDictionary.swift:792: Fatal error: Duplicate values for key: '1'
```

**Passes after**: full app-layer suite, 97 tests, 0 failures
(`xcodebuild test -scheme CabalmailMac`). `swiftlint --strict` from
`apple/` is clean.

Not re-run on the simulator: the repro needs a live mailbox arranged into
a UID collision, which is the tester's setup; the unit test reproduces the
same trap deterministically.

## Not fixed here (offered)

The selection layer below this is still UID-keyed —
`selectedUIDs: Set<UInt32>`, `.tag(envelope.uid)`, `Envelope.id == uid`.
Two search rows sharing a UID therefore still highlight together, and
SwiftUI sees duplicate `ForEach` ids for them. That's a wider change
(row identity across list, selection, drag and dispose) and no longer
crashes anything, so I've left it. Happy to take it as its own issue if
you want it.