### PR TITLE
Title the reply / forward composers by what they are

### DIFF
--- a/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel+Internals.swift
@@ -9,12 +9,23 @@ extension ComposeViewModel {
     // MARK: - Presentation
 
     /// Title for the compose surface (the sheet's navigation bar on iPhone,
-    /// the window title elsewhere). "New Message" is a lie when the user
-    /// tapped Edit Draft on a saved draft: the form comes up populated, and
-    /// sending replaces that draft rather than adding a second one. Replies
-    /// and forwards keep the generic title — they really are new messages.
+    /// the window title elsewhere). "New Message" is a lie for every
+    /// composer that opens populated: a resumed Drafts copy (whose send
+    /// replaces that draft rather than adding a second one), and a reply /
+    /// reply-all / forward, which come up with the recipient, a prefixed
+    /// subject, and the quoted original already in place. Each says what it
+    /// is instead; only a genuinely blank compose is a new message.
+    ///
+    /// The resumed draft wins over the intent: what the user reopened is a
+    /// draft, whatever it was first composed as.
     var navigationTitle: String {
-        isResumedServerDraft ? "Draft" : "New Message"
+        if isResumedServerDraft { return "Draft" }
+        switch composeIntent {
+        case .reply:     return "Reply"
+        case .replyAll:  return "Reply All"
+        case .forward:   return "Forward"
+        case .new:       return "New Message"
+        }
     }
 
     // MARK: - Editor bridge health

--- a/apple/Cabalmail/ViewModels/ComposeViewModel.swift
+++ b/apple/Cabalmail/ViewModels/ComposeViewModel.swift
@@ -101,7 +101,7 @@ final class ComposeViewModel {
     /// `internal` so `ComposeViewModel+Internals.swift` can read them.
     let inReplyTo: String?
     let references: [String]
-    private let composeIntent: ComposeIntent
+    let composeIntent: ComposeIntent
 
     /// Server-side Drafts copy the next save replaces (and a send
     /// discards). Seeded from the draft when resuming; updated after every

--- a/apple/CabalmailTests/ComposeTitleTests.swift
+++ b/apple/CabalmailTests/ComposeTitleTests.swift
@@ -2,11 +2,13 @@ import XCTest
 import CabalmailKit
 @testable import Cabalmail
 
-// Regression coverage for issue #845: tapping Edit Draft on a saved draft
-// put up a composer titled "New Message", on both iPhone and iPad. It isn't
-// a new message — the form comes up populated from the draft, and sending it
-// replaces that draft rather than creating a second one. The title now keys
-// off whether the surface opened on an existing server-side Drafts copy.
+// Regression coverage for issues #845 and #897: a composer that opens
+// populated was titled "New Message". #845 covered the resumed Drafts copy
+// (sending it replaces that draft rather than creating a second one) and
+// left replies on the generic title; #897 reported the reply case as the
+// one that was missed — the sheet says "New Message" over a filled-in To,
+// a "Re: " subject, and the quoted original. The title now keys off the
+// server-side Drafts copy first, then the compose intent.
 @MainActor
 final class ComposeTitleTests: XCTestCase {
 
@@ -26,15 +28,47 @@ final class ComposeTitleTests: XCTestCase {
         XCTAssertEqual(model.navigationTitle, "New Message")
     }
 
-    func testReplyIsStillANewMessage() throws {
+    func testReplySaysReply() throws {
+        // The reported composer: opened from the reader's Reply menu, so it
+        // comes up with the recipient, "Re: <subject>", and the quoted body
+        // already filled in (#897). It used to say "New Message".
         let model = try TestFixtures.makeComposeModel(
             seed: Draft(subject: "Re: hello", inReplyTo: "<abc@example.com>", composeIntent: .reply)
         )
 
-        XCTAssertEqual(
-            model.navigationTitle, "New Message",
-            "a reply really is a new message — only a resumed Drafts copy isn't"
+        XCTAssertEqual(model.navigationTitle, "Reply")
+    }
+
+    func testReplyAllSaysReplyAll() throws {
+        let model = try TestFixtures.makeComposeModel(
+            seed: Draft(subject: "Re: hello", inReplyTo: "<abc@example.com>", composeIntent: .replyAll)
         )
+
+        XCTAssertEqual(model.navigationTitle, "Reply All")
+    }
+
+    func testForwardSaysForward() throws {
+        let model = try TestFixtures.makeComposeModel(
+            seed: Draft(subject: "Fwd: hello", composeIntent: .forward)
+        )
+
+        XCTAssertEqual(model.navigationTitle, "Forward")
+    }
+
+    func testAResumedDraftSaysDraftEvenWhenItBeganAsAReply() throws {
+        // Precedence: what the user reopened is a draft, whatever it was
+        // first composed as.
+        let model = try TestFixtures.makeComposeModel(
+            seed: Draft(
+                subject: "Re: hello",
+                inReplyTo: "<abc@example.com>",
+                composeIntent: .reply,
+                serverUid: 42,
+                serverUidValidity: 9
+            )
+        )
+
+        XCTAssertEqual(model.navigationTitle, "Draft")
     }
 
     func testAutosavingAFreshComposeDoesNotRetitleIt() throws {

--- a/changelog.d/reply-composer-title.fixed.md
+++ b/changelog.d/reply-composer-title.fixed.md
@@ -1,0 +1,5 @@
+- Apple: **Composer titles for replies and forwards.** A reply, reply-all,
+  or forward opened under the title "New Message" despite arriving with the
+  recipient, subject, and quoted original already filled in. Each composer
+  now says what it is — "Reply", "Reply All", "Forward" — alongside the
+  existing "Draft" and "New Message".


### PR DESCRIPTION
## What was wrong

Replying put up a composer titled "New Message" above a filled-in `To:`, a
`Re: <subject>`, and the quoted original (#897). The draft editor got this
right ("Draft", from #845); reply / reply-all / forward fell through to the
new-message string.

## Root cause

`ComposeViewModel.navigationTitle` was
`isResumedServerDraft ? "Draft" : "New Message"`. The seed's
`composeIntent` — already present, already used to decide focus
(`shouldFocusBodyOnAppear`) — never reached the title.

## The fix

The title switches on `composeIntent`: "Reply", "Reply All", "Forward",
"New Message"; a resumed Drafts copy still short-circuits to "Draft", since
what the user reopened is a draft whatever it was first composed as.
`composeIntent` drops `private` so the sibling `+Internals` extension can
read it, matching `inReplyTo` / `references` beside it.

**Note this reverses a decision #845 made deliberately.** That fix left
replies on the generic title, with a test
(`testReplyIsStillANewMessage`) asserting "a reply really is a new message —
only a resumed Drafts copy isn't". #897 reports the opposite as the defect
and you triaged it `accepted`, so I've rewritten that test to the new
expectation rather than working around it. Easy to put back if the report
read your intent wrong.

## Test evidence

- `CabalmailTests/ComposeTitleTests.swift` grows to 7 cases: reply,
  reply-all, forward, resumed-draft-that-began-as-a-reply (precedence), plus
  the three #845 cases unchanged. Against `stage`'s `navigationTitle`
  (impl shimmed back), the 3 new intent cases fail; all 7 pass here.
- Full app suite: 110 tests, 0 failures. `swiftlint` from `apple/`: clean.
- **Live on iPhone 17 sim (iOS 26.5)** against this build, following the
  report's steps: INBOX -> message -> Reply -> **Reply**. Navigation bar
  reads **"Reply"** over `To: daily@qa0722.cabal-mail.com` and
  `Re: Fixer 837 prune probe` (screenshot + AX dump). Forward from the same
  menu titles the sheet **"Forward"** over a `Fwd: ` subject. Nothing was
  sent.

Addresses #897.