### PR TITLE
Keep both search matches when two share a UID

### DIFF
--- a/apple/Cabalmail/Views/MessageListView+Selection.swift
+++ b/apple/Cabalmail/Views/MessageListView+Selection.swift
@@ -47,8 +47,14 @@ extension MessageListView {
                                 indexedRow(index, model: model, visible: visible)
                             }
                         } else {
-                            ForEach(visible) { envelope in
-                                messageRow(envelope, model: model, visible: visible)
+                            // Identity comes from `MessageRowIdentity`, not
+                            // `Envelope.id` (the UID): a cross-folder search can
+                            // return the same UID from two folders, and a
+                            // `ForEach` given two elements with one id draws only
+                            // the first — the other match disappears from the
+                            // list while the header still counts it.
+                            ForEach(MessageRowIdentity.identify(visible)) { row in
+                                messageRow(row.envelope, model: model, visible: visible)
                             }
                         }
                     }

--- a/apple/Cabalmail/Views/MessageRowIdentity.swift
+++ b/apple/Cabalmail/Views/MessageRowIdentity.swift
@@ -1,0 +1,60 @@
+import Foundation
+import CabalmailKit
+
+/// Row identity for the message list's non-virtualized (`ForEach(visible)`)
+/// path — search and filtered results.
+///
+/// `Envelope.id` is its UID, which is unique only *within* a folder. A
+/// cross-folder search routinely returns the same UID twice (`zeta0803`
+/// UID 1 and `alpha0803/kid` UID 1, say), and a `ForEach` handed two
+/// elements with the same id draws only one of them: the second match is
+/// counted by the header and then silently dropped from the list. Keying
+/// on UID *plus* Message-ID separates those rows, matching the key
+/// `SearchSourceFolderIndex` already uses to route each row back to its
+/// own mailbox.
+///
+/// `occurrence` is the last-resort tiebreak for rows that are
+/// indistinguishable even then — same UID and no Message-ID on either,
+/// which the server can return for envelopes it couldn't parse. Distinct
+/// identities there are still better than a vanished row; it only means
+/// SwiftUI rebuilds the later duplicate if an earlier one is removed.
+struct MessageRowIdentity: Hashable {
+    let uid: UInt32
+    let messageID: String?
+    /// 0 for the first row with this (uid, messageID) pair, 1 for the next,
+    /// and so on. Non-zero only in the indistinguishable case above.
+    let occurrence: Int
+}
+
+/// An envelope paired with the identity its row is drawn under.
+struct IdentifiedEnvelope: Identifiable, Hashable {
+    let id: MessageRowIdentity
+    let envelope: Envelope
+}
+
+extension MessageRowIdentity {
+    /// Pairs each envelope with an identity unique across `envelopes`,
+    /// preserving order. What `ForEach` iterates in the search / filtered
+    /// list.
+    static func identify(_ envelopes: [Envelope]) -> [IdentifiedEnvelope] {
+        var seen: [Key: Int] = [:]
+        return envelopes.map { envelope in
+            let key = Key(uid: envelope.uid, messageID: envelope.messageId)
+            let occurrence = seen[key, default: 0]
+            seen[key] = occurrence + 1
+            return IdentifiedEnvelope(
+                id: MessageRowIdentity(
+                    uid: envelope.uid,
+                    messageID: envelope.messageId,
+                    occurrence: occurrence
+                ),
+                envelope: envelope
+            )
+        }
+    }
+
+    private struct Key: Hashable {
+        let uid: UInt32
+        let messageID: String?
+    }
+}

