### PR TITLE
Treat the threading headers as optional when composing

### DIFF
--- a/changelog.d/send-optional-threading-headers.fixed.md
+++ b/changelog.d/send-optional-threading-headers.fixed.md
@@ -1,5 +1,9 @@
-- **Sending without threading headers.** `/send` and `/save_draft` failed
-  with a bodiless 502 when a request omitted the `message_id`, `in_reply_to`,
-  or `references` entries of `other_headers` — the shape a fresh, non-reply
-  compose produces. The composer now reads them as optional, matching the
-  validator that already did.
+- **Incomplete send payloads answered with a bodiless 502.** `/send` and
+  `/save_draft` died on a `KeyError` when a request omitted the `message_id`,
+  `in_reply_to`, or `references` entries of `other_headers` — the shape a
+  fresh, non-reply compose produces — and again when it omitted any of
+  `sender`, `subject`, `to_list`, `cc_list`, `bcc_list`, `text`, `html`, or
+  `host`. The threading headers are now read as optional, matching the
+  validator that already did; the rest are checked before anything indexes
+  them and rejected with the 400 naming the missing field, which both
+  endpoints already returned for a bad value.

--- a/changelog.d/send-optional-threading-headers.fixed.md
+++ b/changelog.d/send-optional-threading-headers.fixed.md
@@ -1,0 +1,5 @@
+- **Sending without threading headers.** `/send` and `/save_draft` failed
+  with a bodiless 502 when a request omitted the `message_id`, `in_reply_to`,
+  or `references` entries of `other_headers` — the shape a fresh, non-reply
+  compose produces. The composer now reads them as optional, matching the
+  validator that already did.

--- a/lambda/api/_shared/compose.py
+++ b/lambda/api/_shared/compose.py
@@ -193,13 +193,20 @@ def compose_from_body(body, user):
     # address part is always the bare validated sender (which /send also pins
     # as the SMTP MAIL FROM).
     from_header = format_mailbox(sender_display_name(user), body['sender'])
+    # The threading headers are read the same defensive way
+    # validate_outbound_headers reads them: absent means no threading
+    # context, which is exactly what a fresh (non-reply) compose has.
+    # Hard-indexing them here made the two halves of one request disagree
+    # -- optional to the validator, required five lines later -- and the
+    # KeyError escaped as a bodiless 502 (#895).
+    others = body.get('other_headers', {}) or {}
     return compose_message(body['subject'], from_header, {
                              "to": ','.join(body['to_list']),
                              "cc": ','.join(body['cc_list']),
                              "bcc": ','.join(body['bcc_list']),
-                             "message_id": body['other_headers']['message_id'],
-                             "in_reply_to": body['other_headers']['in_reply_to'],
-                             "references": body['other_headers']['references']
+                             "message_id": others.get('message_id', []) or [],
+                             "in_reply_to": others.get('in_reply_to', []) or [],
+                             "references": others.get('references', []) or []
                            },
                            body['text'], body['html'], attachments)
 

--- a/lambda/api/_shared/compose.py
+++ b/lambda/api/_shared/compose.py
@@ -42,6 +42,13 @@ DRAFTS_FOLDER = 'Drafts'
 # `[APPENDUID <uidvalidity> <uid>]`.
 _APPENDUID_RE = re.compile(r'\[APPENDUID (\d+) (\d+)\]')
 
+# The body keys compose_from_body indexes directly. A message cannot be
+# built without them, so their absence is a client error -- but only if it
+# is checked, because an escaping KeyError becomes a bodiless 502 rather
+# than the 400 the handlers already have for a rejected payload (#895).
+COMPOSE_REQUIRED_FIELDS = ('sender', 'subject', 'to_list', 'cc_list',
+                           'bcc_list', 'text', 'html')
+
 # The user's display-name preference (set via /set_preferences) becomes the
 # From header's display name. It is read server-side - never from the request
 # body - so a client cannot put an arbitrary name on the wire per message.
