### PR TITLE
Keep the new-folder form when the parent picker closes

### DIFF
--- a/apple/Cabalmail/Views/FolderListView+Helpers.swift
+++ b/apple/Cabalmail/Views/FolderListView+Helpers.swift
@@ -19,7 +19,7 @@ extension FolderListView {
     /// main `FolderListView` body stays under the type-body-length cap.
     func wideSidebarHeader(filter: Binding<String>) -> some View {
         SidebarListHeaderRow(
-            newAction: { showNewFolderSheet = true },
+            newAction: { presentNewFolderSheet() },
             newDisabled: model == nil,
             newAccessibilityLabel: "New folder",
             newIdentifier: "folder.new",
@@ -31,6 +31,14 @@ extension FolderListView {
             refreshIdentifier: "folder.refresh",
             refreshAction: { Task { await manualRefresh() } }
         )
+    }
+
+    /// Raises the "New folder" sheet from an empty form. The form outlives
+    /// the sheet (see `newFolderForm`), so it is cleared on the way in rather
+    /// than by the sheet's own state going away.
+    func presentNewFolderSheet() {
+        newFolderForm.reset()
+        showNewFolderSheet = true
     }
 
     func filteredFolders(_ folders: [Folder]) -> [Folder] {
@@ -228,7 +236,7 @@ extension FolderListView {
     @ViewBuilder
     var newFolderSheet: some View {
         if let model {
-            NewFolderSheet(parents: model.possibleParents) { name, parent in
+            NewFolderSheet(parents: model.possibleParents, form: newFolderForm) { name, parent in
                 await model.createFolder(name: name, parent: parent)
             }
         }

--- a/apple/Cabalmail/Views/FolderListView.swift
+++ b/apple/Cabalmail/Views/FolderListView.swift
@@ -60,6 +60,10 @@ struct FolderListView: View {
     // Drives the "New folder" sheet from the `+` button. Non-private so the
     // `+Helpers` extension's `wideSidebarHeader` can raise it too.
     @State var showNewFolderSheet = false
+    // The new-folder sheet's input. Owned here rather than by the sheet
+    // because SwiftUI re-creates the sheet's body when the parent picker's
+    // menu dismisses, which resets any state the sheet holds itself (#889).
+    @State var newFolderForm = NewFolderForm()
     // Folder staged for deletion by a row's swipe / context menu, presented
     // as a confirmation dialog. Non-private so the delete-dialog plumbing in
     // `FolderListView+Helpers.swift` can reach it (same discipline as
@@ -139,7 +143,7 @@ struct FolderListView: View {
             if externalFilter == nil {
                 ToolbarItem {
                     Button {
-                        showNewFolderSheet = true
+                        presentNewFolderSheet()
                     } label: {
                         Image(systemName: "plus")
                             .accessibilityLabel("New folder")

--- a/apple/Cabalmail/Views/NewFolderForm.swift
+++ b/apple/Cabalmail/Views/NewFolderForm.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// The user's in-progress input for `NewFolderSheet`, owned by the view that
+/// presents the sheet rather than by the sheet itself.
+///
+/// The sheet used to hold `name` and `parent` in its own `@State`. On compact
+/// iPhone that state is lost whenever SwiftUI re-creates the sheet's body —
+/// which is exactly what dismissing the parent `Picker`'s menu does, wiping
+/// the typed name and dropping the selection on the floor (#889). The
+/// presenting view outlives that churn, so keeping the input here is what
+/// makes it stick; the sheet reads and writes it through `@Bindable`.
+@Observable
+final class NewFolderForm {
+    /// Folder name as typed. Not trimmed — `canCreate` and `submissionName`
+    /// decide what counts as usable.
+    var name: String = ""
+
+    /// Selected parent path, or `""` for the picker's "None (top level)" row.
+    var parent: String = ""
+
+    /// The parent to create under: nil when the user left it at top level.
+    var chosenParent: String? {
+        parent.isEmpty ? nil : parent
+    }
+
+    /// Whitespace-only input is not a folder name.
+    var canCreate: Bool {
+        !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    /// Cleared before each presentation so a new sheet starts empty rather
+    /// than showing whatever the last one was carrying.
+    func reset() {
+        name = ""
+        parent = ""
+    }
+}

--- a/apple/Cabalmail/Views/NewFolderSheet.swift
+++ b/apple/Cabalmail/Views/NewFolderSheet.swift
@@ -4,27 +4,30 @@ import CabalmailKit
 /// Sheet for creating a new folder. Captures a name and an optional parent
 /// (picker seeded from the current folder list). Presented from the folder
 /// sidebar's "New folder" toolbar button.
+///
+/// The typed name and the chosen parent live in `NewFolderForm`, owned by the
+/// presenting view — sheet-local `@State` doesn't survive the body being
+/// re-created when the parent picker's menu dismisses (#889).
 struct NewFolderSheet: View {
     let parents: [Folder]
+    @Bindable var form: NewFolderForm
     let onCreate: (String, String?) async -> Bool
 
     @Environment(\.dismiss) private var dismiss
-    @State private var name: String = ""
-    @State private var parent: String = ""
     @State private var isSubmitting = false
 
     var body: some View {
         NavigationStack {
             Form {
                 Section("Name") {
-                    TextField("e.g. Projects", text: $name)
+                    TextField("e.g. Projects", text: $form.name)
                         .autocorrectionDisabled()
                         #if os(iOS) || os(visionOS)
                         .textInputAutocapitalization(.never)
                         #endif
                 }
                 Section("Parent") {
-                    Picker("Parent folder", selection: $parent) {
+                    Picker("Parent folder", selection: $form.parent) {
                         Text("None (top level)").tag("")
                         ForEach(parents) { folder in
                             Text(folder.path).tag(folder.path)
@@ -50,7 +53,7 @@ struct NewFolderSheet: View {
                             Text("Create")
                         }
                     }
-                    .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty || isSubmitting)
+                    .disabled(!form.canCreate || isSubmitting)
                 }
             }
         }
@@ -59,8 +62,7 @@ struct NewFolderSheet: View {
     private func submit() async {
         isSubmitting = true
         defer { isSubmitting = false }
-        let chosenParent = parent.isEmpty ? nil : parent
-        let succeeded = await onCreate(name, chosenParent)
+        let succeeded = await onCreate(form.name, form.chosenParent)
         if succeeded { dismiss() }
     }
 }

--- a/apple/CabalmailTests/NewFolderFormTests.swift
+++ b/apple/CabalmailTests/NewFolderFormTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Cabalmail
+
+// The new-folder sheet's input lives in `NewFolderForm`, held by the view
+// that presents the sheet — the sheet's own state doesn't survive SwiftUI
+// re-creating its body when the parent picker's menu dismisses. These cover
+// what that type owes the sheet: the picker's top-level sentinel, the
+// enable rule behind Create, and the per-presentation clear.
+final class NewFolderFormTests: XCTestCase {
+
+    func testTypedNameAndChosenParentBothSurviveTheFormOutlivingTheSheet() {
+        let form = NewFolderForm()
+        form.name = "kid"
+        form.parent = "INBOX"
+
+        // Standing in for the sheet body being rebuilt around the form:
+        // whatever the view does, the input is still here to submit.
+        XCTAssertEqual(form.name, "kid")
+        XCTAssertEqual(form.chosenParent, "INBOX")
+        XCTAssertTrue(form.canCreate)
+    }
+
+    func testEmptyParentMeansTopLevel() {
+        let form = NewFolderForm()
+        form.name = "kid"
+        XCTAssertNil(form.chosenParent, "the picker's 'None (top level)' row carries an empty tag")
+    }
+
+    func testWhitespaceOnlyNameCannotCreate() {
+        let form = NewFolderForm()
+        XCTAssertFalse(form.canCreate, "an untouched form has nothing to create")
+        form.name = "   "
+        XCTAssertFalse(form.canCreate)
+        form.name = " kid "
+        XCTAssertTrue(form.canCreate)
+    }
+
+    func testResetClearsBothFieldsForTheNextPresentation() {
+        let form = NewFolderForm()
+        form.name = "kid"
+        form.parent = "INBOX"
+
+        form.reset()
+
+        XCTAssertEqual(form.name, "")
+        XCTAssertNil(form.chosenParent, "a reopened sheet starts at top level")
+        XCTAssertFalse(form.canCreate)
+    }
+}

--- a/changelog.d/new-folder-parent-picker-reset.fixed.md
+++ b/changelog.d/new-folder-parent-picker-reset.fixed.md
@@ -1,0 +1,3 @@
+- Apple: **New folder with a parent, on iPhone.** Choosing a parent in the New
+  Folder sheet no longer wipes the name you typed and drop the selection —
+  which had made a nested folder impossible to create from iPhone.


### PR DESCRIPTION
## What was wrong

On compact iPhone, the New Folder sheet lost everything the user had entered the moment the **Parent folder** picker's menu closed: the typed name went back to its placeholder, the parent selection was not applied, and Create went dim again. Choosing a parent and dismissing the menu by tapping outside it behaved identically, so **a folder with a parent could not be created from iPhone at all**. iPad was unaffected.

Reproduced on an iPhone 17 sim (iOS 26.5) against stage before touching anything — typed `kid`, tapped Parent folder, chose INBOX, and read the AX tree back:

```
TextField ... placeholderValue: 'e.g. Projects'          <- name gone
Button    ... label: 'Parent folder, None (top level)'   <- selection dropped
Button    ... label: 'Create', Disabled
```

## Root cause

`NewFolderSheet` held `name` and `parent` in its own `@State`. Dismissing the picker's menu re-creates the sheet's body on compact iPhone, and SwiftUI state that the re-created view owns goes with it — the sheet itself stays presented, which is why the form appeared to clear itself while the sheet stayed up. Both fields resetting together, and the selection never landing, are the same event.

## The fix

Hoist that input into a small `NewFolderForm` (`@Observable`, its own file) owned by the presenting `FolderListView` via `@State`. The presenter is stable — its `showNewFolderSheet` survives the same churn — so the input survives with it; the sheet reads and writes it through `@Bindable`. Both raise sites (compact toolbar `+` and the wide sidebar header) now go through `presentNewFolderSheet()`, which clears the form on the way in, replacing the "fresh sheet state" that used to do that implicitly.

Scoped to the reported problem: the picker, the validation rule and the submit payload are unchanged (`canCreate` is the same trimmed-non-empty test the `.disabled` used, and `chosenParent` the same empty-means-top-level mapping).

## Verification

Same six steps on the fixed build, same sim:

```
TextField ... placeholderValue: 'e.g. Projects', value: kid   <- intact
Button    ... label: 'Parent folder, INBOX'                   <- applied
Button    ... label: 'Create'                                 <- enabled
```

Tapping Create then created `INBOX/kid` — the flow the report called unreachable — and the sidebar drew it nested under INBOX. Test folder deleted afterwards; sim restored to the tester's build, signed in on INBOX.

- `apple/CabalmailTests/NewFolderFormTests.swift` — 4 new tests over the extracted type (input survives, top-level sentinel, whitespace-only name, reset-on-present). Full app-layer suite: **107 tests, 0 failures**. `swiftlint --strict` from `apple/`: clean.
- Honest caveat on the regression test: these cover the type the fix introduces, not the SwiftUI identity behaviour that caused the bug — there is no unit-test seam for "the sheet's body got re-created". The AX-tree before/after above is the evidence for that half, and the unit tests are what keeps the extracted form honest.

Addresses #889