--- a/apple/CabalmailTests/MessageRowIdentityTests.swift
+++ b/apple/CabalmailTests/MessageRowIdentityTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import CabalmailKit
+@testable import Cabalmail
+
+// Search results span folders, and an IMAP UID is unique only within one,
+// so the list's row identity can't be the UID alone: two matches sharing a
+// UID have to stay two rows.
+final class MessageRowIdentityTests: XCTestCase {
+
+    /// The reported mailbox: `zeta0803` UID 1 and `alpha0803/kid` UID 1,
+    /// both matching one query.
+    private var collidingMatches: [Envelope] {
+        [
+            TestFixtures.makeEnvelope(uid: 1, messageId: "<probe1@example.com>", subject: "collide0803 probe 1"),
+            TestFixtures.makeEnvelope(uid: 1, messageId: "<probe2@example.com>", subject: "collide0803 probe 2"),
+        ]
+    }
+
+    func testCollidingUIDsGetDistinctRowIdentities() {
+        let rows = MessageRowIdentity.identify(collidingMatches)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertNotEqual(
+            rows[0].id, rows[1].id,
+            "two search matches sharing a UID must be two rows, not one — a ForEach drops the duplicate id"
+        )
+    }
+
+    func testRowsKeepTheirEnvelopesAndOrder() {
+        let rows = MessageRowIdentity.identify(collidingMatches)
+        XCTAssertEqual(rows.map { $0.envelope.subject }, ["collide0803 probe 1", "collide0803 probe 2"])
+    }
+
+    func testIdentityIsStableAcrossRebuilds() {
+        // The same result set re-identified gives the same ids, so a redraw
+        // doesn't tear down and rebuild every row.
+        XCTAssertEqual(
+            MessageRowIdentity.identify(collidingMatches).map { $0.id },
+            MessageRowIdentity.identify(collidingMatches).map { $0.id }
+        )
+    }
+
+    func testMessagelessCollisionStillYieldsTwoRows() {
+        // Last-resort case: same UID and no Message-ID on either row, so
+        // even the UID + Message-ID key can't tell them apart.
+        let rows = MessageRowIdentity.identify([
+            TestFixtures.makeEnvelope(uid: 4, subject: "no message-id 1"),
+            TestFixtures.makeEnvelope(uid: 4, subject: "no message-id 2"),
+        ])
+        XCTAssertEqual(Set(rows.map { $0.id }).count, 2, "an indistinguishable duplicate still gets its own row")
+    }
+
+    func testDistinctUIDsAreUnaffected() {
+        // The ordinary folder / broken-collision case from the report's
+        // control run: nothing about identity changes when UIDs differ.
+        let rows = MessageRowIdentity.identify([
+            TestFixtures.makeEnvelope(uid: 1, messageId: "<probe1@example.com>"),
+            TestFixtures.makeEnvelope(uid: 4, messageId: "<probe2@example.com>"),
+        ])
+        XCTAssertEqual(rows.map { $0.id.uid }, [1, 4])
+        XCTAssertEqual(rows.map { $0.id.occurrence }, [0, 0])
+    }
+}

--- a/changelog.d/search-uid-row-identity.fixed.md
+++ b/changelog.d/search-uid-row-identity.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Search results sharing a UID.** A cross-folder search that matched
+  two messages carrying the same IMAP UID (UIDs are unique only within a
+  folder) drew only one of them, while the header still counted both. The
+  results list now identifies rows by UID plus Message-ID instead of the UID
+  alone.


### PR DESCRIPTION
## What was wrong

On a cross-folder search, a match whose UID collided with another folder's
match was silently dropped from the results list — the header counted it
("2 of 2 matches") but only one row was drawn, and the message was
unreachable from search. Reported in #894 as the follow-up to #885, which
fixed the *crash* on the same mailbox shape.

## Root cause

An IMAP UID is unique only *within* a folder, so an all-mail search
routinely returns the same UID from two mailboxes. `Envelope.id` is the UID,
and the search / filtered branch of `virtualizedList` iterated
`ForEach(visible)` — i.e. by `Envelope.id`. Handed two elements with the
same id, `ForEach` draws one. The header reads its count from
`searchTotalEstimate`, not from the rows, which is why the two disagreed.

## The fix

Row identity for that branch now comes from a new pure type,
`MessageRowIdentity`: UID **plus** Message-ID — the same key
`SearchSourceFolderIndex` already uses to route each row back to its own
mailbox (#885) — with an occurrence tiebreak for the last-resort case where
neither row carries a Message-ID. Nothing else changes: the virtualized
folder path is still index-addressed, and rows with distinct UIDs get
exactly the identities they had before.

## Test evidence

- New `CabalmailTests/MessageRowIdentityTests.swift` (5 cases). Against the
  old UID-only identity (impl shimmed to return it), 2 fail:
  `testCollidingUIDsGetDistinctRowIdentities` and
  `testMessagelessCollisionStillYieldsTwoRows`; all 5 pass on this branch.
- Full app suite: 112 tests, 0 failures. `swiftlint` from `apple/`: clean.
- **Live repro on iPhone 17 sim (iOS 26.5)** against this build. Seeded
  `fixer894a` UID 1 and `fixer894b` UID 1 (a move into a fresh folder
  rewrites the UID to 1), both matching `fixer894`; Search tab -> "Search all
  mail" -> `fixer894`. Header reads "2 of 2 matches" and **two** `Cell`s are
  in the accessibility tree (`fixer894 probe 1`, `fixer894 probe 2`) — the
  reported build drew one. Seeded folders deleted afterwards.

## Noted, not changed

Both rows still carry the same accessibility identifier
(`message.row.<uid>`), so an XCUITest query for the second colliding row
matches the first. That's a testability wrinkle rather than the reported
defect, and changing the identifier shape would break existing tap recipes —
happy to follow up if you want it. The selection layer (`selectedUIDs`,
`.tag(envelope.uid)`) is likewise still UID-keyed, so the two rows highlight
together; that was offered on #885 and remains un-accepted.

Addresses #894.