### PR TITLE
Share the address-lifecycle request preamble

### DIFF
--- a/lambda/api/_shared/helper.py
+++ b/lambda/api/_shared/helper.py
@@ -283,17 +283,57 @@ def get_imap_client(_host, user, folder, read_only=False):
     return open_imap_client(IMAP_HOST, user, folder, read_only, mpw)
 
 
-def user_authorized_for_sender(user, sender):
-    """Checks whether the user is allowed to send from the specifed sender address"""
+def address_row_for_sender(user, sender):
+    """Fetches the stored cabal-addresses row for `sender` and reports whether
+    the user may send from it, as (item, authorized).
+
+    `item` is the stored row, or {} when the address has no row or the lookup
+    failed, so a caller that also needs the row does not have to read it a
+    second time. A lookup failure is reported as unauthorized rather than
+    raised, so the caller answers 403 instead of relaying a traceback.
+    """
     try:
         response = ddb_table.get_item(Key={'address': sender})
     except ClientError as err:
         print(err.response['Error']['Message'])
-        return False
-    try:
-        return response['Item']['user'] == user
-    except KeyError:
-        return False
+        return {}, False
+    item = response.get('Item') or {}
+    return item, item.get('user') == user
+
+
+def user_authorized_for_sender(user, sender):
+    """Checks whether the user is allowed to send from the specifed sender address"""
+    _, authorized = address_row_for_sender(user, sender)
+    return authorized
+
+
+def authorized_address_request(event):
+    """Parses an address-scoped request body and authorizes the caller against
+    the stored row, returning (address, item, error).
+
+    On success `error` is None, `address` is the requested address and `item`
+    is that address's stored cabal-addresses row. On a malformed body, or an
+    address the caller does not own, `error` is a ready-to-return response and
+    the other two are None, so a handler can `return error`. Shared by the
+    address-lifecycle endpoints (revoke, suspend, reinstate) so all three gate
+    on the same check with the same wire shape, and so the stored row each of
+    them goes on to read costs one DynamoDB lookup rather than two.
+    """
+    body, error = parse_json_body(event)
+    if error:
+        return None, None, error
+    address = body['address']
+    user = event['requestContext']['authorizer']['claims']['cognito:username']
+    item, authorized = address_row_for_sender(user, address)
+    if not authorized:
+        return None, None, {
+            'statusCode': 403,
+            'body': json.dumps({
+                'Error': 'Address not associated with authenticated user'
+            })
+        }
+    return address, item, None
+
 
 def user_authorized_for_domain(user, domain):
     """Checks whether the user is permitted to create addresses on the given

--- a/lambda/api/_shared/tests/test_authorized_address_request.py
+++ b/lambda/api/_shared/tests/test_authorized_address_request.py
@@ -1,0 +1,202 @@
+'''Unit tests for authorized_address_request, the shared preamble behind the
+address-lifecycle endpoints (revoke, suspend_address, reinstate_address), and
+for the user_authorized_for_sender wrapper that now sits on the same lookup.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_authorized_address_request.py
+
+helper.py's third-party imports (boto3, botocore, imap_session) are faked in
+sys.modules before import, so the suite needs no AWS access. The cases pin the
+outcomes the three handlers relied on before the preamble was shared: the 403
+wire shape, a failed lookup reported as unauthorized rather than raised, the
+relayed 400 from parse_json_body, the KeyError a body with no `address` has
+always raised -- and that an authorized request costs exactly one read, since
+the handlers no longer re-fetch the row the check already loaded.'''
+import os
+import sys
+import types
+import unittest
+
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
+
+_SHARED = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SHARED)
+
+# --- fake boto3 / botocore ---------------------------------------------------
+
+
+# Identical to the fake in the sibling suites on purpose. This file sorts first
+# under `unittest discover`, so its fakes are usually the ones every later suite
+# inherits (#860); a leaner fake here fails them, not this one.
+class _FakeSSMExceptions:
+    class ParameterNotFound(Exception):
+        pass
+
+
+class _FakeSSM:
+    exceptions = _FakeSSMExceptions
+
+    def get_parameter(self, Name=None, **_kwargs):  # pylint: disable=invalid-name
+        if Name == '/cabal/maintenance/imap':
+            raise _FakeSSMExceptions.ParameterNotFound()
+        return {"Parameter": {"Value": "fake-master-password"}}
+
+
+class _FakeResource:
+    def Table(self, _name):  # pylint: disable=invalid-name
+        return types.SimpleNamespace()
+
+
+_boto3 = types.ModuleType("boto3")
+_boto3.resource = lambda _name, **_kw: _FakeResource()
+_boto3.client = lambda name, **_kw: _FakeSSM() if name == 'ssm' else types.SimpleNamespace()
+_boto3.session = types.SimpleNamespace(Config=lambda **_kw: None)
+sys.modules.setdefault('boto3', _boto3)
+
+_botocore = types.ModuleType("botocore")
+_botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+
+class _ClientError(Exception):
+    pass
+
+
+_botocore_exceptions.ClientError = _ClientError
+_botocore.exceptions = _botocore_exceptions
+sys.modules.setdefault('botocore', _botocore)
+sys.modules.setdefault('botocore.exceptions', _botocore_exceptions)
+
+_imap_session = types.ModuleType("imap_session")
+_imap_session.open_imap_client = lambda *_a, **_kw: None
+sys.modules.setdefault('imap_session', _imap_session)
+
+import helper  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class _LookupFailure(Exception):
+    '''Carries the `.response` shape helper reads off a botocore ClientError.'''
+
+    def __init__(self):
+        super().__init__('throttled')
+        self.response = {'Error': {'Message': 'throttled'}}
+
+
+class _FakeTable:
+    '''Stands in for the cabal-addresses Table, counting reads.'''
+
+    def __init__(self):
+        self.rows = {}
+        self.raise_on_get = False
+        self.get_calls = 0
+
+    def get_item(self, Key=None, **_kwargs):  # pylint: disable=invalid-name
+        self.get_calls += 1
+        if self.raise_on_get:
+            raise _LookupFailure()
+        address = Key['address']
+        if address in self.rows:
+            return {'Item': self.rows[address]}
+        return {}
+
+
+class _TableCase(unittest.TestCase):
+    '''Binds the fake table, and points helper's `except ClientError` at the
+    fake table's failure. Rebinding rather than relying on the sys.modules fake
+    keeps this correct under a directory-wide `discover` run, where a sibling
+    suite's fake may already have won the import (#860).'''
+
+    def setUp(self):
+        self.table = _FakeTable()
+        self._saved = (helper.ddb_table, helper.ClientError)
+        helper.ddb_table = self.table
+        helper.ClientError = _LookupFailure
+
+    def tearDown(self):
+        helper.ddb_table, helper.ClientError = self._saved
+
+
+def _event(address='user@sub.example.com', user='alice', body=...):
+    '''Builds an API Gateway event; `body` overrides the JSON body wholesale.'''
+    import json  # pylint: disable=import-outside-toplevel
+    if body is ...:
+        body = json.dumps({'address': address})
+    return {
+        'body': body,
+        'requestContext': {'authorizer': {'claims': {'cognito:username': user}}}
+    }
+
+
+class AuthorizedAddressRequestTest(_TableCase):
+    def test_authorized_returns_the_stored_row_in_one_read(self):
+        row = {'address': 'user@sub.example.com', 'user': 'alice',
+               'subdomain': 'sub', 'tld': 'example.com', 'suspended': True}
+        self.table.rows['user@sub.example.com'] = row
+        address, item, error = helper.authorized_address_request(_event())
+        self.assertIsNone(error)
+        self.assertEqual(address, 'user@sub.example.com')
+        self.assertEqual(item, row)
+        # The handlers read subdomain/tld/suspended off this row instead of
+        # issuing a second get_item for it.
+        self.assertEqual(self.table.get_calls, 1)
+
+    def test_row_owned_by_another_user_is_403(self):
+        self.table.rows['user@sub.example.com'] = {'user': 'bob'}
+        address, item, error = helper.authorized_address_request(_event())
+        self.assertIsNone(address)
+        self.assertIsNone(item)
+        self.assertEqual(error['statusCode'], 403)
+        self.assertIn('not associated with authenticated user', error['body'])
+
+    def test_missing_row_is_403(self):
+        _, _, error = helper.authorized_address_request(_event())
+        self.assertEqual(error['statusCode'], 403)
+
+    def test_row_without_a_user_attribute_is_403(self):
+        self.table.rows['user@sub.example.com'] = {'subdomain': 'sub'}
+        _, _, error = helper.authorized_address_request(_event())
+        self.assertEqual(error['statusCode'], 403)
+
+    def test_lookup_failure_is_403_not_a_traceback(self):
+        self.table.raise_on_get = True
+        _, _, error = helper.authorized_address_request(_event())
+        self.assertEqual(error['statusCode'], 403)
+
+    def test_malformed_body_relays_the_parse_error(self):
+        for body in (None, '', '{not json', '[1, 2]'):
+            with self.subTest(body=body):
+                address, item, error = helper.authorized_address_request(
+                    _event(body=body))
+                self.assertIsNone(address)
+                self.assertIsNone(item)
+                self.assertEqual(error['statusCode'], 400)
+        self.assertEqual(self.table.get_calls, 0)
+
+    def test_body_without_an_address_still_raises_key_error(self):
+        # Pre-existing contract: the handlers never guarded this, and a caller
+        # that omits `address` gets a Lambda error rather than a 4xx.
+        with self.assertRaises(KeyError):
+            helper.authorized_address_request(_event(body='{"nothing": 1}'))
+
+
+class UserAuthorizedForSenderTest(_TableCase):
+    '''The wrapper still answers for its other callers (compose.py, /send,
+    /save_draft), which want the boolean and not the row.'''
+
+    def test_owner_is_authorized(self):
+        self.table.rows['a@x.example'] = {'user': 'alice'}
+        self.assertTrue(helper.user_authorized_for_sender('alice', 'a@x.example'))
+
+    def test_non_owner_missing_row_missing_attr_and_failure_are_all_false(self):
+        self.table.rows['a@x.example'] = {'user': 'bob'}
+        self.table.rows['b@x.example'] = {'subdomain': 'x'}
+        self.assertFalse(helper.user_authorized_for_sender('alice', 'a@x.example'))
+        self.assertFalse(helper.user_authorized_for_sender('alice', 'b@x.example'))
+        self.assertFalse(helper.user_authorized_for_sender('alice', 'gone@x.example'))
+        self.table.raise_on_get = True
+        self.assertFalse(helper.user_authorized_for_sender('alice', 'a@x.example'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/reinstate_address/function.py
+++ b/lambda/api/reinstate_address/function.py
@@ -4,9 +4,8 @@ clears the suspended flag in DynamoDB'''
 import json
 import os
 import boto3  # pylint: disable=import-error
-from helper import parse_json_body  # pylint: disable=import-error
+from helper import authorized_address_request  # pylint: disable=import-error
 from helper import publish_address_dns_records  # pylint: disable=import-error
-from helper import user_authorized_for_sender  # pylint: disable=import-error
 
 domains = json.loads(os.environ['DOMAINS'])
 control_domain = os.environ['CONTROL_DOMAIN']
@@ -17,19 +16,9 @@ table = ddb.Table('cabal-addresses')
 
 def handler(event, _context):
     '''Reinstates a suspended email address'''
-    body, error = parse_json_body(event)
+    address, item, error = authorized_address_request(event)
     if error:
         return error
-    address = body['address']
-    user = event['requestContext']['authorizer']['claims']['cognito:username']
-    if not user_authorized_for_sender(user, address):
-        return {
-            'statusCode': 403,
-            'body': json.dumps({
-                'Error': 'Address not associated with authenticated user'
-            })
-        }
-    item = table.get_item(Key={'address': address}).get('Item') or {}
     if not item.get('suspended'):
         return {
             'statusCode': 200,

--- a/lambda/api/revoke/function.py
+++ b/lambda/api/revoke/function.py
@@ -5,9 +5,8 @@ import os
 from datetime import datetime, timezone
 import boto3  # pylint: disable=import-error
 from helper import active_addresses_on_subdomain  # pylint: disable=import-error
+from helper import authorized_address_request  # pylint: disable=import-error
 from helper import delete_address_dns_records  # pylint: disable=import-error
-from helper import parse_json_body  # pylint: disable=import-error
-from helper import user_authorized_for_sender  # pylint: disable=import-error
 
 domains = json.loads(os.environ['DOMAINS'])
 control_domain = os.environ['CONTROL_DOMAIN']
@@ -20,18 +19,9 @@ sns = boto3.client('sns')
 
 def handler(event, _context):
     '''Revokes an email address'''
-    body, error = parse_json_body(event)
+    address, item, error = authorized_address_request(event)
     if error:
         return error
-    address = body['address']
-    user = event['requestContext']['authorizer']['claims']['cognito:username']
-    if not user_authorized_for_sender(user, address):
-        return {
-            'statusCode': 403,
-            'body': json.dumps({
-                'Error': 'Address not associated with authenticated user'
-            })
-        }
     # Take subdomain/tld/zone from the STORED row for `address`, never from the
     # request body. Authorization above is on `address` only, so honoring a
     # client-supplied subdomain/tld would let a caller who owns any one address
@@ -40,7 +30,6 @@ def handler(event, _context):
     # (active_addresses_on_subdomain) returns False for a single-tenant victim
     # subdomain, so the DELETE would proceed. The caller owns `address`, so its
     # row is the authoritative source.
-    item = table.get_item(Key={'address': address}).get('Item') or {}
     subdomain = item.get('subdomain')
     tld = item.get('tld')
     # The zone is resolved from DOMAINS, never from the zone-id cached on the

--- a/lambda/api/suspend_address/function.py
+++ b/lambda/api/suspend_address/function.py
@@ -7,9 +7,8 @@ import os
 from datetime import datetime, timezone
 import boto3  # pylint: disable=import-error
 from helper import active_addresses_on_subdomain  # pylint: disable=import-error
+from helper import authorized_address_request  # pylint: disable=import-error
 from helper import delete_address_dns_records  # pylint: disable=import-error
-from helper import parse_json_body  # pylint: disable=import-error
-from helper import user_authorized_for_sender  # pylint: disable=import-error
 
 domains = json.loads(os.environ['DOMAINS'])
 control_domain = os.environ['CONTROL_DOMAIN']
@@ -20,23 +19,9 @@ table = ddb.Table('cabal-addresses')
 
 def handler(event, _context):
     '''Suspends an email address'''
-    body, error = parse_json_body(event)
+    address, item, error = authorized_address_request(event)
     if error:
         return error
-    address = body['address']
-    user = event['requestContext']['authorizer']['claims']['cognito:username']
-    if not user_authorized_for_sender(user, address):
-        return {
-            'statusCode': 403,
-            'body': json.dumps({
-                'Error': 'Address not associated with authenticated user'
-            })
-        }
-    # Like revoke, take subdomain/tld/zone from the STORED row, never from the
-    # request body: authorization above is on `address` only, so honoring a
-    # client-supplied subdomain/tld would let a caller who owns any one address
-    # delete another user's DNS records.
-    item = table.get_item(Key={'address': address}).get('Item') or {}
     if item.get('suspended'):
         return {
             'statusCode': 200,
@@ -46,6 +31,10 @@ def handler(event, _context):
                 'suspended': True
             })
         }
+    # Like revoke, take subdomain/tld/zone from the STORED row, never from the
+    # request body: authorization above is on `address` only, so honoring a
+    # client-supplied subdomain/tld would let a caller who owns any one address
+    # delete another user's DNS records.
     subdomain = item.get('subdomain')
     tld = item.get('tld')
     # The zone is resolved from DOMAINS, never from the zone-id cached on the


### PR DESCRIPTION
`revoke`, `suspend_address` and `reinstate_address` each opened with the same ~20 lines: `parse_json_body`, the `cognito:username` claim lookup, the `user_authorized_for_sender` check with its 403, and then a second `get_item` for the stored row.

`user_authorized_for_sender` had *already* read that row to make its decision and thrown it away, so every authorized call to these three endpoints cost two DynamoDB reads of the same key.

## What changed

- `helper.address_row_for_sender(user, sender)` — the lookup, now returning `(item, authorized)` instead of just the boolean.
- `helper.user_authorized_for_sender` — unchanged signature and semantics, now a two-line wrapper. Its other callers (`_shared/compose.py`, and through it `/send` and `/save_draft`) are untouched.
- `helper.authorized_address_request(event)` — the shared preamble, returning `(address, item, error)`.
- The three handlers call it and read `subdomain` / `tld` / `suspended` off the returned row.

Net effect on the data plane: one DynamoDB read per authorized request instead of two. Nothing else moves.

## Why it's safe

**Differential probe.** A throwaway harness loaded the real pre-refactor `helper.py` (`git show origin/stage:...`) and the working-tree one side by side under a mocked boto3, then compared the verbatim stage preamble against `authorized_address_request` over 6000 randomized events x table states — malformed bodies, missing `address`, missing claims, absent rows, rows with no `user`, non-string `user` values, and injected `ClientError`s. It compared full outcomes *and* raised exception types.

```
6000 preamble cases, mismatches: 0
  outcome coverage: {'error': 1216, '403': 1719, 'ok': 2702, 'raise': 363}
  DynamoDB get_item calls -- old: 7123  new: 4421
2000 user_authorized_for_sender cases, mismatches: 0
```

The read delta is exactly 2702 — one saved read per authorized case, and none on any other path. The harness is not committed; representative cases are pinned as permanent tests instead.

**Failure modes preserved deliberately**, since each was load-bearing and none is obvious:

- A `ClientError` on the lookup is still printed and answered **403**, not raised. Previously `user_authorized_for_sender` swallowed it and returned `False`; the second `get_item` (outside the handlers' `try`) never ran. Same wire result now.
- `response['Item']['user'] == user` under `try/except KeyError` became `item.get('user') == user`. Equivalent at every branch: no `Item`, no `user` key, and a present `user` all land identically — `cognito:username` is never `None`.
- A body with no `address` still raises `KeyError` and still surfaces as a Lambda error. That was never guarded and this PR does not start guarding it.
- The 400 from `parse_json_body` is relayed verbatim, before any DynamoDB read.

**Security comments kept at their point of use.** The "take subdomain/tld from the STORED row, never from the request body" rationale in `revoke` and `suspend_address` moved down to sit directly above the `item.get('subdomain')` reads it explains, rather than into a helper docstring.

## Verified

- `python3 -m unittest discover -s lambda/api/_shared/tests -p "test_*.py"` — **48 tests OK** (39 on stage + 9 new). The new file sorts first under `discover`, so its boto3/SSM fakes are what later suites inherit; they are byte-identical to the sibling suites' fakes for that reason (#860).
- `python3 -m pylint --rcfile .pylintrc _shared/*.py */function.py push_dispatch/apns.py` — **10.00/10**, unchanged.
- The three `# pylint: disable=duplicate-code` headers were tested for staleness by deleting them and re-running: `R0801` still fires on the handlers' trailing response blocks, so all three stay.
- `.github/scripts/build-api-one.sh` bundling is unaffected — all three handlers still match its `^\s*(from|import)\s+helper` grep.

No changelog fragment: internal maintenance, no user-facing surface.