### PR TITLE
Draw the sidebar's Subscribed section as the tree it is

### DIFF
--- a/apple/Cabalmail/ViewModels/FolderListViewModel.swift
+++ b/apple/Cabalmail/ViewModels/FolderListViewModel.swift
@@ -270,14 +270,7 @@ final class FolderListViewModel {
         FolderTree.sidebarOrder(input, dropNoselectUserFolders: true)
     }
 
-    /// Indentation depth - delegates to `FolderTree.depth(for:)`.
-    func depth(for folder: Folder) -> Int {
-        FolderTree.depth(for: folder)
-    }
-
-    /// True iff this folder has at least one descendant in the current list -
-    /// drives the per-folder collapse chevron in "All folders".
-    func hasChildren(_ folder: Folder) -> Bool {
-        FolderTree.hasChildren(folder, in: folders)
-    }
+    // Per-row indentation and the collapse chevron are section-scoped
+    // (Subscribed and All folders draw different lists), so they're
+    // computed in `FolderSectionRows` rather than here.
 }

--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -89,41 +89,38 @@ struct FolderListView: View {
                     Label(errorMessage, systemImage: "exclamationmark.triangle")
                         .foregroundStyle(.red)
                 }
-                let subscribed = filteredFolders(model.subscribedFolders)
-                let all = filteredFolders(model.folders)
-                let (visibleAll, _) = FolderTree.visibleFolders(
-                    from: all,
+                // Each section is a tree over its own folder list — Subscribed
+                // is a subset of All folders, and the filter narrows both — so
+                // both go through `FolderSectionRows`, which computes depth,
+                // chevron and collapse against the list it's handed.
+                let subscribedRows = FolderSectionRows.rows(
+                    for: filteredFolders(model.subscribedFolders),
+                    collapsed: collapsedSet,
+                    activeSelection: selection?.path
+                )
+                let allRows = FolderSectionRows.rows(
+                    for: filteredFolders(model.folders),
                     collapsed: collapsedSet,
                     activeSelection: selection?.path
                 )
                 if !model.subscribedFolders.isEmpty {
                     DisclosureGroup(isExpanded: $subscribedExpanded) {
-                        ForEach(subscribed, id: \.path) { folder in
-                            folderRow(folder, model: model, depth: 0, collapsed: collapsedSet)
+                        ForEach(subscribedRows) { row in
+                            folderRow(row, model: model, collapsed: collapsedSet)
                         }
                     } label: {
                         Text("Subscribed")
                     }
                     DisclosureGroup(isExpanded: $allExpanded) {
-                        ForEach(visibleAll, id: \.path) { folder in
-                            folderRow(
-                                folder,
-                                model: model,
-                                depth: model.depth(for: folder),
-                                collapsed: collapsedSet
-                            )
+                        ForEach(allRows) { row in
+                            folderRow(row, model: model, collapsed: collapsedSet)
                         }
                     } label: {
                         Text("All folders")
                     }
                 } else {
-                    ForEach(visibleAll, id: \.path) { folder in
-                        folderRow(
-                            folder,
-                            model: model,
-                            depth: model.depth(for: folder),
-                            collapsed: collapsedSet
-                        )
+                    ForEach(allRows) { row in
+                        folderRow(row, model: model, collapsed: collapsedSet)
                     }
                 }
             }
@@ -222,11 +219,11 @@ struct FolderListView: View {
 
     @ViewBuilder
     private func folderRow(
-        _ folder: Folder,
+        _ sectionRow: FolderSectionRow,
         model: FolderListViewModel,
-        depth: Int,
         collapsed: Set<String>
     ) -> some View {
+        let folder = sectionRow.folder
         // `\Noselect` containers can't hold messages, so they're not drop
         // targets (mirrors MoveToFolderSheet's filter). Selectable folders
         // get an `.onDrop` + an accent border while a drag hovers them.
@@ -238,8 +235,8 @@ struct FolderListView: View {
                 unread: appState.folderUnreadCounts[folder.path],
                 total: appState.folderTotalCounts[folder.path]
             ),
-            depth: depth,
-            hasChildren: model.hasChildren(folder),
+            depth: sectionRow.depth,
+            hasChildren: sectionRow.hasChildren,
             isCollapsed: collapsed.contains(folder.path)
         )
             .tag(folder)

--- a/apple/Cabalmail/Views/FolderSectionRows.swift
+++ b/apple/Cabalmail/Views/FolderSectionRows.swift
@@ -1,0 +1,45 @@
+import Foundation
+import CabalmailKit
+
+/// One drawable row of a sidebar folder section: the folder plus the two
+/// things that depend on which section is drawing it.
+struct FolderSectionRow: Identifiable, Equatable {
+    let folder: Folder
+    /// Indentation steps — one per ancestor this section shows.
+    let depth: Int
+    /// Whether this section has rows the folder's chevron can hide.
+    let hasChildren: Bool
+
+    var id: String { folder.path }
+}
+
+/// Turns a section's folder list into its rows. Pure, so the sidebar's
+/// tree rules are testable without standing up a `List`.
+///
+/// The sidebar draws the same folders through two sections over two
+/// different lists — Subscribed is a subset of All folders, and the
+/// filter field narrows both — so depth, the chevron, and the
+/// collapse all have to be computed against the section's own list.
+/// Reading any of them off the full folder set is what let Subscribed
+/// draw a nested folder flat and hand it a chevron whose collapse only
+/// took effect in the section below it.
+enum FolderSectionRows {
+    static func rows(
+        for folders: [Folder],
+        collapsed: Set<String>,
+        activeSelection: String?
+    ) -> [FolderSectionRow] {
+        let (visible, _) = FolderTree.visibleFolders(
+            from: folders,
+            collapsed: collapsed,
+            activeSelection: activeSelection
+        )
+        return visible.map { folder in
+            FolderSectionRow(
+                folder: folder,
+                depth: FolderTree.depth(for: folder, in: folders),
+                hasChildren: FolderTree.hasChildren(folder, in: folders)
+            )
+        }
+    }
+}

--- a/apple/CabalmailKit/Sources/CabalmailKit/Models/FolderTree.swift
+++ b/apple/CabalmailKit/Sources/CabalmailKit/Models/FolderTree.swift
@@ -87,6 +87,20 @@ public enum FolderTree {
         return max(0, folder.path.split(separator: "/").count - 1)
     }
 
+    /// Indentation depth *within `list`* — one step per ancestor that
+    /// list actually contains. The sidebar draws two sections over two
+    /// different lists (Subscribed is a subset of All folders, and the
+    /// filter field narrows both), so depth has to be relative to the
+    /// rows on screen: indenting a folder under a parent the section
+    /// isn't showing would read as a child of whatever row happens to
+    /// sit above it. Where every ancestor is present this agrees with
+    /// `depth(for:)`.
+    public static func depth(for folder: Folder, in list: [Folder]) -> Int {
+        if systemPaths.contains(folder.path) { return 0 }
+        let present = Set(list.map(\.path))
+        return ancestors(of: folder.path).filter(present.contains).count
+    }
+
     /// True iff any other folder in `input` lives under `folder` in the tree.
     /// System folders never have collapsible children regardless of name.
     public static func hasChildren(_ folder: Folder, in input: [Folder]) -> Bool {

--- a/apple/CabalmailKit/Tests/CabalmailKitTests/FolderTreeTests.swift
+++ b/apple/CabalmailKit/Tests/CabalmailKitTests/FolderTreeTests.swift
@@ -110,6 +110,17 @@ final class FolderTreeTests: XCTestCase {
         XCTAssertEqual(FolderTree.depth(for: Folder(path: "Work/Q1/Archive")), 2)
     }
 
+    func testDepthInAListCountsOnlyThePresentAncestors() {
+        let full = folders(["Work", "Work/Q1", "Work/Q1/Archive"])
+        XCTAssertEqual(FolderTree.depth(for: Folder(path: "Work/Q1/Archive"), in: full), 2)
+        // A list that omits an ancestor -- the subscribed subset, or a
+        // filtered list -- must not indent under a row it isn't drawing.
+        let sparse = folders(["Work", "Work/Q1/Archive"])
+        XCTAssertEqual(FolderTree.depth(for: Folder(path: "Work/Q1/Archive"), in: sparse), 1)
+        XCTAssertEqual(FolderTree.depth(for: Folder(path: "Work/Q1/Archive"), in: []), 0)
+        XCTAssertEqual(FolderTree.depth(for: Folder(path: "INBOX"), in: full), 0)
+    }
+
     // MARK: hasChildren
 
     func testHasChildrenIsTrueOnlyForParentsOfPresentFolders() {

--- a/apple/CabalmailTests/FolderSectionRowsTests.swift
+++ b/apple/CabalmailTests/FolderSectionRowsTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// The sidebar draws its folders through two sections over two different
+// lists (Subscribed is a subset of All folders; the filter narrows both),
+// so every row's depth, chevron and collapse has to come from the list its
+// own section is drawing.
+final class FolderSectionRowsTests: XCTestCase {
+
+    private func folder(_ path: String, subscribed: Bool = true) -> Folder {
+        Folder(path: path, attributes: [], isSubscribed: subscribed)
+    }
+
+    /// The mailbox from the report: INBOX, a parent with one child, an
+    /// unrelated sibling, and Archive — all subscribed.
+    private var nested: [Folder] {
+        [folder("INBOX"), folder("alpha0802"), folder("alpha0802/kid"), folder("zeta0802"), folder("Archive")]
+    }
+
+    func testNestedFolderIndentsUnderItsParent() {
+        let rows = FolderSectionRows.rows(for: nested, collapsed: [], activeSelection: nil)
+        let depths = Dictionary(uniqueKeysWithValues: rows.map { ($0.folder.path, $0.depth) })
+        XCTAssertEqual(depths["alpha0802"], 0)
+        XCTAssertEqual(depths["alpha0802/kid"], 1, "a child is one step in from its parent")
+        XCTAssertEqual(depths["zeta0802"], 0, "an unrelated top-level folder stays flush")
+        XCTAssertEqual(depths["INBOX"], 0)
+        XCTAssertEqual(depths["Archive"], 0, "system folders never indent")
+    }
+
+    func testCollapsingAParentHidesItsChildInTheSameSection() {
+        let rows = FolderSectionRows.rows(
+            for: nested,
+            collapsed: ["alpha0802"],
+            activeSelection: nil
+        )
+        XCTAssertEqual(
+            rows.map(\.folder.path),
+            ["INBOX", "alpha0802", "zeta0802", "Archive"],
+            "the collapsed parent's child drops out of this section, not just some other one"
+        )
+    }
+
+    func testOnlyAParentWithChildrenInThisSectionGetsAChevron() {
+        let rows = FolderSectionRows.rows(for: nested, collapsed: [], activeSelection: nil)
+        let chevrons = Dictionary(uniqueKeysWithValues: rows.map { ($0.folder.path, $0.hasChildren) })
+        XCTAssertEqual(chevrons["alpha0802"], true)
+        XCTAssertEqual(chevrons["zeta0802"], false)
+        XCTAssertEqual(chevrons["alpha0802/kid"], false)
+    }
+
+    // MARK: - Subscribed as a subset of All folders
+
+    func testSubscribedChildOfAnUnsubscribedParentStaysFlatAndVisible() {
+        // Only the child is subscribed. The Subscribed section can't show
+        // the parent, so it must neither indent the child under a row that
+        // isn't there nor hide it behind a chevron it never draws.
+        let subscribedOnly = [folder("INBOX"), folder("alpha0802/kid")]
+        let rows = FolderSectionRows.rows(
+            for: subscribedOnly,
+            collapsed: ["alpha0802"],
+            activeSelection: nil
+        )
+        XCTAssertEqual(rows.map(\.folder.path), ["INBOX", "alpha0802/kid"])
+        XCTAssertEqual(rows.last?.depth, 0)
+    }
+
+    func testTheTwoSectionsAgreeOnAFolderTheyBothShow() {
+        let all = nested + [folder("Sent"), folder("Trash", subscribed: false)]
+        let subscribed = all.filter(\.isSubscribed)
+        let allRows = FolderSectionRows.rows(for: all, collapsed: [], activeSelection: nil)
+        let subRows = FolderSectionRows.rows(for: subscribed, collapsed: [], activeSelection: nil)
+        for path in ["INBOX", "alpha0802", "alpha0802/kid", "zeta0802", "Archive"] {
+            XCTAssertEqual(
+                subRows.first { $0.folder.path == path }?.depth,
+                allRows.first { $0.folder.path == path }?.depth,
+                "\(path) draws at the same depth in both sections"
+            )
+        }
+        XCTAssertNil(subRows.first { $0.folder.path == "Trash" }, "unsubscribed folders stay out")
+    }
+
+    func testActiveSelectionOverridesAStaleCollapse() {
+        let rows = FolderSectionRows.rows(
+            for: nested,
+            collapsed: ["alpha0802"],
+            activeSelection: "alpha0802/kid"
+        )
+        XCTAssertTrue(
+            rows.contains { $0.folder.path == "alpha0802/kid" },
+            "the open folder never disappears behind a collapsed ancestor"
+        )
+    }
+}

--- a/changelog.d/subscribed-folder-tree.fixed.md
+++ b/changelog.d/subscribed-folder-tree.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Nesting and collapse in the sidebar's Subscribed section.** Subscribed
+  drew every folder flush left and ignored its own disclosure chevron, so a nested
+  subscribed folder was indistinguishable from a top-level one and its collapse
+  only took effect down in All folders. Each section now takes its indentation,
+  chevron and collapse from the folders it is actually showing.


### PR DESCRIPTION
Addresses #884.

## What was wrong

In the sidebar's **Subscribed** section every folder drew at depth 0, and
the section ignored the collapse state its own chevrons set — while **All
folders**, right below it, drew the same folders correctly. Reported on
iPadOS, reproduced by the OS 27 tester on iPhone too (comment on the
issue), so it is not iPad chrome.

Both halves are the same defect: the section wasn't treating its rows as a
tree.

## Root cause

`FolderListView.folderList` fed the two sections differently:

```swift
ForEach(subscribed, id: \.path) { folder in
    folderRow(folder, model: model, depth: 0, collapsed: collapsedSet)   // <- literal 0, raw list
}
ForEach(visibleAll, id: \.path) { folder in
    folderRow(folder, model: model, depth: model.depth(for: folder), collapsed: collapsedSet)
}
```

Subscribed iterated the unfiltered subscribed list with a literal `depth: 0`
and never went through `FolderTree.visibleFolders`, so neither indentation
nor collapse could reach it. The chevron itself is real (`hasChildren` came
off the full folder list), which is why tapping it flipped the label in both
sections but only hid a row in the other one. The report's diagnosis was
correct and named the exact lines.

Pre-existing, as the report says — not from #882's ordering refactor.

## The fix

New `FolderSectionRows` (`apple/Cabalmail/Views/`), a pure type that turns
one section's folder list into its rows — visibility, depth and chevron all
computed against **that list**. Both sections go through it, so they agree
by construction rather than by two call sites staying in sync.

Depth is section-relative via a new `FolderTree.depth(for:in:)` (one step
per ancestor the list actually contains) rather than the path-segment count.
That matters because Subscribed is a *subset*: a subscribed child of an
unsubscribed parent must not indent under a row the section isn't drawing,
and `visibleFolders` already declines to hide it (it only honours a
collapsed ancestor that is `present` in the same list). `hasChildren` is
scoped the same way, so Subscribed no longer offers a chevron over rows its
collapse can't affect — the other half of "a visible control does nothing
where it sits."

`FolderTree.depth(for:)` is unchanged and still serves the move sheet and
the notification-scope picker.

## Test evidence

- `apple/CabalmailTests/FolderSectionRowsTests.swift` — 6 cases: nesting,
  collapse-hides-in-this-section, chevron scope, the subscribed-subset
  orphan, the two sections agreeing, and the active-selection auto-expand.
  **Fails before**: with `FolderSectionRows` shimmed back to the old
  Subscribed behaviour (depth 0, no `visibleFolders`), exactly the two
  reported symptoms fail —
  `depth: Optional(0) is not equal to Optional(1)` and
  `["INBOX", "alpha0802", "alpha0802/kid", "zeta0802", "Archive"]` where the
  child should have dropped out.
- `apple/CabalmailKit/Tests/.../FolderTreeTests.swift` — `depth(for:in:)`
  including the sparse-list case.
- Suites: `swift test` 378 tests, `xcodebuild test -scheme CabalmailMac` 97
  tests, both 0 failures. `swiftlint --strict` clean.
- iPhone 17 sim against stage: sidebar renders correctly, sections in step,
  no layout regression. I could **not** re-run the nested repro live — the
  tester had already restored the mailbox to a flat layout, and the New
  Folder sheet's parent picker wouldn't drive from `idb` (the name field
  cleared on the picker tap; filed separately as needs-verification since I
  can't tell a driver artifact from a real defect). Simulator state restored:
  the scratch folder is deleted and the tester's build is reinstalled and
  signed in.