@@ -187,6 +194,7 @@ def compose_from_body(body, user):
     (callers translate it to a 400). Sender authorization is the caller's
     responsibility (see unauthorized_sender_response_or_none).'''
     bucket = CACHE_BUCKET
+    require_fields(body, COMPOSE_REQUIRED_FIELDS)
     validate_outbound_headers(body)
     attachments = load_attachments(body.get('attachments', []), bucket, user)
     # The visible From may carry the user's display-name preference, but the
@@ -200,10 +208,13 @@ def compose_from_body(body, user):
     # -- optional to the validator, required five lines later -- and the
     # KeyError escaped as a bodiless 502 (#895).
     others = body.get('other_headers', {}) or {}
+    # Same defensiveness for the recipient lists: the validator above reads
+    # each as `... or []`, so a null list is a payload it accepts and this
+    # must not then die on `','.join(None)`.
     return compose_message(body['subject'], from_header, {
-                             "to": ','.join(body['to_list']),
-                             "cc": ','.join(body['cc_list']),
-                             "bcc": ','.join(body['bcc_list']),
+                             "to": ','.join(body['to_list'] or []),
+                             "cc": ','.join(body['cc_list'] or []),
+                             "bcc": ','.join(body['bcc_list'] or []),
                              "message_id": others.get('message_id', []) or [],
                              "in_reply_to": others.get('in_reply_to', []) or [],
                              "references": others.get('references', []) or []
@@ -222,6 +233,19 @@ def _reject_crlf(value, field):
         return
     if '\r' in value or '\n' in value:
         raise ValueError(f"{field} contains illegal line breaks")
+
+
+def require_fields(body, fields):
+    """Raises ValueError naming every required body key the request omits.
+
+    Callers translate the ValueError to a 400, which is the point: without
+    this the handlers index the key anyway and the KeyError escapes as a
+    bodiless 502 (#895). Presence only - a supplied value still has to get
+    past validate_outbound_headers.
+    """
+    missing = [field for field in fields if field not in body]
+    if missing:
+        raise ValueError(f"missing required field(s): {', '.join(missing)}")
 
 
 def validate_outbound_headers(body):

--- a/lambda/api/_shared/tests/test_compose_required_fields.py
+++ b/lambda/api/_shared/tests/test_compose_required_fields.py
@@ -1,0 +1,269 @@
+'''Unit tests for the required-field half of the /send payload contract.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_compose_required_fields.py
+
+Companion to test_compose_threading_headers.py, which covers the keys the
+composer treats as OPTIONAL. These cover the ones it genuinely needs: a body
+missing `sender`, `subject`, `to_list`, `cc_list`, `bcc_list`, `text`, `html`,
+or `host` used to die on a KeyError, which API Gateway surfaced as a bodiless
+`{"message": "Internal server error"}` 502 (#895) rather than the named 400
+both handlers already had for a rejected value.
+
+Third-party imports (boto3, botocore, imapclient, imap_session, smtp_session)
+are faked in sys.modules before import, so the suite needs no AWS access and
+never dials IMAP or SMTP. `helper` and `compose` themselves are the real
+modules -- faking them would hand every later-discovered suite the stub
+instead (#860/#863). The handlers are loaded under unique module names for
+the same reason.
+'''
+import importlib.util
+import json
+import os
+import sys
+import types
+import unittest
+
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
+
+_SHARED = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_API = os.path.dirname(_SHARED)
+sys.path.insert(0, _SHARED)
+
+TEST_USER = 'testuser'
+TEST_SENDER = 'daily@qa.example.com'
+
+# --- fake boto3 / botocore ---------------------------------------------------
+
+
+class _FakeTable:
+    '''cabal-addresses / cabal-user-preferences stand-in. The address row
+    authorizes TEST_USER for TEST_SENDER so the handler tests reach the
+    composition path rather than short-circuiting on the 500 an
+    unauthorized sender gets.'''
+
+    def get_item(self, Key=None, **_kwargs):  # pylint: disable=invalid-name
+        if Key and Key.get('address') == TEST_SENDER:
+            return {"Item": {"address": TEST_SENDER, "user": TEST_USER}}
+        return {}
+
+
+class _FakeResource:
+    def Table(self, _name):  # pylint: disable=invalid-name
+        return _FakeTable()
+
+
+class _FakeSSMExceptions:
+    class ParameterNotFound(Exception):
+        pass
+
+
+class _FakeSSM:
+    exceptions = _FakeSSMExceptions
+
+    def get_parameter(self, Name=None, **_kwargs):  # pylint: disable=invalid-name
+        if Name == '/cabal/maintenance/imap':
+            raise _FakeSSMExceptions.ParameterNotFound()
+        return {"Parameter": {"Value": "fake-master-password"}}
+
+
+if 'boto3' not in sys.modules:
+    _boto3 = types.ModuleType("boto3")
+    _boto3.resource = lambda _name, **_kw: _FakeResource()
+    _boto3.client = lambda name, **_kw: _FakeSSM() if name == 'ssm' else types.SimpleNamespace()
+    _boto3.session = types.SimpleNamespace(Config=lambda **_kw: None)
+    sys.modules['boto3'] = _boto3
+
+    _botocore = types.ModuleType("botocore")
+    _botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+    class _ClientError(Exception):
+        pass
+
+    _botocore_exceptions.ClientError = _ClientError
+    _botocore.exceptions = _botocore_exceptions
+    sys.modules['botocore'] = _botocore
+    sys.modules['botocore.exceptions'] = _botocore_exceptions
+
+if 'imap_session' not in sys.modules:
+    _imap_session = types.ModuleType("imap_session")
+    _imap_session.open_imap_client = lambda *_a, **_kw: None
+    sys.modules['imap_session'] = _imap_session
+
+if 'smtp_session' not in sys.modules:
+    _smtp_session = types.ModuleType("smtp_session")
+    _smtp_session.open_smtp_client = lambda *_a, **_kw: None
+    sys.modules['smtp_session'] = _smtp_session
+
+if 'imapclient' not in sys.modules:
+    _imapclient = types.ModuleType("imapclient")
+    _imapclient_exceptions = types.ModuleType("imapclient.exceptions")
+
+    class _IMAPClientError(Exception):
+        pass
+
+    _imapclient_exceptions.IMAPClientError = _IMAPClientError
+    _imapclient.exceptions = _imapclient_exceptions
+    sys.modules['imapclient'] = _imapclient
+    sys.modules['imapclient.exceptions'] = _imapclient_exceptions
+
+import compose  # noqa: E402  pylint: disable=wrong-import-position
+import helper  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _load_handler(name):
+    '''Imports lambda/api/<name>/function.py under a unique module name.
+
+    The deployed zips all name their handler module `function`, so importing
+    them as `function` lets whichever suite runs first win the sys.modules
+    slot and hands every later suite the wrong handler (#860).
+    '''
+    path = os.path.join(_API, name, 'function.py')
+    spec = importlib.util.spec_from_file_location(f'function_{name}', path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+send = _load_handler('send')
+save_draft = _load_handler('save_draft')
+
+
+def _body(**overrides):
+    '''The tester's control payload from #895: a complete, valid /send body.'''
+    body = {
+        'host': 'imap.qa.example.com',
+        'smtp_host': 'smtp.qa.example.com',
+        'sender': TEST_SENDER,
+        'to_list': [TEST_SENDER],
+        'cc_list': [],
+        'bcc_list': [],
+        'subject': 'req0803 probe',
+        'html': '<p>probe</p>',
+        'text': 'probe',
+        'draft': False,
+        'attachments': [],
+        'other_headers': {'message_id': [], 'in_reply_to': [], 'references': []},
+    }
+    body.update(overrides)
+    return body
+
+
+def _without(*fields):
+    '''The control payload with `fields` omitted entirely.'''
+    body = _body()
+    for field in fields:
+        body.pop(field)
+    return body
+
+
+def _event(body):
+    '''Wraps a body in the API Gateway event shape both handlers read.'''
+    return {
+        "body": json.dumps(body),
+        "requestContext": {"authorizer": {"claims": {"cognito:username": TEST_USER}}},
+    }
+
+
+class _ComposeCase(unittest.TestCase):
+    '''Binds the module-level tables compose and helper resolved at import
+    time. Rebinding rather than relying on this file's sys.modules fake keeps
+    the suite correct under a directory-wide `discover` run, where a sibling
+    suite's fake may already have won the import (#860/#863).'''
+
+    def setUp(self):
+        table = _FakeTable()
+        # pylint: disable=protected-access
+        self._saved = (compose._preferences_table, helper.ddb_table)
+        compose._preferences_table = table
+        helper.ddb_table = table
+
+    def tearDown(self):
+        # pylint: disable=protected-access
+        compose._preferences_table, helper.ddb_table = self._saved
+
+
+class ComposeRequiredFieldsTest(_ComposeCase):
+    '''compose_from_body rejects an incomplete payload by name instead of
+    dying on a KeyError (#895).'''
+
+    def test_control_payload_composes(self):
+        msg = compose.compose_from_body(_body(), TEST_USER)
+        self.assertEqual(msg['Subject'], 'req0803 probe')
+
+    def test_each_required_field_is_named_when_omitted(self):
+        for field in compose.COMPOSE_REQUIRED_FIELDS:
+            with self.subTest(field=field):
+                with self.assertRaises(ValueError) as caught:
+                    compose.compose_from_body(_without(field), TEST_USER)
+                self.assertIn(field, str(caught.exception))
+
+    def test_every_missing_field_is_named_at_once(self):
+        with self.assertRaises(ValueError) as caught:
+            compose.compose_from_body(_without('text', 'html'), TEST_USER)
+        message = str(caught.exception)
+        self.assertIn('text', message)
+        self.assertIn('html', message)
+
+    def test_null_recipient_lists_compose_as_empty(self):
+        # The validator reads each list as `... or []`, so a null list is a
+        # payload it accepts; the composer must not then die on ','.join(None).
+        msg = compose.compose_from_body(
+            _body(cc_list=None, bcc_list=None), TEST_USER)
+        self.assertIsNone(msg['Cc'])
+        self.assertIsNone(msg['Bcc'])
+        self.assertEqual(msg['To'], TEST_SENDER)
+
+    def test_present_but_empty_fields_are_not_missing(self):
+        # Presence, not truthiness: an empty subject is a real (if dull)
+        # message, not a client error.
+        msg = compose.compose_from_body(_body(subject=''), TEST_USER)
+        self.assertEqual(msg['Subject'], '')
+
+
+class SendHandlerRequiredFieldsTest(_ComposeCase):
+    '''/send returns the 400 rather than letting a KeyError escape as a
+    bodiless 502 -- including for the keys it reads before composing.'''
+
+    def _assert_400(self, response, field):
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn(field, json.loads(response['body'])['status'])
+
+    def test_missing_sender_is_a_400(self):
+        # `sender` is read before compose_from_body, so only the handler's own
+        # check can turn it into a 400.
+        self._assert_400(send.handler(_event(_without('sender')), None), 'sender')
+
+    def test_missing_host_is_a_400(self):
+        # `host` is indexed after delivery (the Sent-copy queue), so without
+        # this check the 502 arrived on a message that had already been sent.
+        self._assert_400(send.handler(_event(_without('host')), None), 'host')
+
+    def test_missing_body_field_is_a_400(self):
+        self._assert_400(send.handler(_event(_without('text')), None), 'text')
+
+
+class SaveDraftHandlerRequiredFieldsTest(_ComposeCase):
+    '''/save_draft composes through the same shared code and had the same
+    exposure on both of its ops.'''
+
+    def _assert_400(self, response, field):
+        self.assertEqual(response['statusCode'], 400)
+        self.assertIn(field, json.loads(response['body'])['status'])
+
+    def test_save_missing_sender_is_a_400(self):
+        self._assert_400(save_draft.handler(_event(_without('sender')), None), 'sender')
+
+    def test_save_missing_host_is_a_400(self):
+        self._assert_400(save_draft.handler(_event(_without('host')), None), 'host')
+
+    def test_discard_missing_host_is_a_400(self):
+        event = _event({'op': 'discard', 'replaces_uid': 1, 'replaces_uidvalidity': 1})
+        self._assert_400(save_draft.handler(event, None), 'host')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/_shared/tests/test_compose_threading_headers.py
+++ b/lambda/api/_shared/tests/test_compose_threading_headers.py
@@ -1,0 +1,151 @@
+'''Unit tests for compose_from_body's handling of the threading headers.
+
+No pytest harness in this repo; run under the stdlib:
+
+    python3 lambda/api/_shared/tests/test_compose_threading_headers.py
+
+compose.py's third-party imports (boto3, botocore) and helper's imap_session
+are faked in sys.modules before import, so the suite needs no AWS access and
+never dials an IMAP server. `helper` itself is the real module — faking it
+would hand every later-discovered suite the stub instead (#860/#863).
+`other_headers` is optional to validate_outbound_headers, so it has to be
+optional to the composer too: a fresh (non-reply) compose carries no
+Message-Id / In-Reply-To / References, and hard-indexing them turned that
+payload into a KeyError and a bodiless 502 (#895).
+'''
+import os
+import sys
+import types
+import unittest
+
+os.environ.setdefault('AWS_REGION', 'us-east-1')
+os.environ.setdefault('CONTROL_DOMAIN', 'test.example.com')
+
+_SHARED = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _SHARED)
+
+# --- fake boto3 / botocore ---------------------------------------------------
+
+
+class _FakeTable:
+    def get_item(self, **_kwargs):  # pylint: disable=invalid-name
+        return {}
+
+
+class _FakeResource:
+    def Table(self, _name):  # pylint: disable=invalid-name
+        return _FakeTable()
+
+
+class _FakeSSMExceptions:
+    class ParameterNotFound(Exception):
+        pass
+
+
+class _FakeSSM:
+    exceptions = _FakeSSMExceptions
+
+    def get_parameter(self, Name=None, **_kwargs):  # pylint: disable=invalid-name
+        if Name == '/cabal/maintenance/imap':
+            raise _FakeSSMExceptions.ParameterNotFound()
+        return {"Parameter": {"Value": "fake-master-password"}}
+
+
+if 'boto3' not in sys.modules:
+    _boto3 = types.ModuleType("boto3")
+    _boto3.resource = lambda _name, **_kw: _FakeResource()
+    _boto3.client = lambda name, **_kw: _FakeSSM() if name == 'ssm' else types.SimpleNamespace()
+    _boto3.session = types.SimpleNamespace(Config=lambda **_kw: None)
+    sys.modules['boto3'] = _boto3
+
+    _botocore = types.ModuleType("botocore")
+    _botocore_exceptions = types.ModuleType("botocore.exceptions")
+
+    class _ClientError(Exception):
+        pass
+
+    _botocore_exceptions.ClientError = _ClientError
+    _botocore.exceptions = _botocore_exceptions
+    sys.modules['botocore'] = _botocore
+    sys.modules['botocore.exceptions'] = _botocore_exceptions
+
+if 'imap_session' not in sys.modules:
+    _imap_session = types.ModuleType("imap_session")
+    _imap_session.open_imap_client = lambda *_a, **_kw: None
+    sys.modules['imap_session'] = _imap_session
+
+import compose  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def _body(**overrides):
+    '''The tester's control payload: valid but for `other_headers`.'''
+    body = {
+        'sender': 'daily@qa.example.com',
+        'to_list': ['daily@qa.example.com'],
+        'cc_list': [],
+        'bcc_list': [],
+        'subject': 'hdr0803 probe',
+        'html': '<p>probe</p>',
+        'text': 'probe',
+        'draft': False,
+        'attachments': [],
+        'other_headers': {'message_id': [], 'in_reply_to': [], 'references': []},
+    }
+    for key, value in overrides.items():
+        if value is None:
+            body.pop(key, None)
+        else:
+            body[key] = value
+    return body
+
+
+class ComposeThreadingHeadersTest(unittest.TestCase):
+    '''A payload with no threading context composes a message with no
+    threading headers -- it does not blow up (#895).'''
+
+    def test_control_payload_composes(self):
+        msg = compose.compose_from_body(_body(), 'testuser')
+        self.assertEqual(msg['Subject'], 'hdr0803 probe')
+        self.assertIsNone(msg['Message-Id'])
+
+    def test_empty_other_headers_composes(self):
+        msg = compose.compose_from_body(_body(other_headers={}), 'testuser')
+        self.assertIsNone(msg['Message-Id'])
+        self.assertIsNone(msg['In-Reply-To'])
+        self.assertIsNone(msg['References'])
+
+    def test_partial_other_headers_composes(self):
+        msg = compose.compose_from_body(
+            _body(other_headers={'message_id': ['<probe@example.com>']}), 'testuser')
+        self.assertEqual(msg['Message-Id'], '<probe@example.com>')
+        self.assertIsNone(msg['In-Reply-To'])
+
+    def test_omitted_other_headers_composes(self):
+        msg = compose.compose_from_body(_body(other_headers=None), 'testuser')
+        self.assertIsNone(msg['Message-Id'])
+
+    def test_null_other_headers_composes(self):
+        # `other_headers: null` — the shape a client sends when it has
+        # nothing to thread against and doesn't special-case the key.
+        msg = compose.compose_from_body(_body(other_headers=False), 'testuser')
+        self.assertIsNone(msg['Message-Id'])
+
+    def test_supplied_threading_headers_are_still_written(self):
+        msg = compose.compose_from_body(_body(other_headers={
+            'message_id': ['<new@example.com>'],
+            'in_reply_to': ['<parent@example.com>'],
+            'references': ['<gramps@example.com>', '<parent@example.com>'],
+        }), 'testuser')
+        self.assertEqual(msg['Message-Id'], '<new@example.com>')
+        self.assertEqual(msg['In-Reply-To'], '<parent@example.com>')
+        self.assertEqual(msg['References'], '<gramps@example.com> <parent@example.com>')
+
+    def test_header_injection_is_still_rejected(self):
+        with self.assertRaises(ValueError):
+            compose.compose_from_body(
+                _body(other_headers={'message_id': ['<x@example.com>\r\nBcc: evil@example.com']}),
+                'testuser')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/api/_shared/tests/test_compose_threading_headers.py
+++ b/lambda/api/_shared/tests/test_compose_threading_headers.py
@@ -103,6 +103,17 @@ class ComposeThreadingHeadersTest(unittest.TestCase):
     '''A payload with no threading context composes a message with no
     threading headers -- it does not blow up (#895).'''
 
+    def setUp(self):
+        # Bind compose's module-level preferences table rather than trusting
+        # this file's sys.modules fake to have won the import: under a
+        # directory-wide `discover` a sibling suite's fake gets there first
+        # and hands compose a table with no get_item (#860/#863).
+        self._saved_table = compose._preferences_table  # pylint: disable=protected-access
+        compose._preferences_table = _FakeTable()  # pylint: disable=protected-access
+
+    def tearDown(self):
+        compose._preferences_table = self._saved_table  # pylint: disable=protected-access
+
     def test_control_payload_composes(self):
         msg = compose.compose_from_body(_body(), 'testuser')
         self.assertEqual(msg['Subject'], 'hdr0803 probe')

--- a/lambda/api/save_draft/function.py
+++ b/lambda/api/save_draft/function.py
@@ -17,10 +17,12 @@ of the purge endpoints. Log hygiene: no subject/body/recipient logging.
 import json
 from imapclient.exceptions import IMAPClientError # pylint: disable=import-error
 from compose import ( # pylint: disable=import-error
+    COMPOSE_REQUIRED_FIELDS,
     DRAFTS_FOLDER,
     append_draft,
     compose_from_body,
     guarded_draft_expunge,
+    require_fields,
     unauthorized_sender_response_or_none,
 )
 from helper import ( # pylint: disable=import-error
@@ -54,6 +56,12 @@ def _save(body, user):
     '''Composes the draft, APPENDs it to Drafts, and (optionally) replaces a
     prior copy. The compose payload is the /send shape, validated and built
     by the same shared code.'''
+    # Presence first, so a body missing `sender` or `host` is a named 400
+    # rather than the bodiless 502 an escaping KeyError becomes (#895).
+    try:
+        require_fields(body, COMPOSE_REQUIRED_FIELDS + ('host',))
+    except ValueError as err:
+        return _invalid(err)
     unauthorized = unauthorized_sender_response_or_none(user, body['sender'])
     if unauthorized:
         return unauthorized
@@ -106,6 +114,7 @@ def _discard(body, user):
     is missing - in both cases the draft the client meant is already gone or
     was never going to be matched.'''
     try:
+        require_fields(body, ('host',))
         uid = validate_uid(body.get('replaces_uid'))
         uidvalidity = validate_uid(body.get('replaces_uidvalidity'))
     except ValueError as err:

--- a/lambda/api/send/function.py
+++ b/lambda/api/send/function.py
@@ -8,10 +8,12 @@ from email.utils import getaddresses
 import boto3 # pylint: disable=import-error
 from botocore.exceptions import ClientError # pylint: disable=import-error
 from compose import ( # pylint: disable=import-error
+    COMPOSE_REQUIRED_FIELDS,
     DRAFTS_FOLDER,
     append_draft,
     compose_from_body,
     guarded_draft_expunge,
+    require_fields,
     unauthorized_sender_response_or_none,
 )
 from helper import delete_object # pylint: disable=import-error
@@ -51,6 +53,13 @@ def handler(event, _context):  # pylint: disable=too-many-return-statements
     if error:
         return error
     user = event['requestContext']['authorizer']['claims']['cognito:username']
+    # Check every key this handler indexes before anything reads one, so a
+    # payload missing (say) `sender` or `host` gets the same named 400 a
+    # rejected value gets rather than a bodiless 502 (#895).
+    try:
+        require_fields(body, COMPOSE_REQUIRED_FIELDS + ('host',))
+    except ValueError as err:
+        return _invalid(err)
     # Pin the sender to the exact validated address and reuse that same string
     # as the SMTP MAIL FROM below, so a display-name game in the From header
     # cannot leave the envelope sender and the visible From disagreeing.
@@ -62,12 +71,7 @@ def handler(event, _context):  # pylint: disable=too-many-return-statements
     try:
         msg = compose_from_body(body, user)
     except ValueError as err:
-        return {
-            "statusCode": 400,
-            "body": json.dumps({
-                "status": str(err)
-            })
-        }
+        return _invalid(err)
 
     if body.get('draft'):
         return _save_draft(body['host'], user, msg)
@@ -97,7 +101,8 @@ def handler(event, _context):  # pylint: disable=too-many-return-statements
 
     recipients = [
         addr for _, addr in
-        getaddresses(body['to_list'] + body['cc_list'] + body['bcc_list'])
+        getaddresses((body['to_list'] or []) + (body['cc_list'] or [])
+                     + (body['bcc_list'] or []))
         if addr
     ]
 
@@ -122,6 +127,16 @@ def handler(event, _context):  # pylint: disable=too-many-return-statements
         "statusCode": 200,
         "body": json.dumps({
             "status": "submitted"
+        })
+    }
+
+
+def _invalid(err):
+    '''Builds the 400 returned when a validator rejects the request.'''
+    return {
+        "statusCode": 400,
+        "body": json.dumps({
+            "status": str(err)
         })
     }
 


### PR DESCRIPTION
## What was wrong

`PUT /send` returned a bodiless `{"message": "Internal server error"}` 502
whenever the request omitted a key the composer indexes directly. Reported
in #895 for the three `other_headers` threading keys, with the CloudWatch
traceback (`KeyError: 'message_id'` from `compose.py:200`); the same shape
answers a body missing `sender`, `subject`, `to_list`, `cc_list`,
`bcc_list`, `text`, `html`, or `host`.

## Root cause

The two halves of one request disagreed about what is optional.
`validate_outbound_headers` reads defensively (`body.get('other_headers',
{}) or {}`, `body.get(field, []) or []`); `compose_from_body`, five lines
later, hard-indexed the same keys. A `KeyError` is not caught by the
handlers' `ValueError` -> 400 translation, so it escaped as an unhandled
exception -- the same shape #859 fixed for `fetch_attachment`.

`host` is the worst of them: `/send` indexes it only *after* the message has
gone out over SMTP (queuing the Sent copy), so the 502 landed on a request
that had already delivered mail.

## The fix

Two halves, matching the two outcomes the report offered:

- **Optional stays optional.** `compose_from_body` reads the three threading
  headers via `.get(...) or []`, in the validator's own idiom. An absent
  threading header means "no threading context", which is what a fresh
  (non-reply) compose genuinely has, and `compose_message` already writes
  each of the three only when non-empty. A 400 would reject a payload the
  validator's own rules call valid. The recipient lists get the same
  treatment, so a null `cc_list` composes as empty instead of dying on
  `','.join(None)`.
- **Required gets the 400** (this revision, per your comment). New
  `require_fields` raises the ValueError both handlers already translate,
  naming every missing key at once. It runs *before* either handler reads a
  key of its own, which is what gets `sender` and `host` into the 400 path
  -- both were read outside the `try`. `/save_draft`'s `op=discard` branch,
  which indexes `host` without composing, is covered too.

This is shared code, so `/save_draft` -- which composes through the same
function and had the identical exposure -- is covered by the same change.

## Test evidence

- New `lambda/api/_shared/tests/test_compose_required_fields.py` (11 cases):
  each required field named when omitted, all missing fields named at once,
  present-but-empty is not missing, null recipient lists compose as empty,
  and handler-level `/send` and `/save_draft` (save *and* discard) returning
  400 for a missing `sender` / `host` / body field. Against `stage`'s code,
  9 of the 11 error out -- 8 with exactly the reported `KeyError`, one with
  the `TypeError: can only join an iterable` from the null list; all 11 pass
  here.
- `test_compose_threading_headers.py` (7 cases) unchanged in substance,
  walking the report's table: full `other_headers` (control), `{}`, partial,
  omitted, `null`; plus supplied headers still landing on the message and
  CRLF injection still raising `ValueError`.
- Whole `_shared` suite via CI's own invocation
  (`python3 -m unittest discover -s lambda/api/_shared/tests -p "test_*.py"`):
  66 tests, OK -- on both 3.14 and 3.9.6, and in reversed discovery order.
- `pylint --rcfile .pylintrc _shared/*.py */function.py push_dispatch/apns.py`:
  10.00/10.

Not verified live: the defect is server-side, so confirming it against stage
needs this merged and deployed. The unit suite reproduces the exact failure.

## One thing this revision had to fix that wasn't the ask

`test_authorized_address_request.py` landed on stage (#893) after this branch
opened. Its boto3 fake wins the `sys.modules` slot under a directory-wide
`discover` and hands `compose` a preferences table with no `get_item`, so
merging stage in turned my existing threading suite red -- six errors, the
`unittest-shared` lint gate would have failed. Both compose suites now bind
`compose._preferences_table` / `helper.ddb_table` in `setUp` rather than
trusting their own fake to have won the import, which is the pattern
`test_authorized_address_request` itself uses for `helper.ddb_table`
(#860/#863). No other suite in the directory is exposed -- I ran all nine
standalone and the full set in both orders.

Addresses #895.
